### PR TITLE
bugfix: processed invalid keyword gets printed

### DIFF
--- a/src/input/inputFileReader.cpp
+++ b/src/input/inputFileReader.cpp
@@ -139,12 +139,13 @@ void InputFileReader::addKeywords()
  */
 void InputFileReader::process(const std::vector<std::string> &lineElements)
 {
-    const auto keyword = toLowerAndReplaceDashesCopy(lineElements[0]);
+    const auto original_keyword = lineElements[0];
+    const auto keyword = toLowerAndReplaceDashesCopy(original_keyword);
 
     if (!_keywordFuncMap.contains(keyword))
         throw InputFileException(std::format(
             "Invalid keyword \"{}\" at line {}",
-            keyword,
+            original_keyword,
             _lineNumber
         ));
 


### PR DESCRIPTION
Minor change to print the original keyword that was invalid in the input file.
At the moment the processed keyword (all lower case and '_' instead of '-') gets printed in the error message.