### PR TITLE
Adding the Possibility of using Custom Mace Models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - new MACE models added
 - ASE based xTB calculator added
+- new keyword added to set custom MACE model *via* url
 
 ### Bug Fixes
 

--- a/docs/sphinx/src/userGuide/inputFile.rst
+++ b/docs/sphinx/src/userGuide/inputFile.rst
@@ -1368,10 +1368,27 @@ Possible options are:
 
    11. **medium-omat-0** - medium MACE-OMAT-0 model
 
-   12. **custom** - custom MACE model (to be set *via* the ``mace_model_url`` keyword)
+   12. **custom** - custom MACE model (to be set *via* the :ref:`mace_model_path <maceModelPathKey>` keyword)
 
 .. Note::
     The :ref:`qm_prog <qmprogamKey>` option ``mace-off`` is only compatible with the first three model sizes: "small", "medium" and "large"
+
+
+.. _maceModelPathKey:
+
+MACE Model Path
+===============
+
+.. admonition:: Key
+    :class: tip
+
+    mace_model_path = {string}
+
+With the ``mace_model_path`` keyword the user can specify a custom URL corresponding to a `MACE <https://github.com/ACEsuit/mace-foundations?tab=readme-ov-file>`_ model for the QM calculations.
+
+.. Note::
+    The ``mace_model_path`` can only be specified if :ref:`mace_model_size <maceModelSizeKey>` keyword is set to ``custom``.
+
 
 .. _xtbMethodKey:
 

--- a/docs/sphinx/src/userGuide/inputFile.rst
+++ b/docs/sphinx/src/userGuide/inputFile.rst
@@ -35,7 +35,7 @@ Every character following a ``#`` will be ignored. The ``#`` as a comment flag c
 Types of Input Values
 =====================
 
-In the following sections the types of the input values will be denoted via ``{}``, where ``{[]}`` represents a list of types:
+In the following sections the types of the input values will be denoted *via* ``{}``, where ``{[]}`` represents a list of types:
 
 +-------------+-------------------------------+
 |    Type     |          Description          |
@@ -90,7 +90,7 @@ With the ``jobtype`` keyword the user can choose from different engines to perfo
 
 Possible options are:
 
-   1. **mm-md** - Represents a full molecular mechanics molecular dynamics simulation performed via the :ref:`GUFF <guffdatFile>` formalism and/or the ``Amber force field``. Respective input file keys are found in the :ref:`mmKeys` section.
+   1. **mm-md** - Represents a full molecular mechanics molecular dynamics simulation performed *via* the :ref:`GUFF <guffdatFile>` formalism and/or the ``Amber force field``. Respective input file keys are found in the :ref:`mmKeys` section.
 
    2. **qm-md** - Represents a full quantum mechanics molecular dynamics simulation. For more information see the :ref:`qmKeys` section.
 
@@ -1367,6 +1367,8 @@ Possible options are:
    10. **medium-mpa-0** - medium MACE-MPA-0 model
 
    11. **medium-omat-0** - medium MACE-OMAT-0 model
+
+   12. **custom** - custom MACE model (to be set *via* the ``mace_model_url`` keyword)
 
 .. Note::
     The :ref:`qm_prog <qmprogamKey>` option ``mace-off`` is only compatible with the first three model sizes: "small", "medium" and "large"

--- a/include/input/inputFileParser/QMInputParser.hpp
+++ b/include/input/inputFileParser/QMInputParser.hpp
@@ -52,6 +52,7 @@ namespace input
         void parseDispersion(const pq::strings &, const size_t);
 
         void parseMaceModelSize(const pq::strings &, const size_t);
+        void parseMaceModelPath(const pq::strings &, const size_t);
         void parseMaceQMMethod(const std::string_view &);
 
         void parseSlakosType(const pq::strings &, const size_t);

--- a/include/settings/qmSettings.hpp
+++ b/include/settings/qmSettings.hpp
@@ -64,7 +64,8 @@ namespace settings
         LARGE0B2,
         MEDIUM0B3,
         MEDIUMMPA0,
-        MEDIUMOMAT0
+        MEDIUMOMAT0,
+        CUSTOM,
     };
 
     /**

--- a/src/input/inputFileParser/QMInputParser.cpp
+++ b/src/input/inputFileParser/QMInputParser.cpp
@@ -90,6 +90,12 @@ QMInputParser::QMInputParser(Engine &engine) : InputFileParser(engine)
     );
 
     addKeyword(
+        std::string("mace_model_path"),
+        bind_front(&QMInputParser::parseMaceModelPath, this),
+        false
+    );
+
+    addKeyword(
         std::string("slakos"),
         bind_front(&QMInputParser::parseSlakosType, this),
         false
@@ -320,6 +326,21 @@ void QMInputParser::parseMaceModelSize(
             "medium-mpa-0, medium-omat-0, custom",
             lineElements[2]
         ));
+}
+
+/**
+ * @brief parse external MACE model url
+ *
+ * @param lineElements
+ * @param lineNumber
+ */
+void QMInputParser::parseMaceModelPath(
+    const std::vector<std::string> &lineElements,
+    const size_t                    lineNumber
+)
+{
+    checkCommand(lineElements, lineNumber);
+    QMSettings::setMaceModelPath(lineElements[2]);
 }
 
 /**

--- a/src/input/inputFileParser/QMInputParser.cpp
+++ b/src/input/inputFileParser/QMInputParser.cpp
@@ -309,12 +309,15 @@ void QMInputParser::parseMaceModelSize(
     else if ("medium_omat_0" == size)
         QMSettings::setMaceModelSize(MEDIUMOMAT0);
 
+    else if ("custom" == size)
+        QMSettings::setMaceModelSize(CUSTOM);
+
     else
         throw InputFileException(std::format(
             "Invalid mace_model_size \"{}\" in input file.\n"
             "Possible values are: small, medium, large, small-0b,\n"
             "medium-0b, small-0b2, medium-0b2, large-0b2, medium-0b3,\n"
-            "medium-mpa-0, medium-omat-0",
+            "medium-mpa-0, medium-omat-0, custom",
             lineElements[2]
         ));
 }

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -82,6 +82,7 @@ std::string settings::string(const MaceModelSize model)
         case MEDIUM0B3: return "medium-0b3";
         case MEDIUMMPA0: return "medium-mpa-0";
         case MEDIUMOMAT0: return "medium-omat-0";
+        case CUSTOM: return "custom";
 
         default: return "none";
     }
@@ -275,6 +276,9 @@ void QMSettings::setMaceModelSize(const std::string_view &model)
 
     else if ("medium_omat_0" == modelToLowerAndReplaceDashes)
         _maceModelSize = MEDIUMOMAT0;
+
+    else if ("custom" == modelToLowerAndReplaceDashes)
+        _maceModelSize = CUSTOM;
 
     else
         throw UserInputException(

--- a/src/setup/qmSetup.cpp
+++ b/src/setup/qmSetup.cpp
@@ -143,6 +143,22 @@ void QMSetup::setupQMMethodMace()
                 string(MaceModelType::MACE_MP)
             ));
     }
+
+    if (QMSettings::getMaceModelSize() == MaceModelSize::CUSTOM &&
+        QMSettings::getMaceModelPath().empty())
+        throw InputFileException(
+            "You have requested a custom MACE model but haven't provided a "
+            "MACE model path."
+            "This setup is invalid."
+        );
+
+    if (!(QMSettings::getMaceModelSize() == MaceModelSize::CUSTOM) &&
+        !QMSettings::getMaceModelPath().empty())
+        throw InputFileException(
+            "You have set a custom MACE model path without requesting a custom "
+            "mace model size."
+            "This setup is invalid."
+        );
 }
 
 /**
@@ -298,18 +314,24 @@ void QMSetup::setupWriteInfo() const
     {
         const auto modelType = QMSettings::getMaceModelType();
         const auto modelSize = QMSettings::getMaceModelSize();
+        const auto modelPath = QMSettings::getMaceModelPath();
         const auto fp        = Settings::getFloatingPointPybindString();
         const auto useDisp   = QMSettings::useDispersionCorr() ? "on" : "off";
 
         // clang-format off
         const auto modelTypeMsg = std::format("Model type:            {}", string(modelType));
         const auto modelSizeMsg = std::format("Model size:            {}", string(modelSize));
+        const auto modelPathMsg = std::format("Model path:            {}", modelPath);
         const auto fpMsg        = std::format("Floating point type:   {}", fp);
         const auto dispCorrMsg  = std::format("Dispersion Correction: {}", useDisp);
         // clang-format on
 
         logOutput.writeSetupInfo(modelTypeMsg);
         logOutput.writeSetupInfo(modelSizeMsg);
+
+        if (modelSize == MaceModelSize::CUSTOM)
+            logOutput.writeSetupInfo(modelPathMsg);
+
         logOutput.writeSetupInfo(fpMsg);
         logOutput.writeSetupInfo(dispCorrMsg);
     }

--- a/src/setup/qmSetup.cpp
+++ b/src/setup/qmSetup.cpp
@@ -152,7 +152,7 @@ void QMSetup::setupQMMethodMace()
             "This setup is invalid."
         );
 
-    if (!(QMSettings::getMaceModelSize() == MaceModelSize::CUSTOM) &&
+    if (QMSettings::getMaceModelSize() != MaceModelSize::CUSTOM &&
         !QMSettings::getMaceModelPath().empty())
         throw InputFileException(
             "You have set a custom MACE model path without requesting a custom "

--- a/tests/data/inputFileReader/keywordList.txt
+++ b/tests/data/inputFileReader/keywordList.txt
@@ -118,6 +118,7 @@ qm_script_full_path         false
 qm_loop_time_limit          false
 dispersion                  false
 mace_model_size             false
+mace_model_path             false
 slakos                      false
 slakos_path                 false
 third_order                 false

--- a/tests/src/input/inputFileParsing/testQMParser.cpp
+++ b/tests/src/input/inputFileParsing/testQMParser.cpp
@@ -206,13 +206,16 @@ TEST_F(TestInputFileReader, parseMaceModelSize)
     parser.parseMaceModelSize({"mace_model_size", "=", "medium_omat_0"}, 0);
     EXPECT_EQ(QMSettings::getMaceModelSize(), MEDIUMOMAT0);
 
+    parser.parseMaceModelSize({"mace_model_size", "=", "custom"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModelSize(), CUSTOM);
+
     ASSERT_THROW_MSG(
         parser.parseMaceModelSize({"mace_model_size", "=", "notASize"}, 0),
         InputFileException,
         "Invalid mace_model_size \"notASize\" in input file.\n"
         "Possible values are: small, medium, large, small-0b,\n"
         "medium-0b, small-0b2, medium-0b2, large-0b2, medium-0b3,\n"
-        "medium-mpa-0, medium-omat-0"
+        "medium-mpa-0, medium-omat-0, custom"
     )
 }
 

--- a/tests/src/settings/testQMSettings.cpp
+++ b/tests/src/settings/testQMSettings.cpp
@@ -60,7 +60,7 @@ TEST(QMSettingsTest, SetMaceModelSizeTest)
 {
     QMSettings::setMaceModelSize("small");
     EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::SMALL);
-    
+
     QMSettings::setMaceModelSize("medium");
     EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::MEDIUM);
 
@@ -90,6 +90,9 @@ TEST(QMSettingsTest, SetMaceModelSizeTest)
 
     QMSettings::setMaceModelSize("medium-omat-0");
     EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::MEDIUMOMAT0);
+
+    QMSettings::setMaceModelSize("custom");
+    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::CUSTOM);
 
     ASSERT_THROW_MSG(
         QMSettings::setMaceModelSize("notAMaceModelSize"),
@@ -243,6 +246,7 @@ TEST(QMSettingsTest, ReturnMaceModelSizeTest)
     EXPECT_EQ(string(MaceModelSize::MEDIUM0B3), "medium-0b3");
     EXPECT_EQ(string(MaceModelSize::MEDIUMMPA0), "medium-mpa-0");
     EXPECT_EQ(string(MaceModelSize::MEDIUMOMAT0), "medium-omat-0");
+    EXPECT_EQ(string(MaceModelSize::CUSTOM), "custom");
 }
 
 TEST(QMSettingsTest, ReturnXtbMethodTest)

--- a/tests/src/setup/testQMSetup.cpp
+++ b/tests/src/setup/testQMSetup.cpp
@@ -225,3 +225,41 @@ TEST(TestQMSetup, setupQMMethodMaceOffInvalidModelSize)
         "model type."
     );
 }
+
+TEST(TestQMSetup, setupQMMethodMaceRedundantModelPath)
+{
+    engine::QMMDEngine engine;
+    QMSetup            qmSetup{QMSetup(engine)};
+
+    QMSettings::setQMMethod(QMMethod::MACE);
+    QMSettings::setMaceModelType("mace-mp");
+    QMSettings::setMaceModelSize("medium-omat-0");
+    QMSettings::setMaceModelPath("https://not-a-valid-url");
+
+    ASSERT_THROW_MSG(
+        qmSetup.setupQMMethodMace(),
+        customException::InputFileException,
+        "You have set a custom MACE model path without requesting a custom "
+        "mace model size."
+        "This setup is invalid."
+    );
+}
+
+TEST(TestQMSetup, setupQMMethodMaceMissingModelPath)
+{
+    engine::QMMDEngine engine;
+    QMSetup            qmSetup{QMSetup(engine)};
+
+    QMSettings::setQMMethod(QMMethod::MACE);
+    QMSettings::setMaceModelType("mace-mp");
+    QMSettings::setMaceModelSize("custom");
+    QMSettings::setMaceModelPath("");
+
+    ASSERT_THROW_MSG(
+        qmSetup.setupQMMethodMace(),
+        customException::InputFileException,
+        "You have requested a custom MACE model but haven't provided a "
+        "MACE model path."
+        "This setup is invalid."
+    );
+}


### PR DESCRIPTION
This PR solves issue #144 

I added the option `custom` for the `mace_model_size` keyword and enabled the already existing `mace_model_path` key to set the url for the MACE model to be used.