### PR TITLE
Bugfix/rescale

### DIFF
--- a/include/simulationBox/molecule.hpp
+++ b/include/simulationBox/molecule.hpp
@@ -67,6 +67,7 @@ namespace simulationBox
 
         void calculateCenterOfMass(const Box &);
         void scale(const pq::tensor3D &, const Box &);
+        void decenter(const Box &box);
 
         [[nodiscard]] size_t              getNumberOfAtomTypes();
         [[nodiscard]] std::vector<size_t> getExternalGlobalVDWTypes() const;

--- a/src/manostat/stochasticRescalingManostat.cpp
+++ b/src/manostat/stochasticRescalingManostat.cpp
@@ -136,19 +136,12 @@ void StochasticRescalingManostat::applyManostat(
 
     simBox.checkCoulRadiusCutOff(ExceptionType::MANOSTATEXCEPTION);
 
-    // auto pbcPositions = [&simBox](auto &molecule)
-    // {
-    //     molecule.calculateCenterOfMass(simBox.getBox());
-    //     for (std::size_t i = 0; i < molecule.getNumberOfAtoms(); ++i)
-    //     {
-    //         auto position  = molecule.getAtomPosition(i);
-    //         position      += molecule.getCenterOfMass();
-    //         simBox.applyPBC(position);
-    //         molecule.setAtomPosition(i, position);
-    //     }
-    // };
+    simBox.calculateCenterOfMass();
 
-    // std::ranges::for_each(simBox.getMolecules(), pbcPositions);
+    auto decenterPositions = [&simBox](auto &molecule)
+    { molecule.decenter(simBox.getBox()); };
+
+    std::ranges::for_each(simBox.getMolecules(), decenterPositions);
 
     stopTimingsSection("Stochastic Rescaling");
 }

--- a/src/manostat/stochasticRescalingManostat.cpp
+++ b/src/manostat/stochasticRescalingManostat.cpp
@@ -119,13 +119,6 @@ void StochasticRescalingManostat::applyManostat(
 
     const auto mu = calculateMu(simBox.getVolume());
 
-    simBox.scaleBox(mu);
-
-    physicalData.setVolume(simBox.getVolume());
-    physicalData.setDensity(simBox.getDensity());
-
-    simBox.checkCoulRadiusCutOff(ExceptionType::MANOSTATEXCEPTION);
-
     auto scalePositions = [&mu, &simBox](auto &molecule)
     { molecule.scale(mu, simBox.getBox()); };
 
@@ -133,7 +126,29 @@ void StochasticRescalingManostat::applyManostat(
     { atom->scaleVelocityOrthogonalSpace(inverse(mu), simBox.getBox()); };
 
     std::ranges::for_each(simBox.getMolecules(), scalePositions);
+
     std::ranges::for_each(simBox.getAtoms(), scaleVelocities);
+
+    simBox.scaleBox(mu);
+
+    physicalData.setVolume(simBox.getVolume());
+    physicalData.setDensity(simBox.getDensity());
+
+    simBox.checkCoulRadiusCutOff(ExceptionType::MANOSTATEXCEPTION);
+
+    // auto pbcPositions = [&simBox](auto &molecule)
+    // {
+    //     molecule.calculateCenterOfMass(simBox.getBox());
+    //     for (std::size_t i = 0; i < molecule.getNumberOfAtoms(); ++i)
+    //     {
+    //         auto position  = molecule.getAtomPosition(i);
+    //         position      += molecule.getCenterOfMass();
+    //         simBox.applyPBC(position);
+    //         molecule.setAtomPosition(i, position);
+    //     }
+    // };
+
+    // std::ranges::for_each(simBox.getMolecules(), pbcPositions);
 
     stopTimingsSection("Stochastic Rescaling");
 }

--- a/src/manostat/stochasticRescalingManostat.cpp
+++ b/src/manostat/stochasticRescalingManostat.cpp
@@ -56,7 +56,9 @@ StochasticRescalingManostat::StochasticRescalingManostat(
     : Manostat(other),
       _tau(other._tau),
       _compressibility(other._compressibility),
-      _dt(other._dt) {};
+      _dt(other._dt)
+{
+}
 
 /**
  * @brief Construct a new Stochastic Rescaling Manostat:: Stochastic Rescaling
@@ -78,7 +80,9 @@ SemiIsotropicStochasticRescalingManostat::
     )
     : StochasticRescalingManostat(targetPressure, tau, compressibility),
       _2DAnisotropicAxis(anisotropicAxis),
-      _2DIsotropicAxes(isotropicAxes) {};
+      _2DIsotropicAxes(isotropicAxes)
+{
+}
 
 /**
  * @brief Construct a new Stochastic Rescaling Manostat:: Stochastic Rescaling
@@ -155,7 +159,9 @@ tensor3D StochasticRescalingManostat::calculateMu(const double volume)
 
     const auto deltaP = _targetPressure - _pressure;
 
-    return diagonalMatrix(::exp(-compress * (deltaP) + stochasticFactor / 3.0));
+    return diagonalMatrix(
+        ::exp(-compress * (deltaP) / 3.0 + stochasticFactor / 3.0)
+    );
 }
 
 /**

--- a/src/simulationBox/molecule.cpp
+++ b/src/simulationBox/molecule.cpp
@@ -110,7 +110,7 @@ void Molecule::scale(const tensor3D &shiftTensor, const Box &box)
     if (ManostatSettings::getIsotropy() != Isotropy::FULL_ANISOTROPIC)
         centerOfMass = box.toOrthoSpace(_centerOfMass);
 
-    const auto shift = shiftTensor * centerOfMass - centerOfMass;
+    const auto shift = shiftTensor; // * centerOfMass - centerOfMass;
 
     auto scaleAtomPosition = [&box, shift](auto atom)
     {
@@ -119,13 +119,10 @@ void Molecule::scale(const tensor3D &shiftTensor, const Box &box)
         if (ManostatSettings::getIsotropy() != Isotropy::FULL_ANISOTROPIC)
             position = box.toOrthoSpace(position);
 
-        position += shift;
+        position = shift * position;
 
         if (ManostatSettings::getIsotropy() != Isotropy::FULL_ANISOTROPIC)
             position = box.toSimSpace(position);
-
-        // add pbc to the position
-        box.applyPBC(position);
 
         atom->setPosition(position);
     };

--- a/src/simulationBox/molecule.cpp
+++ b/src/simulationBox/molecule.cpp
@@ -40,14 +40,14 @@ using namespace settings;
  *
  * @param name
  */
-Molecule::Molecule(const std::string_view name) : _name(name){};
+Molecule::Molecule(const std::string_view name) : _name(name) {}
 
 /**
  * @brief Construct a new Molecule:: Molecule object
  *
  * @param moltype
  */
-Molecule::Molecule(const size_t moltype) : _moltype(moltype){};
+Molecule::Molecule(const size_t moltype) : _moltype(moltype) {}
 
 /**
  * @brief finds number of different atom types in molecule
@@ -123,6 +123,9 @@ void Molecule::scale(const tensor3D &shiftTensor, const Box &box)
 
         if (ManostatSettings::getIsotropy() != Isotropy::FULL_ANISOTROPIC)
             position = box.toSimSpace(position);
+
+        // add pbc to the position
+        box.applyPBC(position);
 
         atom->setPosition(position);
     };

--- a/tests/src/simulationBox/testMolecule.cpp
+++ b/tests/src/simulationBox/testMolecule.cpp
@@ -98,11 +98,11 @@ TEST_F(TestMolecule, scaleAtoms)
     const auto centerOfMassBeforeScaling = _molecule->getCenterOfMass();
 
     const linearAlgebra::Vec3D shift =
-        diagonal(scale); //* centerOfMassBeforeScaling - centerOfMassBeforeScaling;
+        diagonal(scale) * centerOfMassBeforeScaling - centerOfMassBeforeScaling;
 
-    linearAlgebra::Vec3D pos1 = shift * atomPosition_1;
-    linearAlgebra::Vec3D pos2 = shift * atomPosition_2;
-    linearAlgebra::Vec3D pos3 = shift * atomPosition_3;
+    linearAlgebra::Vec3D pos1 = atomPosition_1 + shift;
+    linearAlgebra::Vec3D pos2 = atomPosition_2 + shift;
+    linearAlgebra::Vec3D pos3 = atomPosition_3 + shift;
 
     _molecule->scale(scale, box);
 
@@ -112,6 +112,46 @@ TEST_F(TestMolecule, scaleAtoms)
     EXPECT_EQ(_molecule->getAtomPosition(0), pos1);
     EXPECT_EQ(_molecule->getAtomPosition(1), pos2);
     EXPECT_EQ(_molecule->getAtomPosition(2), pos3);
+}
+
+TEST_F(TestMolecule, decenterPositions)
+{
+    simulationBox::OrthorhombicBox box;
+    box.setBoxDimensions({1.0, 2.0, 3.0});
+    _molecule->setNumberOfAtoms(3);
+    _molecule->setAtomPosition(0, linearAlgebra::Vec3D(0.5, 0.0, 0.0));
+    _molecule->setAtomPosition(1, linearAlgebra::Vec3D(0.0, 1.5, 0.0));
+    _molecule->setAtomPosition(2, linearAlgebra::Vec3D(0.0, 0.0, 2.5));
+    const auto centerOfMassBeforeScaling = _molecule->getCenterOfMass();
+    const linearAlgebra::tensor3D scale =
+        diagonalMatrix(linearAlgebra::Vec3D{-2.0, -2.0, -2.0});
+    const linearAlgebra::Vec3D atomPosition_1 = _molecule->getAtomPosition(0);
+    const linearAlgebra::Vec3D atomPosition_2 = _molecule->getAtomPosition(1);
+    const linearAlgebra::Vec3D atomPosition_3 = _molecule->getAtomPosition(2);
+
+    _molecule->scale(scale, box);
+    _molecule->calculateCenterOfMass(box);
+    const auto centerOfMassAfterScaling = _molecule->getCenterOfMass();
+
+    _molecule->decenter(box);
+    const linearAlgebra::Vec3D shift =
+        diagonal(scale) * centerOfMassBeforeScaling - centerOfMassBeforeScaling;
+
+    linearAlgebra::Vec3D pos1 =
+        atomPosition_1 + shift + centerOfMassAfterScaling;
+    linearAlgebra::Vec3D pos2 =
+        atomPosition_2 + shift + centerOfMassAfterScaling;
+    linearAlgebra::Vec3D pos3 =
+        atomPosition_3 + shift + centerOfMassAfterScaling;
+
+    box.applyPBC(pos1);
+    box.applyPBC(pos2);
+    box.applyPBC(pos3);
+
+    EXPECT_EQ(_molecule->getAtomPosition(0), pos1);
+    EXPECT_EQ(_molecule->getAtomPosition(1), pos2);
+    EXPECT_EQ(_molecule->getAtomPosition(2), pos3);
+    EXPECT_EQ(_molecule->getCenterOfMass(), centerOfMassAfterScaling);
 }
 
 TEST_F(TestMolecule, setAtomForceToZero)

--- a/tests/src/simulationBox/testMolecule.cpp
+++ b/tests/src/simulationBox/testMolecule.cpp
@@ -22,6 +22,8 @@
 
 #include "testMolecule.hpp"
 
+#include <algorithm>   // for std::ranges::for_each
+
 #include "gtest/gtest.h"         // for Message, TestPartResult
 #include "orthorhombicBox.hpp"   // for OrthorhombicBox
 #include "staticMatrix.hpp"      // for diagonalMatrix
@@ -39,26 +41,77 @@ TEST_F(TestMolecule, calculateCenterOfMass)
 
 TEST_F(TestMolecule, scaleAtoms)
 {
-    const linearAlgebra::tensor3D scale =
-        diagonalMatrix(linearAlgebra::Vec3D{1.0, 2.0, 3.0});
-    const linearAlgebra::Vec3D atomPosition1 = _molecule->getAtomPosition(0);
-    const linearAlgebra::Vec3D atomPosition2 = _molecule->getAtomPosition(1);
-    const linearAlgebra::Vec3D atomPosition3 = _molecule->getAtomPosition(2);
+    // const linearAlgebra::tensor3D scale =
+    //     diagonalMatrix(linearAlgebra::Vec3D{1.0, 2.0, 3.0});
+    // const linearAlgebra::Vec3D atomPosition1 = _molecule->getAtomPosition(0);
+    // const linearAlgebra::Vec3D atomPosition2 = _molecule->getAtomPosition(1);
+    // const linearAlgebra::Vec3D atomPosition3 = _molecule->getAtomPosition(2);
+
+    // simulationBox::OrthorhombicBox box;
+    // box.setBoxDimensions({10.0, 10.0, 10.0});
+
+    // _molecule->calculateCenterOfMass(box);
+
+    // const auto centerOfMassBeforeScaling = _molecule->getCenterOfMass();
+    // const linearAlgebra::Vec3D shift =
+    //     centerOfMassBeforeScaling * (diagonal(scale) - 1.0);
+
+    // _molecule->scale(scale, box);
+
+    // EXPECT_EQ(_molecule->getAtomPosition(0), atomPosition1 + shift);
+    // EXPECT_EQ(_molecule->getAtomPosition(1), atomPosition2 + shift);
+    // EXPECT_EQ(_molecule->getAtomPosition(2), atomPosition3 + shift);
+
+    // Test atoms scaling on the boundaries
 
     simulationBox::OrthorhombicBox box;
-    box.setBoxDimensions({10.0, 10.0, 10.0});
+    simulationBox::OrthorhombicBox box_control;
+    box.setBoxDimensions({1.0, 2.0, 3.0});
+    box_control.setBoxDimensions({1.0, 2.0, 3.0});
+    _molecule->setNumberOfAtoms(3);
+    _molecule->setAtomPosition(0, linearAlgebra::Vec3D(0.5, 0.0, 0.0));
+    _molecule->setAtomPosition(1, linearAlgebra::Vec3D(0.0, 1.5, 0.0));
+    _molecule->setAtomPosition(2, linearAlgebra::Vec3D(0.0, 0.0, 2.5));
+
+    EXPECT_EQ(
+        _molecule->getAtomPosition(0),
+        linearAlgebra::Vec3D(0.5, 0.0, 0.0)
+    );
+    EXPECT_EQ(
+        _molecule->getAtomPosition(1),
+        linearAlgebra::Vec3D(0.0, 1.5, 0.0)
+    );
+    EXPECT_EQ(
+        _molecule->getAtomPosition(2),
+        linearAlgebra::Vec3D(0.0, 0.0, 2.5)
+    );
+
+    const linearAlgebra::tensor3D scale =
+        diagonalMatrix(linearAlgebra::Vec3D{-2.0, -2.0, -2.0});
+
+    const linearAlgebra::Vec3D atomPosition_1 = _molecule->getAtomPosition(0);
+    const linearAlgebra::Vec3D atomPosition_2 = _molecule->getAtomPosition(1);
+    const linearAlgebra::Vec3D atomPosition_3 = _molecule->getAtomPosition(2);
 
     _molecule->calculateCenterOfMass(box);
 
     const auto centerOfMassBeforeScaling = _molecule->getCenterOfMass();
+
     const linearAlgebra::Vec3D shift =
-        centerOfMassBeforeScaling * (diagonal(scale) - 1.0);
+        diagonal(scale); //* centerOfMassBeforeScaling - centerOfMassBeforeScaling;
+
+    linearAlgebra::Vec3D pos1 = shift * atomPosition_1;
+    linearAlgebra::Vec3D pos2 = shift * atomPosition_2;
+    linearAlgebra::Vec3D pos3 = shift * atomPosition_3;
 
     _molecule->scale(scale, box);
 
-    EXPECT_EQ(_molecule->getAtomPosition(0), atomPosition1 + shift);
-    EXPECT_EQ(_molecule->getAtomPosition(1), atomPosition2 + shift);
-    EXPECT_EQ(_molecule->getAtomPosition(2), atomPosition3 + shift);
+    // scale box
+    box_control.scaleBox(scale);
+
+    EXPECT_EQ(_molecule->getAtomPosition(0), pos1);
+    EXPECT_EQ(_molecule->getAtomPosition(1), pos2);
+    EXPECT_EQ(_molecule->getAtomPosition(2), pos3);
 }
 
 TEST_F(TestMolecule, setAtomForceToZero)


### PR DESCRIPTION
If the scaling is done atom-wise the shake distances are evenly distributed. The bug is probably located in the scaling function and it is related with the box scaling.