### PR TITLE
refactor: return cell list / neighbour cells by const&, drop secondStep shared_ptr copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ All notable changes to this project will be documented in this file.
   on Vector3D compound-assignment operators and fixed a narrowing conversion in
   TriclinicBox)
 
+### Internal
+
+- `CellList::getCells()` and `Cell::getNeighbourCells()` now return by
+  `const &` instead of by value, and `VelocityVerlet::secondStep` no longer
+  copies the per-atom `shared_ptr` into its lambda parameter
+
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31
 

--- a/include/simulationBox/cell.hpp
+++ b/include/simulationBox/cell.hpp
@@ -71,7 +71,7 @@ namespace simulationBox
         [[nodiscard]] std::vector<Molecule *> getMolecules() const;
 
         [[nodiscard]] Cell *getNeighbourCell(const size_t index) const;
-        [[nodiscard]] std::vector<Cell *> getNeighbourCells() const;
+        [[nodiscard]] const std::vector<Cell *> &getNeighbourCells() const;
 
         [[nodiscard]] const std::vector<size_t> &getAtomIndices(
             const size_t index

--- a/include/simulationBox/celllist.hpp
+++ b/include/simulationBox/celllist.hpp
@@ -87,7 +87,7 @@ namespace simulationBox
         [[nodiscard]] pq::Vec3Dul       getNumberOfCells() const;
         [[nodiscard]] pq::Vec3Dul       getNumberOfNeighbourCells() const;
         [[nodiscard]] pq::Vec3D         getCellSize() const;
-        [[nodiscard]] std::vector<Cell> getCells() const;
+        [[nodiscard]] const std::vector<Cell> &getCells() const;
         [[nodiscard]] Cell             &getCell(const size_t index);
 
         /***************************

--- a/src/integrator/velocityVerlet.cpp
+++ b/src/integrator/velocityVerlet.cpp
@@ -70,7 +70,7 @@ void VelocityVerlet::secondStep(SimulationBox &simBox)
 
     std::ranges::for_each(
         simBox.getAtoms(),
-        [this](auto atom) { integrateVelocities(atom.get()); }
+        [this](auto &atom) { integrateVelocities(atom.get()); }
     );
 
     stopTimingsSection("Velocity Verlet - Second Step");

--- a/src/integrator/velocityVerlet.cpp
+++ b/src/integrator/velocityVerlet.cpp
@@ -70,7 +70,7 @@ void VelocityVerlet::secondStep(SimulationBox &simBox)
 
     std::ranges::for_each(
         simBox.getAtoms(),
-        [this](auto &atom) { integrateVelocities(atom.get()); }
+        [this](const auto &atom) { integrateVelocities(atom.get()); }
     );
 
     stopTimingsSection("Velocity Verlet - Second Step");

--- a/src/simulationBox/cell.cpp
+++ b/src/simulationBox/cell.cpp
@@ -144,9 +144,12 @@ Cell *Cell::getNeighbourCell(const size_t index) const
 /**
  * @brief returns the neighbour cells vector
  *
- * @return std::vector<Cell*>
+ * @return const std::vector<Cell*>&
  */
-std::vector<Cell *> Cell::getNeighbourCells() const { return _neighbourCells; }
+const std::vector<Cell *> &Cell::getNeighbourCells() const
+{
+    return _neighbourCells;
+}
 
 /**
  * @brief returns the atom indices at the given index

--- a/src/simulationBox/celllist.cpp
+++ b/src/simulationBox/celllist.cpp
@@ -364,9 +364,9 @@ Vec3D CellList::getCellSize() const { return _cellSize; }
 /**
  * @brief get cells
  *
- * @return std::vector<Cell>
+ * @return const std::vector<Cell>&
  */
-std::vector<Cell> CellList::getCells() const { return _cells; }
+const std::vector<Cell> &CellList::getCells() const { return _cells; }
 
 /**
  * @brief get cell by index

--- a/tests/src/simulationBox/testCelllist.cpp
+++ b/tests/src/simulationBox/testCelllist.cpp
@@ -48,7 +48,7 @@ TEST_F(TestCellList, determineCellBoundaries)
     _cellList->resizeCells();
     _cellList->determineCellBoundaries(_simulationBox->getBoxDimensions());
 
-    auto cells = _cellList->getCells();
+    const auto &cells = _cellList->getCells();
 
     const auto box = _simulationBox->getBoxDimensions();
     auto index     = static_cast<linearAlgebra::Vec3D>(cells[0].getCellIndex());
@@ -110,7 +110,7 @@ TEST_F(TestCellList, addNeighbouringCellPointers)
     _cellList->determineCellBoundaries(_simulationBox->getBoxDimensions());
     _cellList->addNeighbouringCellPointers(cell);
 
-    const auto neighbourCells = cell.getNeighbourCells();
+    const auto &neighbourCells = cell.getNeighbourCells();
 
     EXPECT_EQ(neighbourCells.size(), 13);
     EXPECT_EQ(
@@ -179,7 +179,7 @@ TEST_F(TestCellList, addNeighbouringCells)
 
     for (const auto &cell : _cellList->getCells())
     {
-        const auto neighbourCells = cell.getNeighbourCells();
+        const auto &neighbourCells = cell.getNeighbourCells();
         EXPECT_EQ(neighbourCells.size(), 62);
     }
 


### PR DESCRIPTION
Three small const-ref cleanups along the MD hot path. No behavior change; an A/B (1500 steps, `examples/h2o_mm`) showed wall-clock is dominated by real arithmetic, not these copies — purely strictly-less-work.

1. `CellList::getCells()` → `const std::vector<Cell>&`. Both call sites (`potentialCellList.cpp:71,104`) already iterate `const auto&`; the previous form deep-copied the entire cell list twice per force evaluation.
2. `Cell::getNeighbourCells()` → `const std::vector<Cell*>&`. One call site (`potentialCellList.cpp:108`).
3. `VelocityVerlet::secondStep` lambda takes `auto&` instead of `auto` — per-atom `shared_ptr<Atom>` no longer atomic-ref-counted every step. `firstStep` already used `auto&`.

Test callers (`testCelllist.cpp:51,180,113,182`) bind to the const-ref form unchanged.