### PR TITLE
build: guard built-in SLAKOS path so non-ASE builds compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
   `BUILD_WITH_LTO` (default OFF) instead of always-on in Release builds;
   `ccache` is used automatically as a compiler launcher when available; and a
   faster linker (`mold`/`lld`) is used automatically on Linux when available
+- Fixed compilation with `-DBUILD_WITH_ASE=Off`: the built-in SLAKOS path
+  (`__SLAKOS_DIR__`) is now guarded, so non-ASE builds compile and report a
+  clear error only if a built-in SLAKOS set is actually requested
 
 ### CI
 

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -129,6 +129,25 @@ std::string settings::string(const SlakosType slakos)
 }
 
 /**
+ * @brief builds the file path for a built-in SLAKOS set (3ob/matsci)
+ *
+ * @details __SLAKOS_DIR__ is only defined when building with ASE support (see
+ * .cmake/slakos.cmake). In a build without ASE, requesting a built-in set is
+ * reported as a user input error instead of failing to compile.
+ */
+static std::string builtinSlakosPath([[maybe_unused]] const SlakosType type)
+{
+#ifdef __SLAKOS_DIR__
+    return __SLAKOS_DIR__ + settings::string(type) + "/skfiles/";
+#else
+    throw InputFileException(
+        "Built-in SLAKOS sets (3ob/matsci) require building PQ with "
+        "-DBUILD_WITH_ASE=On"
+    );
+#endif
+}
+
+/**
  * @brief returns the xTB method as string
  *
  * @param method
@@ -405,13 +424,13 @@ void QMSettings::setSlakosType(const std::string_view &slakos)
     if ("3ob" == slakosType)
     {
         _slakosType = THREEOB;
-        _slakosPath = __SLAKOS_DIR__ + string(_slakosType) + "/skfiles/";
+        _slakosPath = builtinSlakosPath(_slakosType);
     }
 
     else if ("matsci" == slakosType)
     {
         _slakosType = MATSCI;
-        _slakosPath = __SLAKOS_DIR__ + string(_slakosType) + "/skfiles/";
+        _slakosPath = builtinSlakosPath(_slakosType);
     }
 
     else if ("custom" == slakosType)


### PR DESCRIPTION
`__SLAKOS_DIR__` is only defined when building with ASE support (`slakos.cmake`), so `src/settings/qmSettings.cpp` failed to compile with `-DBUILD_WITH_ASE=Off`:

```
error: '__SLAKOS_DIR__' was not declared in this scope
```

This routes the built-in SLAKOS path through a guarded helper: with ASE it builds the path as before; without ASE it throws a clear `InputFileException` only if a built-in set (`3ob`/`matsci`) is actually requested.

**Effect:** `-DBUILD_WITH_ASE=Off` builds now compile (lighter dev/CI builds, no Python/conda/slakos needed). ASE-on behaviour is unchanged.

**Validated:** full `PQ` builds with `-DBUILD_WITH_ASE=Off` under gcc-13 (was the only ASE-off blocker).