### PR TITLE
Feature: keywords can now be given with '-' instead of '_' and vice versa

### DIFF
--- a/include/utilities/stringUtilities.hpp
+++ b/include/utilities/stringUtilities.hpp
@@ -44,6 +44,8 @@ namespace utilities
 
     std::string toLowerCopy(std::string);
     std::string toLowerCopy(std::string_view);
+    std::string toLowerAndReplaceDashesCopy(std::string);
+    std::string toLowerAndReplaceDashesCopy(std::string_view);
     std::string firstLetterToUpperCaseCopy(std::string);
 
     void addSpaces(std::string &, const std::string &, const size_t);

--- a/src/input/inputFileParser/generalInputParser.cpp
+++ b/src/input/inputFileParser/generalInputParser.cpp
@@ -105,24 +105,24 @@ void GeneralInputParser::parseJobTypeForEngine(
     using enum JobType;
     checkCommand(lineElements, lineNumber);
 
-    const auto jobtype = toLowerCopy(lineElements[2]);
+    const auto jobtype = toLowerAndReplaceDashesCopy(lineElements[2]);
 
-    if (jobtype == "mm-opt")
+    if (jobtype == "mm_opt")
     {
         Settings::setJobtype(MM_OPT);
         engine.reset(new OptEngine());
     }
-    else if (jobtype == "mm-md")
+    else if (jobtype == "mm_md")
     {
         Settings::setJobtype(MM_MD);
         engine.reset(new MMMDEngine());
     }
-    else if (jobtype == "qm-md")
+    else if (jobtype == "qm_md")
     {
         Settings::setJobtype(QM_MD);
         engine.reset(new QMMDEngine());
     }
-    else if (jobtype == "qm-rpmd")
+    else if (jobtype == "qm_rpmd")
     {
         Settings::setJobtype(RING_POLYMER_QM_MD);
         engine.reset(new RingPolymerQMMDEngine());

--- a/src/input/inputFileParser/inputFileParser.cpp
+++ b/src/input/inputFileParser/inputFileParser.cpp
@@ -121,7 +121,7 @@ void InputFileParser::addKeyword(
     bool               required
 )
 {
-    const auto keywordLowerCase = toLowerCopy(keyword);
+    const auto keywordLowerCase = toLowerAndReplaceDashesCopy(keyword);
     _keywordFuncMap.try_emplace(keywordLowerCase, parserFunc);
     _keywordRequiredMap.try_emplace(keywordLowerCase, required);
     _keywordCountMap.try_emplace(keywordLowerCase, 0);

--- a/src/input/inputFileParser/integratorInputParser.cpp
+++ b/src/input/inputFileParser/integratorInputParser.cpp
@@ -76,14 +76,14 @@ void IntegratorInputParser::parseIntegrator(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto integrator = toLowerCopy(lineElements[2]);
+    const auto integrator = toLowerAndReplaceDashesCopy(lineElements[2]);
 
     if (!Settings::isMDJobType())
         throw InputFileException(
             std::format("Integrator is only supported for MD simulations!")
         );
 
-    if (integrator == "v-verlet")
+    if (integrator == "v_verlet")
     {
         auto &mdEngine = dynamic_cast<MDEngine &>(_engine);
         mdEngine.makeIntegrator(VelocityVerlet());

--- a/src/input/inputFileParser/manostatInputParser.cpp
+++ b/src/input/inputFileParser/manostatInputParser.cpp
@@ -105,7 +105,7 @@ void ManostatInputParser::parseManostat(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto manostat = toLowerCopy(lineElements[2]);
+    const auto manostat = toLowerAndReplaceDashesCopy(lineElements[2]);
 
     using enum ManostatType;
 
@@ -220,7 +220,7 @@ void ManostatInputParser::parseIsotropy(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto isotropy = toLowerCopy(lineElements[2]);
+    const auto isotropy = toLowerAndReplaceDashesCopy(lineElements[2]);
 
     using enum Isotropy;
 

--- a/src/input/inputFileParser/optInputParser.cpp
+++ b/src/input/inputFileParser/optInputParser.cpp
@@ -107,11 +107,11 @@ void OptInputParser::parseOptimizer(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto method = toLowerCopy(lineElements[2]);
+    const auto method = toLowerAndReplaceDashesCopy(lineElements[2]);
 
     using enum OptimizerType;
 
-    if ("steepest-descent" == method)
+    if ("steepest_descent" == method)
         OptimizerSettings::setOptimizer(STEEPEST_DESCENT);
 
     else if ("adam" == method)
@@ -144,18 +144,18 @@ void OptInputParser::parseLearningRateStrategy(
     using enum LREnum;
     checkCommand(lineElements, lineNumber);
 
-    const auto strategy = toLowerCopy(lineElements[2]);
+    const auto strategy = toLowerAndReplaceDashesCopy(lineElements[2]);
 
     if ("constant" == strategy)
         OptimizerSettings::setLearningRateStrategy(CONSTANT);
 
-    else if ("constant-decay" == strategy)
+    else if ("constant_decay" == strategy)
         OptimizerSettings::setLearningRateStrategy(CONSTANT_DECAY);
 
-    else if ("exponential-decay" == strategy)
+    else if ("exponential_decay" == strategy)
         OptimizerSettings::setLearningRateStrategy(EXPONENTIAL_DECAY);
 
-    else if ("linesearch-wolfe" == strategy)
+    else if ("linesearch_wolfe" == strategy)
         OptimizerSettings::setLearningRateStrategy(LINESEARCH_WOLFE);
 
     else if ("linesearch" == strategy)

--- a/src/input/inputFileParser/thermostatInputParser.cpp
+++ b/src/input/inputFileParser/thermostatInputParser.cpp
@@ -130,7 +130,7 @@ void ThermostatInputParser::parseThermostat(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto thermostat = toLowerCopy(lineElements[2]);
+    const auto thermostat = toLowerAndReplaceDashesCopy(lineElements[2]);
 
     using enum ThermostatType;
 
@@ -155,7 +155,7 @@ void ThermostatInputParser::parseThermostat(
         ReferencesOutput::addReferenceFile(_LANGEVIN_FILE_);
     }
 
-    else if (thermostat == "nh-chain")
+    else if (thermostat == "nh_chain")
     {
         ThermostatSettings::setThermostatType(NOSE_HOOVER);
         ReferencesOutput::addReferenceFile(_NOSE_HOOVER_CHAIN_FILE_);

--- a/src/input/inputFileReader.cpp
+++ b/src/input/inputFileReader.cpp
@@ -139,7 +139,7 @@ void InputFileReader::addKeywords()
  */
 void InputFileReader::process(const std::vector<std::string> &lineElements)
 {
-    const auto keyword = toLowerCopy(lineElements[0]);
+    const auto keyword = toLowerAndReplaceDashesCopy(lineElements[0]);
 
     if (!_keywordFuncMap.contains(keyword))
         throw InputFileException(std::format(

--- a/src/input/moldescriptorReader.cpp
+++ b/src/input/moldescriptorReader.cpp
@@ -106,10 +106,10 @@ void MoldescriptorReader::read()
         {
             auto &simBox = _engine.getSimulationBox();
 
-            if ("water_type" == toLowerCopy(lineElements[0]))
+            if ("water_type" == toLowerAndReplaceDashesCopy(lineElements[0]))
                 simBox.setWaterType(std::stoi(lineElements[1]));
 
-            else if ("ammonia_type" == toLowerCopy(lineElements[0]))
+            else if ("ammonia_type" == toLowerAndReplaceDashesCopy(lineElements[0]))
                 simBox.setAmmoniaType(std::stoi(lineElements[1]));
 
             else

--- a/src/input/parameterFileReader/jCouplingSection.cpp
+++ b/src/input/parameterFileReader/jCouplingSection.cpp
@@ -41,7 +41,7 @@ using namespace constants;
  *
  * @return "j-couplings"
  */
-std::string JCouplingSection::keyword() { return "j-couplings"; }
+std::string JCouplingSection::keyword() { return "j_couplings"; }
 
 /**
  * @brief processes one line of the j-coupling section of the parameter file and

--- a/src/input/parameterFileReader/parameterFileReader.cpp
+++ b/src/input/parameterFileReader/parameterFileReader.cpp
@@ -89,7 +89,7 @@ ParameterFileSection *ParameterFileReader::determineSection(
     const auto iterEnd   = _parameterFileSections.end();
 
     for (auto section = iterStart; section != iterEnd; ++section)
-        if ((*section)->keyword() == toLowerCopy(lineElements[0]))
+        if ((*section)->keyword() == toLowerAndReplaceDashesCopy(lineElements[0]))
             return (*section).get();
 
     throw ParameterFileException(

--- a/src/input/restartFileReader/restartFileReader.cpp
+++ b/src/input/restartFileReader/restartFileReader.cpp
@@ -70,7 +70,7 @@ RestartFileSection *RestartFileReader::determineSection(
 )
 {
     for (const auto &section : _sections)
-        if (section->keyword() == toLowerCopy(lineElements[0]))
+        if (section->keyword() == toLowerAndReplaceDashesCopy(lineElements[0]))
             return section.get();
 
     return _atomSection.get();

--- a/src/input/topologyFileReader/jCouplingSection.cpp
+++ b/src/input/topologyFileReader/jCouplingSection.cpp
@@ -104,7 +104,7 @@ void JCouplingSection::processSection(
  *
  * @return "j-couplings"
  */
-std::string JCouplingSection::keyword() { return "j-couplings"; }
+std::string JCouplingSection::keyword() { return "j_couplings"; }
 
 /**
  * @brief checks if j-coupling section ends normally

--- a/src/input/topologyFileReader/topologyReader.cpp
+++ b/src/input/topologyFileReader/topologyReader.cpp
@@ -125,7 +125,7 @@ TopologySection *TopologyReader::determineSection(
     const auto iterEnd   = _topologySections.end();
 
     for (auto section = iterStart; section != iterEnd; ++section)
-        if ((*section)->keyword() == toLowerCopy(lineElements[0]))
+        if ((*section)->keyword() == toLowerAndReplaceDashesCopy(lineElements[0]))
             return (*section).get();
 
     throw TopologyException(

--- a/src/settings/manostatSettings.cpp
+++ b/src/settings/manostatSettings.cpp
@@ -77,7 +77,7 @@ std::string settings::string(const Isotropy &isotropy)
 void ManostatSettings::setManostatType(const std::string_view &manostatType)
 {
     using enum ManostatType;
-    const auto manostatTypeToLower = utilities::toLowerCopy(manostatType);
+    const auto manostatTypeToLower = utilities::toLowerAndReplaceDashesCopy(manostatType);
 
     if (manostatTypeToLower == "berendsen")
         _manostatType = BERENDSEN;
@@ -107,7 +107,7 @@ void ManostatSettings::setManostatType(const ManostatType &manostatType)
 void ManostatSettings::setIsotropy(const std::string_view &isotropy)
 {
     using enum Isotropy;
-    const auto isotropyToLower = utilities::toLowerCopy(isotropy);
+    const auto isotropyToLower = utilities::toLowerAndReplaceDashesCopy(isotropy);
 
     if (isotropyToLower == "isotropic")
         _isotropy = ISOTROPIC;

--- a/src/settings/optimizerSettings.cpp
+++ b/src/settings/optimizerSettings.cpp
@@ -81,9 +81,9 @@ std::string settings::string(const LREnum method)
 void OptimizerSettings::setOptimizer(const std::string_view &optimizer)
 {
     using enum OptimizerType;
-    const auto optimizerLower = toLowerCopy(optimizer);
+    const auto optimizerLower = toLowerAndReplaceDashesCopy(optimizer);
 
-    if ("steepest-descent" == optimizerLower)
+    if ("steepest_descent" == optimizerLower)
         setOptimizer(OptimizerType::STEEPEST_DESCENT);
 
     else if ("adam" == optimizerLower)
@@ -112,18 +112,18 @@ void OptimizerSettings::setLearningRateStrategy(const std::string_view &method)
 {
     using enum LREnum;
 
-    const auto methodLower = toLowerCopy(method);
+    const auto methodLower = toLowerAndReplaceDashesCopy(method);
 
     if ("constant" == methodLower)
         setLearningRateStrategy(CONSTANT);
 
-    else if ("constant-decay" == methodLower)
+    else if ("constant_decay" == methodLower)
         setLearningRateStrategy(CONSTANT_DECAY);
 
-    else if ("exponential-decay" == methodLower)
+    else if ("exponential_decay" == methodLower)
         setLearningRateStrategy(EXPONENTIAL_DECAY);
 
-    else if ("linesearch-wolfe" == methodLower)
+    else if ("linesearch_wolfe" == methodLower)
         setLearningRateStrategy(LINESEARCH_WOLFE);
 
     else

--- a/src/settings/potentialSettings.cpp
+++ b/src/settings/potentialSettings.cpp
@@ -85,7 +85,7 @@ std::string settings::string(const CoulombLongRangeType coulombLongRangeType)
 void PotentialSettings::setNonCoulombType(const std::string_view &type)
 {
     using enum NonCoulombType;
-    const auto typeToLower = toLowerCopy(type);
+    const auto typeToLower = toLowerAndReplaceDashesCopy(type);
 
     if (typeToLower == "lj")
         _nonCoulombType = LJ;

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -195,7 +195,7 @@ void QMSettings::setMaceModelSize(const MaceModelSize model)
 void QMSettings::setMaceModelType(const std::string_view &model)
 {
     using enum MaceModelType;
-    const auto modelToLower = toLowerCopy(model);
+    const auto modelToLower = toLowerAndReplaceDashesCopy(model);
 
     if ("mace_mp" == modelToLower)
         _maceModelType = MACE_MP;

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -238,7 +238,7 @@ void QMSettings::setMaceModelPath(const std::string_view &path)
  */
 void QMSettings::setQMScript(const std::string_view &script)
 {
-    _qmScript = script;
+    _qmScript = toLowerAndReplaceDashesCopy(script);
 }
 
 /**

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -65,7 +65,7 @@ std::string settings::string(const JobType jobtype)
 void Settings::setJobtype(const std::string_view jobtype)
 {
     using enum JobType;
-    const auto jobtypeToLower = toLowerCopy(jobtype);
+    const auto jobtypeToLower = toLowerAndReplaceDashesCopy(jobtype);
 
     if (jobtypeToLower == "mmmd")
         setJobtype(MM_MD);

--- a/src/settings/thermostatSettings.cpp
+++ b/src/settings/thermostatSettings.cpp
@@ -90,7 +90,7 @@ void ThermostatSettings::setThermostatType(
 )
 {
     using enum ThermostatType;
-    const auto thermostatTypeToLower = toLowerCopy(thermostatType);
+    const auto thermostatTypeToLower = toLowerAndReplaceDashesCopy(thermostatType);
 
     if (thermostatTypeToLower == "berendsen")
         _thermostatType = BERENDSEN;
@@ -101,7 +101,7 @@ void ThermostatSettings::setThermostatType(
     else if (thermostatTypeToLower == "langevin")
         _thermostatType = LANGEVIN;
 
-    else if (thermostatTypeToLower == "nh-chain")
+    else if (thermostatTypeToLower == "nh_chain")
         _thermostatType = NOSE_HOOVER;
 
     else

--- a/src/utilities/stringUtilities.cpp
+++ b/src/utilities/stringUtilities.cpp
@@ -152,8 +152,12 @@ std::string utilities::toLowerCopy(const std::string_view myString)
  */
 std::string utilities::toLowerAndReplaceDashesCopy(std::string myString)
 {
-    std::ranges::for_each(myString, [](char &c) { c = char(::tolower(c)); });
-    replace(myString.begin(), myString.end(), '-', '_');
+    for (char &c : myString)
+    {
+        c = char(::tolower(c));
+        if (c == '-')
+            c = '_';
+    }
     return myString;
 }
 

--- a/src/utilities/stringUtilities.cpp
+++ b/src/utilities/stringUtilities.cpp
@@ -145,6 +145,32 @@ std::string utilities::toLowerCopy(const std::string_view myString)
 }
 
 /**
+ * @brief returns a copy of a string all lower case and with '-' replaced by '_'
+ *
+ * @param myString
+ * @return string
+ */
+std::string utilities::toLowerAndReplaceDashesCopy(std::string myString)
+{
+    std::ranges::for_each(myString, [](char &c) { c = char(::tolower(c)); });
+    replace(myString.begin(), myString.end(), '-', '_');
+    return myString;
+}
+
+/**
+ * @brief returns a copy of a string all lower case and with '-' replaced by '_'
+ *
+ * @param myString
+ * @return string
+ */
+std::string utilities::toLowerAndReplaceDashesCopy(
+    const std::string_view myString
+)
+{
+    return toLowerAndReplaceDashesCopy(std::string(myString));
+}
+
+/**
  * @brief converts the first letter of a string to upper case and the rest to
  * lower case
  *

--- a/tests/src/input/parameterFileReader/testParameterFileReader.cpp
+++ b/tests/src/input/parameterFileReader/testParameterFileReader.cpp
@@ -89,7 +89,7 @@ TEST_F(TestParameterFileReader, determineSection)
         typeid(input::parameterFile::NonCoulombicsSection)
     );
 
-    const auto *section6 = reader->determineSection({"j-couplings"});
+    const auto *section6 = reader->determineSection({"j_couplings"});
     EXPECT_EQ(
         typeid(*section6),
         typeid(input::parameterFile::JCouplingSection)
@@ -137,7 +137,7 @@ TEST_F(TestParameterFileReader, deleteSection)
     reader->deleteSection(section5);
     EXPECT_EQ(reader->getParameterFileSections().size(), 1);
 
-    const auto *section6 = reader->determineSection({"j-couplings"});
+    const auto *section6 = reader->determineSection({"j_couplings"});
     reader->deleteSection(section6);
     EXPECT_EQ(reader->getParameterFileSections().size(), 0);
 }

--- a/tests/src/utilities/testStringUtilities.cpp
+++ b/tests/src/utilities/testStringUtilities.cpp
@@ -106,6 +106,16 @@ TEST(TestStringUtilities, toLowerCopy)
 }
 
 /**
+ * @brief test toLowerAndReplaceDashesCopy function
+ *
+ */
+TEST(TestStringUtilities, toLowerAndReplaceDashesCopy)
+{
+    std::string line = "TE-S--T";
+    EXPECT_EQ("te_s__t", utilities::toLowerAndReplaceDashesCopy(line));
+}
+
+/**
  * @brief test firstLetterToUpperCaseCopy function
  *
  */


### PR DESCRIPTION
I added the functionality to give keywords in the input file with dashes instead of underscores and vice versa.
Therefore, I added a new string utility to convert a string to lowercase while also converting all dashes to underscores.
I exchanged the existing `toLowerCopy()` function with this new function named `toLowerAndReplaceDashesCopy()` where it makes sense and adjusted the corresponding keywords accordingly.
A new test for this string utility is also added.