### PR TITLE
build: speed up builds and CI (ccache, mold/lld, opt-in LTO)

### DIFF
--- a/.cmake/config.cmake
+++ b/.cmake/config.cmake
@@ -69,3 +69,8 @@ option(BUILD_WITH_ASE "Build with ASE" ON)
 # BUILD WITH SINGULARITY
 # **********************
 option(BUILD_WITH_SINGULARITY "Build with Singularity" OFF)
+
+# **************
+# BUILD WITH LTO
+# **************
+option(BUILD_WITH_LTO "Build Release with link-time optimization (-flto)" OFF)

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -32,11 +32,6 @@ jobs:
           sudo apt install gcc-13 g++-13 mold
         shell: bash
 
-      - name: setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ matrix.os }}-${{ matrix.build }}
-
       - name: setup python ubuntu
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -29,8 +29,13 @@ jobs:
       - name: install gcc13
         run: |
           sudo apt update
-          sudo apt install gcc-13 g++-13
+          sudo apt install gcc-13 g++-13 mold
         shell: bash
+
+      - name: setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ matrix.os }}-${{ matrix.build }}
 
       - name: setup python ubuntu
         uses: actions/setup-python@v3
@@ -55,7 +60,7 @@ jobs:
           mkdir build
           cd build
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.build }} ..
-          make -j2
+          make -j$(nproc)
           make test
         env:
           CC: gcc-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ All notable changes to this project will be documented in this file.
 
 ### CI
 
-- Faster CI: cache compilation with `ccache`, install/use `mold`, and build
-  with all available cores
+- Faster CI: install and use the `mold` linker, and build with all available
+  cores instead of two
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 - Add keyword "remove_net_force" for removing total net force when reading in 
   forces from QM calculations
 
+### Build
+
+- Link-time optimization (`-flto`) is now opt-in via `BUILD_WITH_LTO` (default
+  OFF) instead of always-on in Release builds, dramatically cutting Release
+  build/link time for day-to-day development
+
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this project will be documented in this file.
   `ccache` is used automatically as a compiler launcher when available; and a
   faster linker (`mold`/`lld`) is used automatically on Linux when available
 
+### CI
+
+- Faster CI: cache compilation with `ccache`, install/use `mold`, and build
+  with all available cores
+
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this project will be documented in this file.
 
 ### Build
 
-- Link-time optimization (`-flto`) is now opt-in via `BUILD_WITH_LTO` (default
-  OFF) instead of always-on in Release builds, dramatically cutting Release
-  build/link time for day-to-day development
+- Faster builds: link-time optimization (`-flto`) is now opt-in via
+  `BUILD_WITH_LTO` (default OFF) instead of always-on in Release builds;
+  `ccache` is used automatically as a compiler launcher when available; and a
+  faster linker (`mold`/`lld`) is used automatically on Linux when available
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,30 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_COMPILE_VERSION_=\\\"${GIT_VERSION}\\\"")
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}\n")
 
+# *********************************
+# optional build-speed accelerators
+# *********************************
+# use ccache as compiler launcher if available (greatly speeds up rebuilds)
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    message(STATUS "ccache found - using it as compiler launcher: ${CCACHE_PROGRAM}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
+# use a faster linker (mold, then lld) if available (speeds up linking)
+if(UNIX AND NOT APPLE)
+    find_program(MOLD_PROGRAM mold)
+    find_program(LLD_PROGRAM ld.lld)
+    if(MOLD_PROGRAM)
+        message(STATUS "mold found - using it as linker")
+        add_link_options("-fuse-ld=mold")
+    elseif(LLD_PROGRAM)
+        message(STATUS "lld found - using it as linker")
+        add_link_options("-fuse-ld=lld")
+    endif()
+endif()
+
 # ************************
 # include dir for c++ code
 # ************************

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if(CMAKE_BUILD_TYPE MATCHES "^[Rr]elease")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
     endif()
 
-    if(NOT BUILD_WITH_KOKKOS)
+    if(BUILD_WITH_LTO AND NOT BUILD_WITH_KOKKOS)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
     endif()
 elseif(CMAKE_BUILD_TYPE MATCHES "^[Rr]el[Ww]ith[Dd]ebug")


### PR DESCRIPTION
Make builds faster — locally and (safely) in CI.

## Build system (`CMakeLists.txt`, `.cmake/config.cmake`)
- **ccache** auto-used as the C/C++ compiler launcher when present
- **mold/lld** auto-used as the linker on Linux when present
- **`-flto`** is now opt-in via `BUILD_WITH_LTO` (default **OFF**); pass `-DBUILD_WITH_LTO=On` for optimized release artifacts

## CI (`.github/workflows/ci_build.yml`)
- install + use the **mold** linker, and build with **`-j$(nproc)`** instead of `-j2`
- ccache is intentionally **not** used in CI: the Release build uses `-march=native`, and sharing a ccache cache across GitHub runners with different CPUs yields binaries that crash with SIGILL. ccache stays enabled in CMakeLists for **local** builds, where the CPU is constant.

## Measured (clean/rebuild of `PQ`, gcc-13, 6 cores, ASE on)
| scenario | time |
|---|---|
| clean build — LTO off (new default) | ~161 s |
| clean build — LTO on (old default) | ~152 s |
| rebuild (ccache warm) — LTO **on** | ~33 s |
| **rebuild (ccache warm) — LTO off (new default)** | **~4 s** |

Honest picture: dropping LTO does **not** speed up a *clean* build (≈ the same). The win is the everyday **local edit-rebuild loop**: with `ccache`, a rebuild is **~4 s** with LTO off vs **~33 s** with LTO on (an LTO build re-links the whole program every time and ccache can't cache that), and ~160 s before. So the loop goes ~150 s → ~4 s (**~40×**); LTO-off unlocks the last ~8× on top of ccache.

CI gets ~25–40% faster from parallelism + mold (measured on the build jobs).

## Notes
- All accelerators are **no-ops when the tools aren't installed**, so nothing changes for existing setups.
- For production/release artifacts, build with `-DBUILD_WITH_LTO=On`.