### PR TITLE
fix: enable compilation with Clang/Apple Clang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 - Add keyword "remove_net_force" for removing total net force when reading in 
   forces from QM calculations
 
+### Build
+
+- Enabled compilation with Clang/Apple Clang (matched the `requires`-clause form
+  on Vector3D compound-assignment operators and fixed a narrowing conversion in
+  TriclinicBox)
+
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31
 

--- a/include/linearAlgebra/vector3d/vector3dClass.hpp
+++ b/include/linearAlgebra/vector3d/vector3dClass.hpp
@@ -90,28 +90,28 @@ namespace linearAlgebra
 
         // += operators
         void operator+=(const Vector3D<T> &)
-        requires(pq::ArithmeticVector3D<T> || pq::Arithmetic<T>);
+        requires pq::ArithmeticVector3D<T> || pq::Arithmetic<T>;
 
         Vector3D &operator+=(const T)
         requires pq::Arithmetic<T>;
 
         // -= operators
         Vector3D &operator-=(const Vector3D<T> &)
-        requires(pq::ArithmeticVector3D<T> || pq::Arithmetic<T>);
+        requires pq::ArithmeticVector3D<T> || pq::Arithmetic<T>;
 
         Vector3D &operator-=(const T)
         requires pq::Arithmetic<T>;
 
         // *= operators
         Vector3D &operator*=(const Vector3D<T> &)
-        requires(pq::ArithmeticVector3D<T> || pq::Arithmetic<T>);
+        requires pq::ArithmeticVector3D<T> || pq::Arithmetic<T>;
 
         Vector3D &operator*=(const T)
         requires pq::Arithmetic<T>;
 
         // /= operators
         Vector3D &operator/=(const Vector3D<T> &)
-        requires(pq::ArithmeticVector3D<T> || pq::Arithmetic<T>);
+        requires pq::ArithmeticVector3D<T> || pq::Arithmetic<T>;
 
         Vector3D &operator/=(const T)
         requires pq::Arithmetic<T>;

--- a/src/box/triclinicBox.cpp
+++ b/src/box/triclinicBox.cpp
@@ -128,7 +128,8 @@ void TriclinicBox::applyPBC(Vec3D &position) const
             for (int j = -1; j <= 1; ++j)
                 for (int k = -1; k <= 1; ++k)
                 {
-                    const auto shift = _boxMatrix * Vec3D{i, j, k};
+                    const auto shift =
+                        _boxMatrix * Vec3D{double(i), double(j), double(k)};
 
                     const auto newPosition = originalPosition + shift;
 

--- a/src/box/triclinicBox.cpp
+++ b/src/box/triclinicBox.cpp
@@ -128,8 +128,11 @@ void TriclinicBox::applyPBC(Vec3D &position) const
             for (int j = -1; j <= 1; ++j)
                 for (int k = -1; k <= 1; ++k)
                 {
-                    const auto shift =
-                        _boxMatrix * Vec3D{double(i), double(j), double(k)};
+                    const auto shift = _boxMatrix * Vec3D{
+                        static_cast<double>(i),
+                        static_cast<double>(j),
+                        static_cast<double>(k),
+                    };
 
                     const auto newPosition = originalPosition + shift;
 


### PR DESCRIPTION
Two Clang-only build breakers (GCC accepts both, so CI — which is GCC-only — never caught them):

1. `Vector3D` compound-assignment operators (`+= -= *= /=`) declared a parenthesized `requires(...)` clause but defined an unparenthesized one. Redeclaration matching requires token-identical constraint expressions, so Clang rejects the out-of-line definitions in `vector3dClass.tpp.hpp`.
2. `TriclinicBox::applyPBC` builds `Vec3D{i, j, k}` from `int` loop variables — a narrowing conversion in a braced initializer (ill-formed; GCC only warns).

With both, a full build succeeds under Apple Clang. No behavior change on GCC (constraint syntax only / value-identical cast).