### PR TITLE
bugifx: qm_script_full_path preserves original casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Index 0 is now correctly out of bounds in topology file
+- The path provided for qm_script_full_path preserves its letter casing
 
 ### Internal
 

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -379,7 +379,7 @@ void QMSettings::setXtbMethod(const XtbMethod method) { _xtbMethod = method; }
  */
 void QMSettings::setQMScript(const std::string_view &script)
 {
-    _qmScript = toLowerAndReplaceDashesCopy(script);
+    _qmScript = script;
 }
 
 /**

--- a/tests/src/input/inputFileParsing/testQMParser.cpp
+++ b/tests/src/input/inputFileParsing/testQMParser.cpp
@@ -82,10 +82,10 @@ TEST_F(TestInputFileReader, parseQMScriptFullPath)
 {
     auto parser = QMInputParser(*_engine);
     parser.parseQMScriptFullPath(
-        {"qm_script_full_path", "=", "/path/to/script.sh"},
+        {"qm_script_full_path", "=", "/path/to/QM/Script.sh"},
         0
     );
-    EXPECT_EQ(QMSettings::getQMScriptFullPath(), "/path/to/script.sh");
+    EXPECT_EQ(QMSettings::getQMScriptFullPath(), "/path/to/QM/Script.sh");
 }
 
 TEST_F(TestInputFileReader, parseQMLoopTimeLimit)

--- a/tests/src/setup/testQMSetup.cpp
+++ b/tests/src/setup/testQMSetup.cpp
@@ -271,7 +271,7 @@ TEST(TestQMSetup, setupQMLoopTimeLimitDefault)
 
     _engine->getEngineOutput().getLogOutput().setFilename("default.log");
     QMSettings::setQMMethod(QMMethod::DFTBPLUS);
-    QMSettings::setQMScript("paTH/To/myQMScript");
+    QMSettings::setQMScript("path/To/myQMScript");
 
     _qmSetup->setupWriteInfo();
 
@@ -282,7 +282,7 @@ TEST(TestQMSetup, setupQMLoopTimeLimitDefault)
     getline(file, line);
     EXPECT_EQ(line, "");
     getline(file, line);
-    EXPECT_EQ(line, "         QM script: path/to/myqmscript");
+    EXPECT_EQ(line, "         QM script: path/To/myQMScript");
     getline(file, line);
     EXPECT_EQ(line, "");
     getline(file, line);
@@ -300,7 +300,7 @@ TEST(TestQMSetup, setupQMLoopTimeLimitNegative)
 
     _engine->getEngineOutput().getLogOutput().setFilename("default.log");
     QMSettings::setQMMethod(QMMethod::DFTBPLUS);
-    QMSettings::setQMScript("paTH/To/myQMScript");
+    QMSettings::setQMScript("path/To/myQMScript");
     QMSettings::setQMLoopTimeLimit(-1.2);
 
     _qmSetup->setupWriteInfo();
@@ -312,7 +312,7 @@ TEST(TestQMSetup, setupQMLoopTimeLimitNegative)
     getline(file, line);
     EXPECT_EQ(line, "");
     getline(file, line);
-    EXPECT_EQ(line, "         QM script: path/to/myqmscript");
+    EXPECT_EQ(line, "         QM script: path/To/myQMScript");
     getline(file, line);
     EXPECT_EQ(line, "");
     getline(file, line);
@@ -330,7 +330,7 @@ TEST(TestQMSetup, setupQMLoopTimeLimitZero)
 
     _engine->getEngineOutput().getLogOutput().setFilename("default.log");
     QMSettings::setQMMethod(QMMethod::DFTBPLUS);
-    QMSettings::setQMScript("paTH/To/myQMScript");
+    QMSettings::setQMScript("path/To/myQMScript");
     QMSettings::setQMLoopTimeLimit(0);
 
     _qmSetup->setupWriteInfo();
@@ -342,7 +342,7 @@ TEST(TestQMSetup, setupQMLoopTimeLimitZero)
     getline(file, line);
     EXPECT_EQ(line, "");
     getline(file, line);
-    EXPECT_EQ(line, "         QM script: path/to/myqmscript");
+    EXPECT_EQ(line, "         QM script: path/To/myQMScript");
     getline(file, line);
     EXPECT_EQ(line, "");
     getline(file, line);
@@ -360,7 +360,7 @@ TEST(TestQMSetup, setupQMLoopTimeLimitPositive)
 
     _engine->getEngineOutput().getLogOutput().setFilename("default.log");
     QMSettings::setQMMethod(QMMethod::DFTBPLUS);
-    QMSettings::setQMScript("paTH/To/myQMScript");
+    QMSettings::setQMScript("path/To/myQMScript");
     QMSettings::setQMLoopTimeLimit(3.14);
 
     _qmSetup->setupWriteInfo();
@@ -372,7 +372,7 @@ TEST(TestQMSetup, setupQMLoopTimeLimitPositive)
     getline(file, line);
     EXPECT_EQ(line, "");
     getline(file, line);
-    EXPECT_EQ(line, "         QM script: path/to/myqmscript");
+    EXPECT_EQ(line, "         QM script: path/To/myQMScript");
     getline(file, line);
     EXPECT_EQ(line, "");
     getline(file, line);


### PR DESCRIPTION
This PR solves issue #167 