### PR TITLE
Feature: Added input file keyword for timings file

### DIFF
--- a/docs/sphinx/src/userGuide/inputFile.rst
+++ b/docs/sphinx/src/userGuide/inputFile.rst
@@ -384,6 +384,20 @@ The ``stress_file`` keyword sets the name for the :ref:`stressFile`, which store
 
 .. centered:: *default value* = "default.stress"
 
+.. _timingsfilekey:
+
+Timings File
+============
+
+.. admonition:: Key
+    :class: tip
+
+    timings_file = {file} -> "default.timings"
+
+The ``timings_file`` keyword sets the name for the :ref:`timingFile`, which tracks the time **PQ** takes for executing individual parts of the simulation.
+
+.. centered:: *default value* = "default.timings"
+
 .. _trajectoryfilekey:
 
 Trajectory File

--- a/include/input/inputFileParser/outputInputParser.hpp
+++ b/include/input/inputFileParser/outputInputParser.hpp
@@ -61,6 +61,7 @@ namespace input
         void parseVirialFilename(const pq::strings &, const size_t);
         void parseStressFilename(const pq::strings &, const size_t);
         void parseBoxFilename(const pq::strings &, const size_t);
+        void parseTimingsFilename(const pq::strings &, const size_t);
         void parseOptFilename(const pq::strings &, const size_t);
 
         void parseRPMDRestartFilename(const pq::strings &, const size_t);

--- a/src/input/inputFileParser/outputInputParser.cpp
+++ b/src/input/inputFileParser/outputInputParser.cpp
@@ -38,16 +38,30 @@ using namespace settings;
  * object
  *
  * @details following keywords are added to the _keywordFuncMap,
- * _keywordRequiredMap and _keywordCountMap: 1) output_freq <size_t> 2)
- * output_file <string> 3) info_file <string> 4) energy_file <string> 5)
- * instant_energy_file <string> 6) traj_file <string> 7) vel_file <string> 8)
- * force_file <string> 9) restart_file <string> 10) charge_file <string> 11)
- * momentum_file <string> 12) virial_file <string> 13) stress_file <string> 14)
- * box_file <string> 15) rpmd_restart_file <string> 16) rpmd_traj_file <string>
- * 17) rpmd_vel_file <string>
- * 18) rpmd_force_file <string>
- * 19) rpmd_charge_file <string>
- * 20) rpmd_energy_file <string>
+ * _keywordRequiredMap and _keywordCountMap: 
+ * 1) output_freq <size_t> 
+ * 2) file_prefix <string> 
+ * 3) output_file <string> 
+ * 4) info_file <string> 
+ * 5) energy_file <string> 
+ * 6) instant_energy_file <string> 
+ * 7) traj_file <string> 
+ * 8) vel_file <string> 
+ * 9) force_file <string> 
+ * 10) restart_file <string> 
+ * 11) charge_file <string> 
+ * 12) momentum_file <string> 
+ * 13) virial_file <string> 
+ * 14) stress_file <string> 
+ * 15) box_file <string> 
+ * 16) timings_file <string> 
+ * 17) opt_file <string>
+ * 18) rpmd_restart_file <string> 
+ * 19) rpmd_traj_file <string>
+ * 20) rpmd_vel_file <string>
+ * 21) rpmd_force_file <string>
+ * 22) rpmd_charge_file <string>
+ * 23) rpmd_energy_file <string>
  *
  * @param engine
  */
@@ -128,6 +142,11 @@ OutputInputParser::OutputInputParser(Engine &engine) : InputFileParser(engine)
     addKeyword(
         std::string("box_file"),
         bind_front(&OutputInputParser::parseBoxFilename, this),
+        false
+    );
+    addKeyword(
+        std::string("timings_file"),
+        bind_front(&OutputInputParser::parseTimingsFilename, this),
         false
     );
     addKeyword(
@@ -418,6 +437,22 @@ void OutputInputParser::parseBoxFilename(
 {
     checkCommand(lineElements, lineNumber);
     OutputFileSettings::setBoxFileName(lineElements[2]);
+}
+
+/**
+ * @brief parse timings filename of simulation and add it to output
+ *
+ * @details default value is default.timings
+ *
+ * @param lineElements
+ */
+void OutputInputParser::parseTimingsFilename(
+    const std::vector<std::string> &lineElements,
+    const size_t                    lineNumber
+)
+{
+    checkCommand(lineElements, lineNumber);
+    OutputFileSettings::setTimingsFileName(lineElements[2]);
 }
 
 /**

--- a/tests/data/inputFileReader/keywordList.txt
+++ b/tests/data/inputFileReader/keywordList.txt
@@ -83,6 +83,7 @@ virial_file                 false
 stress_file                 false
 momentum_file               false
 box_file                    false
+timings_file                false
 opt_file                    false
 
 rpmd_restart_file           false

--- a/tests/src/input/inputFileParsing/testOutputParser.cpp
+++ b/tests/src/input/inputFileParsing/testOutputParser.cpp
@@ -270,6 +270,19 @@ TEST_F(TestInputFileReader, testBoxFilename)
 }
 
 /**
+ * @brief tests parsing the "timings_file" command
+ *
+ */
+TEST_F(TestInputFileReader, testTimingsFilename)
+{
+    OutputInputParser parser(*_engine);
+    _fileName                                   = "timings.txt";
+    const std::vector<std::string> lineElements = {"timings_file", "=", _fileName};
+    parser.parseTimingsFilename(lineElements, 0);
+    EXPECT_EQ(settings::OutputFileSettings::getTimingsFileName(), _fileName);
+}
+
+/**
  * @brief tests parsing the "rpmd_traj_file" command
  *
  */


### PR DESCRIPTION
I added the option to provide a keyword in the PQ input file for defining the .timings file. As i am a freshman, i suggest to double check my changes and in case show me what I did wrong. I also added the respective keyword in the documentation and tests (or at least I tried).