### PR TITLE
QM Loop Time Limit print and default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Next Release
 
+### Enhancements
+
+- QM looptime limit info now gets printed in the .log file
+
 <!-- insertion marker -->
 ## [v0.6.0](https://github.com/MolarVerse/PQ/releases/tag/v0.6.0) - 2025-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Enhancements
 
-- QM looptime limit info now gets printed in the .log file
+- QM loop time limit info gets printed to the .log file
+- QM loop time limit default value is set to 3600 (1 hour)
 
 <!-- insertion marker -->
 ## [v0.6.0](https://github.com/MolarVerse/PQ/releases/tag/v0.6.0) - 2025-04-02

--- a/docs/sphinx/src/userGuide/inputFile.rst
+++ b/docs/sphinx/src/userGuide/inputFile.rst
@@ -1328,9 +1328,9 @@ QM Loop Time Limit
 .. admonition:: Key
     :class: tip
 
-    qm_loop_time_limit = {double} s -> -1 s
+    qm_loop_time_limit = {double} s -> 3600 s
 
-With the ``qm_loop_time_limit`` keyword the user can specify the loop time limit in ``s`` of all QM type calculations. If the time limit is reached the calculation will be stopped. Default value is -1 s, which means no time limit is set, and the calculation will continue until it is finished. In general all negative values will be interpreted as no time limit.
+With the ``qm_loop_time_limit`` keyword the user can specify the loop time limit in ``s`` of all QM type calculations. If the time limit is reached the calculation will be stopped. Default value is 3600 s (1 hour). Values smaller equal than zero are interpreted as no time limit and the calculation will continue until it is finished.
 
 .. _disperstoncorrectionKey:
 

--- a/include/config/defaults.hpp
+++ b/include/config/defaults.hpp
@@ -86,7 +86,7 @@ namespace defaults
 
     static constexpr size_t _DIMENSIONALITY_DEFAULT_ = 3;
 
-    static constexpr double _QM_LOOP_TIME_LIMIT_DEFAULT_ = -1.0;   // in s
+    static constexpr double _QM_LOOP_TIME_LIMIT_DEFAULT_ = 3600;   // in s
 
     static constexpr char   _OPTIMIZER_DEFAULT_[]           = "gradient-descent";
     static constexpr size_t _N_EPOCHS_DEFAULT_              = 100;

--- a/src/setup/qmSetup.cpp
+++ b/src/setup/qmSetup.cpp
@@ -136,12 +136,15 @@ void QMSetup::setupQMMethodMace()
         if (modelSize != MaceModelSize::SMALL &&
             modelSize != MaceModelSize::MEDIUM &&
             modelSize != MaceModelSize::LARGE)
-            throw InputFileException(std::format(
-                "The '{}' model size is only compatible with the '{}' model "
-                "type.",
-                string(modelSize),
-                string(MaceModelType::MACE_MP)
-            ));
+            throw InputFileException(
+                std::format(
+                    "The '{}' model size is only compatible with the '{}' "
+                    "model "
+                    "type.",
+                    string(modelSize),
+                    string(MaceModelType::MACE_MP)
+                )
+            );
     }
 
     if (QMSettings::getMaceModelSize() == MaceModelSize::CUSTOM &&
@@ -389,5 +392,15 @@ void QMSetup::setupWriteInfo() const
         logOutput.writeSetupInfo(xtbMethodMsg);
     }
 
+    const auto qm_loop_time_limit = QMSettings::getQMLoopTimeLimit();
+
+    const auto qmLoopTimeLimitMsg = std::format(
+        "QM looptime limit: {}",
+        qm_loop_time_limit > 0 ? std::format("{} s", qm_loop_time_limit)
+                               : "unlimited"
+    );
+
+    logOutput.writeEmptyLine();
+    logOutput.writeSetupInfo(qmLoopTimeLimitMsg);
     logOutput.writeEmptyLine();
 }

--- a/tests/src/setup/testQMSetup.cpp
+++ b/tests/src/setup/testQMSetup.cpp
@@ -263,3 +263,122 @@ TEST(TestQMSetup, setupQMMethodMaceMissingModelPath)
         "This setup is invalid."
     );
 }
+
+TEST(TestQMSetup, setupQMLoopTimeLimitDefault)
+{
+    auto _engine  = new engine::QMMDEngine();
+    auto _qmSetup = new QMSetup(*_engine);
+
+    _engine->getEngineOutput().getLogOutput().setFilename("default.log");
+    QMSettings::setQMMethod(QMMethod::DFTBPLUS);
+    QMSettings::setQMScript("paTH/To/myQMScript");
+
+    _qmSetup->setupWriteInfo();
+
+    std::ifstream file("default.log");
+    std::string   line;
+    getline(file, line);
+    EXPECT_EQ(line, "         QM runner: DFTBPLUS");
+    getline(file, line);
+    EXPECT_EQ(line, "");
+    getline(file, line);
+    EXPECT_EQ(line, "         QM script: path/to/myqmscript");
+    getline(file, line);
+    EXPECT_EQ(line, "");
+    getline(file, line);
+    EXPECT_EQ(line, "         QM looptime limit: unlimited");
+
+    ::remove("default.log");
+    delete _engine;
+    delete _qmSetup;
+}
+
+TEST(TestQMSetup, setupQMLoopTimeLimitNegative)
+{
+    auto _engine  = new engine::QMMDEngine();
+    auto _qmSetup = new QMSetup(*_engine);
+
+    _engine->getEngineOutput().getLogOutput().setFilename("default.log");
+    QMSettings::setQMMethod(QMMethod::DFTBPLUS);
+    QMSettings::setQMScript("paTH/To/myQMScript");
+    QMSettings::setQMLoopTimeLimit(-1.2);
+
+    _qmSetup->setupWriteInfo();
+
+    std::ifstream file("default.log");
+    std::string   line;
+    getline(file, line);
+    EXPECT_EQ(line, "         QM runner: DFTBPLUS");
+    getline(file, line);
+    EXPECT_EQ(line, "");
+    getline(file, line);
+    EXPECT_EQ(line, "         QM script: path/to/myqmscript");
+    getline(file, line);
+    EXPECT_EQ(line, "");
+    getline(file, line);
+    EXPECT_EQ(line, "         QM looptime limit: unlimited");
+
+    ::remove("default.log");
+    delete _engine;
+    delete _qmSetup;
+}
+
+TEST(TestQMSetup, setupQMLoopTimeLimitZero)
+{
+    auto _engine  = new engine::QMMDEngine();
+    auto _qmSetup = new QMSetup(*_engine);
+
+    _engine->getEngineOutput().getLogOutput().setFilename("default.log");
+    QMSettings::setQMMethod(QMMethod::DFTBPLUS);
+    QMSettings::setQMScript("paTH/To/myQMScript");
+    QMSettings::setQMLoopTimeLimit(0);
+
+    _qmSetup->setupWriteInfo();
+
+    std::ifstream file("default.log");
+    std::string   line;
+    getline(file, line);
+    EXPECT_EQ(line, "         QM runner: DFTBPLUS");
+    getline(file, line);
+    EXPECT_EQ(line, "");
+    getline(file, line);
+    EXPECT_EQ(line, "         QM script: path/to/myqmscript");
+    getline(file, line);
+    EXPECT_EQ(line, "");
+    getline(file, line);
+    EXPECT_EQ(line, "         QM looptime limit: unlimited");
+
+    ::remove("default.log");
+    delete _engine;
+    delete _qmSetup;
+}
+
+TEST(TestQMSetup, setupQMLoopTimeLimitPositive)
+{
+    auto _engine  = new engine::QMMDEngine();
+    auto _qmSetup = new QMSetup(*_engine);
+
+    _engine->getEngineOutput().getLogOutput().setFilename("default.log");
+    QMSettings::setQMMethod(QMMethod::DFTBPLUS);
+    QMSettings::setQMScript("paTH/To/myQMScript");
+    QMSettings::setQMLoopTimeLimit(3.14);
+
+    _qmSetup->setupWriteInfo();
+
+    std::ifstream file("default.log");
+    std::string   line;
+    getline(file, line);
+    EXPECT_EQ(line, "         QM runner: DFTBPLUS");
+    getline(file, line);
+    EXPECT_EQ(line, "");
+    getline(file, line);
+    EXPECT_EQ(line, "         QM script: path/to/myqmscript");
+    getline(file, line);
+    EXPECT_EQ(line, "");
+    getline(file, line);
+    EXPECT_EQ(line, "         QM looptime limit: 3.14 s");
+
+    ::remove("default.log");
+    delete _engine;
+    delete _qmSetup;
+}

--- a/tests/src/setup/testQMSetup.cpp
+++ b/tests/src/setup/testQMSetup.cpp
@@ -286,7 +286,7 @@ TEST(TestQMSetup, setupQMLoopTimeLimitDefault)
     getline(file, line);
     EXPECT_EQ(line, "");
     getline(file, line);
-    EXPECT_EQ(line, "         QM looptime limit: unlimited");
+    EXPECT_EQ(line, "         QM looptime limit: 3600 s");
 
     ::remove("default.log");
     delete _engine;


### PR DESCRIPTION
This PR solves Issue #148 and #153

`qm_loop_time_limit` keyword default value is now set to 3600 sec (1 hour) and the time is printed to the `.log` file accordingly