### PR TITLE
external: fixing eigen version to 3.4.1 -> next release 5.0.0 seems

### DIFF
--- a/.cmake/eigen.cmake
+++ b/.cmake/eigen.cmake
@@ -1,11 +1,13 @@
 message(CHECK_START "Fetching Eigen3")
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
+set(EIGEN_TAG 3.4.1)
+
 include(FetchContent)
 FetchContent_Declare(
     Eigen
     GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-    GIT_TAG master
+    GIT_TAG ${EIGEN_TAG}
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE
 )

--- a/.cmake/eigen.cmake
+++ b/.cmake/eigen.cmake
@@ -1,7 +1,7 @@
 message(CHECK_START "Fetching Eigen3")
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
-set(EIGEN_TAG 3.4.1)
+set(EIGEN_TAG 5.0.0)
 
 include(FetchContent)
 FetchContent_Declare(
@@ -18,7 +18,6 @@ FetchContent_Declare(
 # scoped
 set(BUILD_TESTING OFF)
 set(EIGEN_BUILD_TESTING OFF)
-set(EIGEN_MPL2_ONLY ON)
 set(EIGEN_BUILD_PKGCONFIG OFF)
 set(EIGEN_BUILD_DOC OFF)
 FetchContent_MakeAvailable(Eigen)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Next Release
 
+### Bug Fixes
+
+- Eigen version finally fixed to 3.4.1 (latest aka 5.0.0 broken 28.09.25)
+
 <!-- insertion marker -->
 ## [v0.6.2](https://github.com/MolarVerse/PQ/releases/tag/v0.6.2) - 2025-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- Eigen version finally fixed to 3.4.1 (latest aka 5.0.0 broken 28.09.25)
+- Eigen version finally fixed to 5.0.0 (latest aka master broken on 28.09.25)
 
 <!-- insertion marker -->
 ## [v0.6.2](https://github.com/MolarVerse/PQ/releases/tag/v0.6.2) - 2025-08-22


### PR DESCRIPTION
[Eigen 5.0.0](https://gitlab.com/libeigen/eigen/-/tags/5.0.0) seems to be broken