### PR TITLE
Feature: Overwrite Output Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - new MACE models added
 - ASE based xTB calculator added
+- option to overwrite existing output files added
 
 ### Bug Fixes
 

--- a/docs/sphinx/src/userGuide/inputFile.rst
+++ b/docs/sphinx/src/userGuide/inputFile.rst
@@ -224,6 +224,18 @@ The ``output_freq`` keyword sets the frequency (*i.e.* every n-th step) of how o
 
 .. centered:: *default value* = 1
 
+.. _overwriteoutputkey:
+
+Overwrite Output Files
+======================
+
+.. admonition:: Key
+    :class: tip
+
+    overwrite_output = {bool} -> false
+
+The ``overwrite_output`` keyword allows the user to overwrite any existing output files.
+
 .. _fileprefixkey:
 
 File Prefix

--- a/include/input/inputFileParser/outputInputParser.hpp
+++ b/include/input/inputFileParser/outputInputParser.hpp
@@ -44,6 +44,8 @@ namespace input
        public:
         explicit OutputInputParser(pq::Engine &);
 
+        void parseOverwriteOutput(const pq::strings &, const size_t);
+
         void parseOutputFreq(const pq::strings &, const size_t);
         void parseFilePrefix(const pq::strings &, const size_t);
 

--- a/include/settings/outputFileSettings.hpp
+++ b/include/settings/outputFileSettings.hpp
@@ -43,7 +43,8 @@ namespace settings
        private:
         static inline size_t _outputFrequency = 1;
 
-        static inline bool        _filePrefixSet = false;
+        static inline bool        _overwriteOutputFiles = false;
+        static inline bool        _filePrefixSet        = false;
         static inline std::string _filePrefix;
 
         static inline std::string _energyFile = defaults::_ENERGY_FILE_DEFAULT_;
@@ -116,6 +117,8 @@ namespace settings
 
         static void setTimingsFileName(const std::string_view);
 
+        static void setOverwriteOutputFiles(const bool);
+
         /***************************
          * standard getter methods *
          ***************************/
@@ -151,6 +154,8 @@ namespace settings
         [[nodiscard]] static std::string getRPMDEnergyFileName();
 
         [[nodiscard]] static std::string getTimingsFileName();
+
+        [[nodiscard]] static bool getOverwriteOutputFiles();
     };
 
 }   // namespace settings

--- a/src/input/inputFileParser/outputInputParser.cpp
+++ b/src/input/inputFileParser/outputInputParser.cpp
@@ -27,9 +27,11 @@
 
 #include "exceptions.hpp"           // for InputFileException
 #include "outputFileSettings.hpp"   // for OutputFileSettings
+#include "stringUtilities.hpp"      // for toLowerCopy
 
 using namespace input;
 using namespace engine;
+using namespace utilities;
 using namespace customException;
 using namespace settings;
 
@@ -186,6 +188,11 @@ OutputInputParser::OutputInputParser(Engine &engine) : InputFileParser(engine)
     addKeyword(
         std::string("rpmd_energy_file"),
         bind_front(&OutputInputParser::parseRPMDEnergyFilename, this),
+        false
+    );
+    addKeyword(
+        std::string("overwrite_output"),
+        bind_front(&OutputInputParser::parseOverwriteOutput, this),
         false
     );
 }
@@ -584,4 +591,33 @@ void OutputInputParser::parseRPMDEnergyFilename(
 {
     checkCommand(lineElements, lineNumber);
     OutputFileSettings::setRingPolymerEnergyFileName(lineElements[2]);
+}
+
+/**
+ * @brief parse if existing output files should be overwritten
+ *
+ * @param lineElements
+ * @param lineNumber
+ */
+void OutputInputParser::parseOverwriteOutput(
+    const std::vector<std::string> &lineElements,
+    const size_t                    lineNumber
+)
+{
+    checkCommand(lineElements, lineNumber);
+
+    const auto overwrite = toLowerCopy(lineElements[2]);
+
+    if ("true" == overwrite || "yes" == overwrite || "on" == overwrite)
+        OutputFileSettings::setOverwriteOutputFiles(true);
+
+    else if ("false" == overwrite || "no" == overwrite || "off" == overwrite)
+        OutputFileSettings::setOverwriteOutputFiles(false);
+
+    else
+        throw InputFileException(std::format(
+            "Invalid overwrite_output value \"{}\" in input file.\n"
+            "Possible values are: true, yes, on, false, no, off",
+            lineElements[2]
+        ));
 }

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -25,11 +25,13 @@
 #include <filesystem>   // for create_directory
 #include <fstream>      // for ifstream, ofstream, std
 
-#include "exceptions.hpp"   // for InputFileException, customException
+#include "exceptions.hpp"           // for InputFileException, customException
+#include "outputFileSettings.hpp"   // for OutputFileSettings
 
 using namespace std;
 using namespace customException;
 using namespace output;
+using namespace settings;
 
 /**
  * @brief Sets the filename of the output file
@@ -38,15 +40,19 @@ using namespace output;
  *
  * @throw InputFileException if filename is empty
  * @throw InputFileException if file already exists
+ * and output should not be overwritten
  */
 void Output::setFilename(const string_view &filename)
 {
     _fileName = filename;
+    const auto overwriteOutputFiles =
+        OutputFileSettings::getOverwriteOutputFiles();
 
     if (_fileName.empty())
         throw InputFileException("Filename cannot be empty");
 
-    if (const ifstream fp(_fileName.c_str()); fp.good())
+    if (const ifstream fp(_fileName.c_str());
+        fp.good() && !overwriteOutputFiles)
         throw InputFileException(
             "File already exists - filename = " + string(_fileName)
         );

--- a/src/settings/outputFileSettings.cpp
+++ b/src/settings/outputFileSettings.cpp
@@ -437,6 +437,16 @@ void OutputFileSettings::setTimingsFileName(const std::string_view name)
     _timeFile = name;
 }
 
+/**
+ * @brief sets if existing output files will be overwritten
+ *
+ * @param overwrite
+ */
+void OutputFileSettings::setOverwriteOutputFiles(const bool overwrite)
+{
+    _overwriteOutputFiles = overwrite;
+}
+
 /***************************
  *                         *
  * standard getter methods *
@@ -635,3 +645,13 @@ std::string OutputFileSettings::getRPMDEnergyFileName()
  * @return std::string
  */
 std::string OutputFileSettings::getTimingsFileName() { return _timeFile; }
+
+/**
+ * @brief returns if existing output files will be overwritten
+ *
+ * @return bool
+ */
+bool OutputFileSettings::getOverwriteOutputFiles()
+{
+    return _overwriteOutputFiles;
+}

--- a/tests/data/inputFileReader/keywordList.txt
+++ b/tests/data/inputFileReader/keywordList.txt
@@ -69,6 +69,7 @@ coupling_frequency          false
 
 noncoulomb                  false
 
+overwrite_output            false
 output_freq                 false
 file_prefix                 false
 output_file                 false

--- a/tests/src/input/inputFileParsing/testOutputParser.cpp
+++ b/tests/src/input/inputFileParsing/testOutputParser.cpp
@@ -34,6 +34,7 @@
 #include "throwWithMessage.hpp"      // for EXPECT_THROW_MSG
 
 using namespace input;
+using namespace settings;
 
 /**
  * @brief tests parsing the "outputfreq" command
@@ -46,7 +47,7 @@ TEST_F(TestInputFileReader, testParseOutputFreq)
     OutputInputParser        parser(*_engine);
     std::vector<std::string> lineElements = {"outputfreq", "=", "1000"};
     parser.parseOutputFreq(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getOutputFrequency(), 1000);
+    EXPECT_EQ(OutputFileSettings::getOutputFrequency(), 1000);
 
     lineElements = {"outputfreq", "=", "-1000"};
     EXPECT_THROW_MSG(
@@ -70,7 +71,7 @@ TEST_F(TestInputFileReader, testParseFilePrefix)
         "prefix"
     };
     parser.parseFilePrefix(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getFilePrefix(), "prefix");
+    EXPECT_EQ(OutputFileSettings::getFilePrefix(), "prefix");
 }
 
 /**
@@ -83,7 +84,7 @@ TEST_F(TestInputFileReader, testParseLogFilename)
     _fileName                             = "log.txt";
     std::vector<std::string> lineElements = {"logfilename", "=", _fileName};
     parser.parseLogFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getLogFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getLogFileName(), _fileName);
 }
 
 /**
@@ -96,7 +97,7 @@ TEST_F(TestInputFileReader, testParseInfoFilename)
     _fileName                             = "info.txt";
     std::vector<std::string> lineElements = {"infoFilename", "=", "info.txt"};
     parser.parseInfoFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getInfoFileName(), "info.txt");
+    EXPECT_EQ(OutputFileSettings::getInfoFileName(), "info.txt");
 }
 
 /**
@@ -109,7 +110,7 @@ TEST_F(TestInputFileReader, testParseEnergyFilename)
     _fileName                             = "energy.txt";
     std::vector<std::string> lineElements = {"energyFilename", "=", _fileName};
     parser.parseEnergyFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getEnergyFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getEnergyFileName(), _fileName);
 }
 
 /**
@@ -126,10 +127,7 @@ TEST_F(TestInputFileReader, testParseInstantEnergyFilename)
         _fileName
     };
     parser.parseInstantEnergyFilename(lineElements, 0);
-    EXPECT_EQ(
-        settings::OutputFileSettings::getInstantEnergyFileName(),
-        _fileName
-    );
+    EXPECT_EQ(OutputFileSettings::getInstantEnergyFileName(), _fileName);
 }
 
 /**
@@ -146,7 +144,7 @@ TEST_F(TestInputFileReader, testParseTrajectoryFilename)
         _fileName
     };
     parser.parseTrajectoryFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getTrajectoryFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getTrajectoryFileName(), _fileName);
 }
 
 /**
@@ -163,7 +161,7 @@ TEST_F(TestInputFileReader, testVelocityFilename)
         _fileName
     };
     parser.parseVelocityFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getVelocityFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getVelocityFileName(), _fileName);
 }
 
 /**
@@ -176,7 +174,7 @@ TEST_F(TestInputFileReader, testForceFilename)
     _fileName                             = "force.xyz";
     std::vector<std::string> lineElements = {"forceFilename", "=", _fileName};
     parser.parseForceFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getForceFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getForceFileName(), _fileName);
 }
 
 /**
@@ -189,7 +187,7 @@ TEST_F(TestInputFileReader, testParseRestartFilename)
     _fileName                             = "restart.xyz";
     std::vector<std::string> lineElements = {"restartFilename", "=", _fileName};
     parser.parseRestartFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getRestartFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getRestartFileName(), _fileName);
 }
 
 /**
@@ -202,7 +200,7 @@ TEST_F(TestInputFileReader, testChargeFilename)
     _fileName                             = "charge.xyz";
     std::vector<std::string> lineElements = {"chargeFilename", "=", _fileName};
     parser.parseChargeFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getChargeFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getChargeFileName(), _fileName);
 }
 
 /**
@@ -219,7 +217,7 @@ TEST_F(TestInputFileReader, testMomentumFilename)
         _fileName
     };
     parser.parseMomentumFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getMomentumFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getMomentumFileName(), _fileName);
 }
 
 /**
@@ -236,7 +234,7 @@ TEST_F(TestInputFileReader, testVirialFilename)
         _fileName
     };
     parser.parseVirialFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getVirialFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getVirialFileName(), _fileName);
 }
 
 /**
@@ -253,7 +251,7 @@ TEST_F(TestInputFileReader, testStressFilename)
         _fileName
     };
     parser.parseStressFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getStressFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getStressFileName(), _fileName);
 }
 
 /**
@@ -266,7 +264,7 @@ TEST_F(TestInputFileReader, testBoxFilename)
     _fileName                                   = "box.xyz";
     const std::vector<std::string> lineElements = {"box_file", "=", _fileName};
     parser.parseBoxFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getBoxFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getBoxFileName(), _fileName);
 }
 
 /**
@@ -277,9 +275,13 @@ TEST_F(TestInputFileReader, testTimingsFilename)
 {
     OutputInputParser parser(*_engine);
     _fileName                                   = "timings.txt";
-    const std::vector<std::string> lineElements = {"timings_file", "=", _fileName};
+    const std::vector<std::string> lineElements = {
+        "timings_file",
+        "=",
+        _fileName
+    };
     parser.parseTimingsFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getTimingsFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getTimingsFileName(), _fileName);
 }
 
 /**
@@ -296,7 +298,7 @@ TEST_F(TestInputFileReader, testRPMDTrajectoryFilename)
         _fileName
     };
     parser.parseRPMDTrajectoryFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getRPMDTrajFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getRPMDTrajFileName(), _fileName);
 }
 
 /**
@@ -313,10 +315,7 @@ TEST_F(TestInputFileReader, testRPMDRestartFilename)
         _fileName
     };
     parser.parseRPMDRestartFilename(lineElements, 0);
-    EXPECT_EQ(
-        settings::OutputFileSettings::getRPMDRestartFileName(),
-        _fileName
-    );
+    EXPECT_EQ(OutputFileSettings::getRPMDRestartFileName(), _fileName);
 }
 
 /**
@@ -333,7 +332,7 @@ TEST_F(TestInputFileReader, testRPMDEnergyFilename)
         _fileName
     };
     parser.parseRPMDEnergyFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getRPMDEnergyFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getRPMDEnergyFileName(), _fileName);
 }
 
 /**
@@ -350,7 +349,7 @@ TEST_F(TestInputFileReader, testRPMDForceFilename)
         _fileName
     };
     parser.parseRPMDForceFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getRPMDForceFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getRPMDForceFileName(), _fileName);
 }
 
 /**
@@ -367,7 +366,7 @@ TEST_F(TestInputFileReader, testRPMDChargeFilename)
         _fileName
     };
     parser.parseRPMDChargeFilename(lineElements, 0);
-    EXPECT_EQ(settings::OutputFileSettings::getRPMDChargeFileName(), _fileName);
+    EXPECT_EQ(OutputFileSettings::getRPMDChargeFileName(), _fileName);
 }
 
 /**
@@ -384,8 +383,40 @@ TEST_F(TestInputFileReader, testRPMDVelocityFilename)
         _fileName
     };
     parser.parseRPMDVelocityFilename(lineElements, 0);
-    EXPECT_EQ(
-        settings::OutputFileSettings::getRPMDVelocityFileName(),
-        _fileName
-    );
+    EXPECT_EQ(OutputFileSettings::getRPMDVelocityFileName(), _fileName);
+}
+
+/**
+ * @brief tests parsing the "overwrite_output" command
+ *
+ */
+TEST_F(TestInputFileReader, parseOverwriteOutput)
+{
+    EXPECT_FALSE(OutputFileSettings::getOverwriteOutputFiles());
+
+    OutputInputParser parser(*_engine);
+    parser.parseOverwriteOutput({"overwrite_output", "=", "true"}, 0);
+    EXPECT_TRUE(OutputFileSettings::getOverwriteOutputFiles());
+
+    parser.parseOverwriteOutput({"overwrite_output", "=", "yes"}, 0);
+    EXPECT_TRUE(OutputFileSettings::getOverwriteOutputFiles());
+
+    parser.parseOverwriteOutput({"overwrite_output", "=", "on"}, 0);
+    EXPECT_TRUE(OutputFileSettings::getOverwriteOutputFiles());
+
+    parser.parseOverwriteOutput({"overwrite_output", "=", "false"}, 0);
+    EXPECT_FALSE(OutputFileSettings::getOverwriteOutputFiles());
+
+    parser.parseOverwriteOutput({"overwrite_output", "=", "no"}, 0);
+    EXPECT_FALSE(OutputFileSettings::getOverwriteOutputFiles());
+
+    parser.parseOverwriteOutput({"overwrite_output", "=", "off"}, 0);
+    EXPECT_FALSE(OutputFileSettings::getOverwriteOutputFiles());
+
+    ASSERT_THROW_MSG(
+        parser.parseOverwriteOutput({"overwrite_output", "=", "notABool"}, 0),
+        customException::InputFileException,
+        "Invalid overwrite_output value \"notABool\" in input file.\n"
+        "Possible values are: true, yes, on, false, no, off"
+    )
 }


### PR DESCRIPTION
This PR solves Issue #119

I added the feature to overwrite existing output files _via_ a keyword in the input file.