### PR TITLE
ci: callgrind perf-regression gate (11 benchmarks)

### DIFF
--- a/.cmake/config.cmake
+++ b/.cmake/config.cmake
@@ -82,3 +82,10 @@ option(BUILD_WITH_LTO "Build Release with link-time optimization (-flto)" OFF)
 # portable/cacheable builds (e.g. CI), where -march=native would otherwise
 # produce binaries that crash on a different CPU.
 option(BUILD_WITH_NATIVE "Optimize Release for the build machine's CPU (-march=native)" ON)
+
+# *********************
+# BUILD WITH PERF BENCH
+# *********************
+# Build the fixed-work performance-regression benchmark (benchmarks/perf),
+# used by CI to gate on instruction-count regressions via callgrind.
+option(BUILD_WITH_PERF_BENCH "Build the performance-regression benchmark" OFF)

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,65 @@
+name: Performance Gate
+
+# Builds the fixed-work perf benchmarks for the PR and for the base branch,
+# runs each under callgrind, and fails if any regressed by more than the
+# threshold. Instruction counts are deterministic, so this is not flaky.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+jobs:
+  perf-regression:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref || 'dev' }}
+          submodules: recursive
+          path: base
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-13 g++-13 valgrind mold
+        shell: bash
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: perf-${{ github.base_ref || 'dev' }}
+
+      - name: Build PR benchmarks
+        run: |
+          cmake -S . -B build-pr \
+            -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_NATIVE=Off \
+            -DBUILD_WITH_PERF_BENCH=On -DBUILD_WITH_ASE=Off \
+            -DBUILD_WITH_TESTS=Off -DBUILD_WITH_DOCS=Off
+          cmake --build build-pr --target perf_benchmarks -j$(nproc)
+        env:
+          CC: gcc-13
+          CXX: g++-13
+
+      - name: Build base benchmarks (baseline)
+        run: |
+          cmake -S base -B build-base \
+            -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_NATIVE=Off \
+            -DBUILD_WITH_PERF_BENCH=On -DBUILD_WITH_ASE=Off \
+            -DBUILD_WITH_TESTS=Off -DBUILD_WITH_DOCS=Off || true
+          cmake --build build-base --target perf_benchmarks -j$(nproc) \
+            || echo "base branch has no perf benchmarks yet - baseline skipped"
+        env:
+          CC: gcc-13
+          CXX: g++-13
+
+      - name: Compare instruction counts (gate)
+        run: bash scripts/perf_gate.sh build-pr/benchmarks/perf build-base/benchmarks/perf 2

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -90,6 +90,7 @@ jobs:
           script: |
             const fs = require('fs');
             const marker = '<!-- perf-gate-comment -->';
+            const botLogin = 'pq-perf-bot[bot]';
             let body;
             try { body = fs.readFileSync('perf_report.md', 'utf8'); }
             catch (e) { core.info('no perf_report.md, skipping comment'); return; }
@@ -98,12 +99,22 @@ jobs:
             const { data: comments } =
               await github.rest.issues.listComments({ owner, repo, issue_number });
             const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing)
-              await github.rest.issues.updateComment(
-                { owner, repo, comment_id: existing.id, body });
-            else
+            // GitHub fixes a comment's author at creation time; if an older
+            // comment exists under a different author (e.g. github-actions[bot]
+            // before the App was wired in), delete and recreate so the visible
+            // author becomes pq-perf-bot[bot].
+            if (existing && existing.user.login !== botLogin) {
+              await github.rest.issues.deleteComment(
+                { owner, repo, comment_id: existing.id });
               await github.rest.issues.createComment(
                 { owner, repo, issue_number, body });
+            } else if (existing) {
+              await github.rest.issues.updateComment(
+                { owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment(
+                { owner, repo, issue_number, body });
+            }
 
       - name: Fail on regression
         if: steps.gate.outcome == 'failure'

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -11,6 +11,10 @@ on:
       - dev
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   perf-regression:
     runs-on: ubuntu-24.04
@@ -62,4 +66,35 @@ jobs:
           CXX: g++-13
 
       - name: Compare instruction counts (gate)
+        id: gate
+        continue-on-error: true
         run: bash scripts/perf_gate.sh build-pr/benchmarks/perf build-base/benchmarks/perf 2
+
+      - name: Post / update performance comment
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- perf-gate-comment -->';
+            let body;
+            try { body = fs.readFileSync('perf_report.md', 'utf8'); }
+            catch (e) { core.info('no perf_report.md, skipping comment'); return; }
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } =
+              await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing)
+              await github.rest.issues.updateComment(
+                { owner, repo, comment_id: existing.id, body });
+            else
+              await github.rest.issues.createComment(
+                { owner, repo, issue_number, body });
+
+      - name: Fail on regression
+        if: steps.gate.outcome == 'failure'
+        run: |
+          echo "performance regression detected (see the comment / summary above)"
+          exit 1

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -70,11 +70,23 @@ jobs:
         continue-on-error: true
         run: bash scripts/perf_gate.sh build-pr/benchmarks/perf build-base/benchmarks/perf 2
 
+      - name: Mint PQ Perf Bot installation token
+        id: app-token
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PQ_PERF_BOT_APP_ID }}
+          private-key: ${{ secrets.PQ_PERF_BOT_PRIVATE_KEY }}
+
       - name: Post / update performance comment
         if: always() && github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@v7
         with:
+          # Comment author is pq-perf-bot[bot] when the token mint succeeds,
+          # else falls back to github-actions[bot] so the comment still posts.
+          github-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const marker = '<!-- perf-gate-comment -->';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ All notable changes to this project will be documented in this file.
 - Enabled compilation with Clang/Apple Clang (matched the `requires`-clause form
   on Vector3D compound-assignment operators and fixed a narrowing conversion in
   TriclinicBox)
+- Performance-regression gate: fixed-work benchmarks (`BUILD_WITH_PERF_BENCH`)
+  run under callgrind; CI fails if a benchmark's instruction count regresses vs
+  the base branch (deterministic, so not flaky)
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,10 @@ endif()
 
 add_subdirectory(apps)
 
+if(BUILD_WITH_PERF_BENCH)
+    add_subdirectory(benchmarks/perf)
+endif()
+
 if(BUILD_WITH_DOC)
     include(doxygen)
     add_subdirectory(docs EXCLUDE_FROM_ALL)

--- a/benchmarks/perf/CMakeLists.txt
+++ b/benchmarks/perf/CMakeLists.txt
@@ -12,6 +12,7 @@ set(perf_benchmarks
     integrator.cpp
     kinetics.cpp
     virial.cpp
+    constraints.cpp
 )
 
 include(CheckIncludeFileCXX)
@@ -33,6 +34,7 @@ foreach(perf_source ${perf_benchmarks})
         forceField
         integrator
         virial
+        constraints
         simulationBox
         potential
         physicalData

--- a/benchmarks/perf/CMakeLists.txt
+++ b/benchmarks/perf/CMakeLists.txt
@@ -6,6 +6,9 @@ set(perf_benchmarks
     coulombKernel.cpp
     nonCoulombPairs.cpp
     shiftVector.cpp
+    linearAlgebra.cpp
+    boxTransforms.cpp
+    bondedForces.cpp
 )
 
 include(CheckIncludeFileCXX)
@@ -24,8 +27,10 @@ foreach(perf_source ${perf_benchmarks})
     target_link_libraries(perf_${perf_name}
         PRIVATE
         intraNonBonded
+        forceField
         simulationBox
         potential
+        physicalData
         box
         linearAlgebra
     )

--- a/benchmarks/perf/CMakeLists.txt
+++ b/benchmarks/perf/CMakeLists.txt
@@ -3,6 +3,9 @@
 # (.github/workflows/perf.yml) auto-discovers every perf_* target.
 set(perf_benchmarks
     forceKernel.cpp
+    coulombKernel.cpp
+    nonCoulombPairs.cpp
+    shiftVector.cpp
 )
 
 include(CheckIncludeFileCXX)
@@ -23,6 +26,7 @@ foreach(perf_source ${perf_benchmarks})
         intraNonBonded
         simulationBox
         potential
+        box
         linearAlgebra
     )
 

--- a/benchmarks/perf/CMakeLists.txt
+++ b/benchmarks/perf/CMakeLists.txt
@@ -8,6 +8,7 @@ set(perf_benchmarks
 include(CheckIncludeFileCXX)
 check_include_file_cxx("valgrind/callgrind.h" HAVE_CALLGRIND_H)
 
+set(perf_targets "")
 foreach(perf_source ${perf_benchmarks})
     get_filename_component(perf_name ${perf_source} NAME_WE)
     add_executable(perf_${perf_name} ${perf_source})
@@ -29,4 +30,10 @@ foreach(perf_source ${perf_benchmarks})
     if(HAVE_CALLGRIND_H)
         target_compile_definitions(perf_${perf_name} PRIVATE PQ_WITH_CALLGRIND)
     endif()
+
+    list(APPEND perf_targets perf_${perf_name})
 endforeach()
+
+# aggregate target so CI can build every benchmark with one command
+add_custom_target(perf_benchmarks)
+add_dependencies(perf_benchmarks ${perf_targets})

--- a/benchmarks/perf/CMakeLists.txt
+++ b/benchmarks/perf/CMakeLists.txt
@@ -9,6 +9,9 @@ set(perf_benchmarks
     linearAlgebra.cpp
     boxTransforms.cpp
     bondedForces.cpp
+    integrator.cpp
+    kinetics.cpp
+    virial.cpp
 )
 
 include(CheckIncludeFileCXX)
@@ -28,6 +31,8 @@ foreach(perf_source ${perf_benchmarks})
         PRIVATE
         intraNonBonded
         forceField
+        integrator
+        virial
         simulationBox
         potential
         physicalData

--- a/benchmarks/perf/CMakeLists.txt
+++ b/benchmarks/perf/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Each performance-regression benchmark is a standalone fixed-work executable.
+# To add one: drop a <name>.cpp here and add it to the list below. The CI gate
+# (.github/workflows/perf.yml) auto-discovers every perf_* target.
+set(perf_benchmarks
+    forceKernel.cpp
+)
+
+include(CheckIncludeFileCXX)
+check_include_file_cxx("valgrind/callgrind.h" HAVE_CALLGRIND_H)
+
+foreach(perf_source ${perf_benchmarks})
+    get_filename_component(perf_name ${perf_source} NAME_WE)
+    add_executable(perf_${perf_name} ${perf_source})
+
+    target_include_directories(perf_${perf_name}
+        PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+    )
+
+    target_link_libraries(perf_${perf_name}
+        PRIVATE
+        intraNonBonded
+        simulationBox
+        potential
+        linearAlgebra
+    )
+
+    # enable the callgrind counter hook if valgrind's header is available
+    if(HAVE_CALLGRIND_H)
+        target_compile_definitions(perf_${perf_name} PRIVATE PQ_WITH_CALLGRIND)
+    endif()
+endforeach()

--- a/benchmarks/perf/benchSetup.hpp
+++ b/benchmarks/perf/benchSetup.hpp
@@ -1,0 +1,129 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+// Shared construction helpers for the performance benchmarks, so each
+// benchmark does not re-implement the molecule/box/potential setup. This code
+// runs before CALLGRIND_ZERO_STATS in every benchmark, so it is excluded from
+// the measured instruction count.
+
+#ifndef PQ_BENCH_SETUP_HPP
+#define PQ_BENCH_SETUP_HPP
+
+#include <cstddef>
+#include <memory>
+
+#include "atom.hpp"
+#include "forceFieldNonCoulomb.hpp"
+#include "lennardJonesPair.hpp"
+#include "matrix.hpp"
+#include "molecule.hpp"
+#include "simulationBox.hpp"
+#include "vector3d.hpp"
+
+namespace potential
+{
+    class NonCoulombPair;   // forward declaration
+}
+
+namespace benchSetup
+{
+    // A molecule of nAtoms on a compact lattice with mass / velocity / force /
+    // shift-force / charge / atom-type / vdW-type set. Atom types alternate
+    // 0/1 and charges +/-0.4.
+    inline simulationBox::Molecule makeMolecule(
+        const std::size_t nAtoms,
+        const double      origin = 0.0
+    )
+    {
+        auto molecule = simulationBox::Molecule();
+        molecule.setMoltype(1);
+        molecule.setNumberOfAtoms(nAtoms);
+
+        double molMass = 0.0;
+        for (std::size_t i = 0; i < nAtoms; ++i)
+        {
+            auto atom = std::make_shared<simulationBox::Atom>();
+
+            const double d = static_cast<double>(i);
+            atom->setPosition({origin + 1.0 + 0.7 * d, 0.4 * d, 0.25 * d});
+            atom->setVelocity({0.01 * (d + 1.0), -0.015, 0.02});
+            atom->setForce({0.1, -0.2, 0.05});
+            atom->setShiftForce({0.0, 0.0, 0.0});
+            atom->setMass(12.0);
+            atom->setAtomType(i % 2);
+            atom->setInternalGlobalVDWType(i % 2);
+            atom->setPartialCharge((i % 2 == 0) ? 0.4 : -0.4);
+
+            molecule.addAtom(atom);
+            molMass += 12.0;
+        }
+        molecule.setMolMass(molMass);
+
+        return molecule;
+    }
+
+    // A ForceFieldNonCoulomb with a Lennard-Jones pair for the 0/1 vdW types.
+    inline potential::ForceFieldNonCoulomb makeNonCoulomb()
+    {
+        auto nonCoulomb = potential::ForceFieldNonCoulomb();
+        nonCoulomb.setNonCoulombPairsMatrix(
+            linearAlgebra::Matrix<std::shared_ptr<potential::NonCoulombPair>>(2, 2)
+        );
+
+        auto pair =
+            potential::LennardJonesPair(std::size_t(0), std::size_t(1), 12.0, 2.0, 3.0);
+        nonCoulomb.setNonCoulombPairsMatrix(0, 1, pair);
+        nonCoulomb.setNonCoulombPairsMatrix(1, 0, pair);
+
+        return nonCoulomb;
+    }
+
+    // A SimulationBox populated with nMolecules of nAtomsPerMol. Both the flat
+    // atom list (used by integrator/kinetics) and the molecule list (used by
+    // center-of-mass/virial) are filled, and the box totals are computed.
+    inline simulationBox::SimulationBox makePopulatedBox(
+        const std::size_t nMolecules,
+        const std::size_t nAtomsPerMol
+    )
+    {
+        auto box = simulationBox::SimulationBox();
+        box.setBoxDimensions({30.0, 30.0, 30.0});
+
+        for (std::size_t m = 0; m < nMolecules; ++m)
+        {
+            auto molecule = makeMolecule(nAtomsPerMol, 3.0 * static_cast<double>(m));
+
+            for (std::size_t i = 0; i < nAtomsPerMol; ++i)
+                box.addAtom(molecule.getAtoms()[i]);   // share the atom pointers
+
+            box.addMolecule(molecule);
+        }
+
+        box.calculateTotalMass();
+        box.calculateDegreesOfFreedom();
+        box.calculateCenterOfMass();
+
+        return box;
+    }
+}   // namespace benchSetup
+
+#endif   // PQ_BENCH_SETUP_HPP

--- a/benchmarks/perf/benchSetup.hpp
+++ b/benchmarks/perf/benchSetup.hpp
@@ -63,8 +63,10 @@ namespace benchSetup
         {
             auto atom = std::make_shared<simulationBox::Atom>();
 
-            const double d = static_cast<double>(i);
-            atom->setPosition({origin + 1.0 + 0.7 * d, 0.4 * d, 0.25 * d});
+            const double               d = static_cast<double>(i);
+            const linearAlgebra::Vec3D pos{origin + 1.0 + 0.7 * d, 0.4 * d, 0.25 * d};
+            atom->setPosition(pos);
+            atom->setPositionOld(pos);   // at-rest start (stable for constraints)
             atom->setVelocity({0.01 * (d + 1.0), -0.015, 0.02});
             atom->setForce({0.1, -0.2, 0.05});
             atom->setShiftForce({0.0, 0.0, 0.0});

--- a/benchmarks/perf/bondedForces.cpp
+++ b/benchmarks/perf/bondedForces.cpp
@@ -1,0 +1,144 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+// Fixed-work micro-benchmark of the bonded force kernels (bond, angle,
+// dihedral). Setup mirrors the forceField unit tests.
+
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
+#include <memory>
+
+#ifdef PQ_WITH_CALLGRIND
+#include <valgrind/callgrind.h>
+#else
+#define CALLGRIND_ZERO_STATS
+#endif
+
+#include "angleForceField.hpp"
+#include "atom.hpp"
+#include "bondForceField.hpp"
+#include "coulombShiftedPotential.hpp"
+#include "dihedralForceField.hpp"
+#include "forceFieldNonCoulomb.hpp"
+#include "lennardJonesPair.hpp"
+#include "matrix.hpp"
+#include "molecule.hpp"
+#include "physicalData.hpp"
+#include "potentialSettings.hpp"
+#include "simulationBox.hpp"
+#include "vector3d.hpp"
+
+namespace potential
+{
+    class NonCoulombPair;   // forward declaration
+}
+
+static constexpr long ITERATIONS = 20000;
+
+int main()
+{
+    auto box = simulationBox::SimulationBox();
+    box.setBoxDimensions({10.0, 10.0, 10.0});
+
+    auto physicalData        = physicalData::PhysicalData();
+    auto coulombPotential    = potential::CoulombShiftedPotential(20.0);
+    auto nonCoulombPotential = potential::ForceFieldNonCoulomb();
+
+    auto nonCoulombPair =
+        potential::LennardJonesPair(size_t(0), size_t(1), 15.0, 2.0, 4.0);
+    nonCoulombPotential.setNonCoulombPairsMatrix(
+        linearAlgebra::Matrix<std::shared_ptr<potential::NonCoulombPair>>(2, 2)
+    );
+    nonCoulombPotential.setNonCoulombPairsMatrix(0, 1, nonCoulombPair);
+    nonCoulombPotential.setNonCoulombPairsMatrix(1, 0, nonCoulombPair);
+
+    auto molecule = simulationBox::Molecule();
+    molecule.setMoltype(0);
+    molecule.setNumberOfAtoms(4);
+
+    for (size_t i = 0; i < 4; ++i)
+    {
+        auto atom = std::make_shared<simulationBox::Atom>();
+        atom->setPosition({double(i), 0.5 * double(i), 0.3 * double(i)});
+        atom->setForce({0.0, 0.0, 0.0});
+        atom->setInternalGlobalVDWType(i % 2);
+        atom->setAtomType(i % 2);
+        atom->setPartialCharge((i % 2 == 0) ? 1.0 : -0.5);
+        molecule.addAtom(atom);
+    }
+
+    settings::PotentialSettings::setScale14Coulomb(0.75);
+    settings::PotentialSettings::setScale14VanDerWaals(0.5);
+
+    auto bond = forceField::BondForceField(&molecule, &molecule, 0, 1, 0);
+    bond.setEquilibriumBondLength(1.2);
+    bond.setForceConstant(3.0);
+
+    auto angle =
+        forceField::AngleForceField({&molecule, &molecule, &molecule}, {0, 1, 2}, 0);
+    angle.setEquilibriumAngle(M_PI / 2.0);
+    angle.setForceConstant(3.0);
+
+    auto dihedral = forceField::DihedralForceField(
+        {&molecule, &molecule, &molecule, &molecule},
+        {0, 1, 2, 3},
+        0
+    );
+    dihedral.setPhaseShift(M_PI);
+    dihedral.setPeriodicity(3);
+    dihedral.setForceConstant(3.0);
+    dihedral.setIsLinker(false);
+
+    CALLGRIND_ZERO_STATS;
+
+    for (long i = 0; i < ITERATIONS; ++i)
+    {
+        bond.calculateEnergyAndForces(
+            box,
+            physicalData,
+            coulombPotential,
+            nonCoulombPotential
+        );
+        angle.calculateEnergyAndForces(
+            box,
+            physicalData,
+            coulombPotential,
+            nonCoulombPotential
+        );
+        dihedral.calculateEnergyAndForces(
+            box,
+            physicalData,
+            false,
+            coulombPotential,
+            nonCoulombPotential
+        );
+    }
+
+    // read state so the loop cannot be optimized away
+    std::printf(
+        "%.6f\n",
+        physicalData.getBondEnergy() + physicalData.getAngleEnergy() +
+            physicalData.getDihedralEnergy() + molecule.getAtomForce(0)[0]
+    );
+    return 0;
+}

--- a/benchmarks/perf/bondedForces.cpp
+++ b/benchmarks/perf/bondedForces.cpp
@@ -21,12 +21,10 @@
 ******************************************************************************/
 
 // Fixed-work micro-benchmark of the bonded force kernels (bond, angle,
-// dihedral). Setup mirrors the forceField unit tests.
+// dihedral).
 
 #include <cmath>
-#include <cstddef>
 #include <cstdio>
-#include <memory>
 
 #ifdef PQ_WITH_CALLGRIND
 #include <valgrind/callgrind.h>
@@ -35,23 +33,13 @@
 #endif
 
 #include "angleForceField.hpp"
-#include "atom.hpp"
+#include "benchSetup.hpp"
 #include "bondForceField.hpp"
 #include "coulombShiftedPotential.hpp"
 #include "dihedralForceField.hpp"
-#include "forceFieldNonCoulomb.hpp"
-#include "lennardJonesPair.hpp"
-#include "matrix.hpp"
-#include "molecule.hpp"
 #include "physicalData.hpp"
 #include "potentialSettings.hpp"
 #include "simulationBox.hpp"
-#include "vector3d.hpp"
-
-namespace potential
-{
-    class NonCoulombPair;   // forward declaration
-}
 
 static constexpr long ITERATIONS = 20000;
 
@@ -62,30 +50,9 @@ int main()
 
     auto physicalData        = physicalData::PhysicalData();
     auto coulombPotential    = potential::CoulombShiftedPotential(20.0);
-    auto nonCoulombPotential = potential::ForceFieldNonCoulomb();
+    auto nonCoulombPotential = benchSetup::makeNonCoulomb();
 
-    auto nonCoulombPair =
-        potential::LennardJonesPair(size_t(0), size_t(1), 15.0, 2.0, 4.0);
-    nonCoulombPotential.setNonCoulombPairsMatrix(
-        linearAlgebra::Matrix<std::shared_ptr<potential::NonCoulombPair>>(2, 2)
-    );
-    nonCoulombPotential.setNonCoulombPairsMatrix(0, 1, nonCoulombPair);
-    nonCoulombPotential.setNonCoulombPairsMatrix(1, 0, nonCoulombPair);
-
-    auto molecule = simulationBox::Molecule();
-    molecule.setMoltype(0);
-    molecule.setNumberOfAtoms(4);
-
-    for (size_t i = 0; i < 4; ++i)
-    {
-        auto atom = std::make_shared<simulationBox::Atom>();
-        atom->setPosition({double(i), 0.5 * double(i), 0.3 * double(i)});
-        atom->setForce({0.0, 0.0, 0.0});
-        atom->setInternalGlobalVDWType(i % 2);
-        atom->setAtomType(i % 2);
-        atom->setPartialCharge((i % 2 == 0) ? 1.0 : -0.5);
-        molecule.addAtom(atom);
-    }
+    auto molecule = benchSetup::makeMolecule(4);
 
     settings::PotentialSettings::setScale14Coulomb(0.75);
     settings::PotentialSettings::setScale14VanDerWaals(0.5);
@@ -94,8 +61,11 @@ int main()
     bond.setEquilibriumBondLength(1.2);
     bond.setForceConstant(3.0);
 
-    auto angle =
-        forceField::AngleForceField({&molecule, &molecule, &molecule}, {0, 1, 2}, 0);
+    auto angle = forceField::AngleForceField(
+        {&molecule, &molecule, &molecule},
+        {0, 1, 2},
+        0
+    );
     angle.setEquilibriumAngle(M_PI / 2.0);
     angle.setForceConstant(3.0);
 

--- a/benchmarks/perf/boxTransforms.cpp
+++ b/benchmarks/perf/boxTransforms.cpp
@@ -1,0 +1,67 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+// Fixed-work micro-benchmark of the box coordinate transforms: wrapping into
+// the box, and triclinic <-> orthogonal space conversions.
+
+#include <cstdio>
+
+#ifdef PQ_WITH_CALLGRIND
+#include <valgrind/callgrind.h>
+#else
+#define CALLGRIND_ZERO_STATS
+#endif
+
+#include "orthorhombicBox.hpp"
+#include "triclinicBox.hpp"
+#include "vector3d.hpp"
+
+static constexpr long ITERATIONS = 20000;
+
+int main()
+{
+    using linearAlgebra::Vec3D;
+
+    auto ortho = simulationBox::OrthorhombicBox();
+    ortho.setBoxDimensions({20.0, 20.0, 20.0});
+
+    auto triclinic = simulationBox::TriclinicBox();
+    triclinic.setBoxDimensions({20.0, 20.0, 20.0});
+    triclinic.setBoxAngles({80.0, 90.0, 100.0});
+
+    CALLGRIND_ZERO_STATS;
+
+    double sink = 0.0;
+    for (long i = 0; i < ITERATIONS; ++i)
+    {
+        const double x = (i & 127) * 0.3 - 19.0;
+        const Vec3D  v(x, 0.5 * x, -x);
+
+        sink += norm(ortho.wrapPositionIntoBox(v));
+        sink += norm(triclinic.wrapPositionIntoBox(v));
+        sink += norm(triclinic.toOrthoSpace(v));
+        sink += norm(triclinic.toSimSpace(v));
+    }
+
+    std::printf("%.6f\n", sink);
+    return 0;
+}

--- a/benchmarks/perf/constraints.cpp
+++ b/benchmarks/perf/constraints.cpp
@@ -20,9 +20,11 @@
 <GPL_HEADER>
 ******************************************************************************/
 
-// Fixed-work micro-benchmark of the per-step kinetic diagnostics
-// (temperature, momentum, angular momentum, total force).
+// Fixed-work micro-benchmark of the SHAKE/RATTLE constraint solver. One bond
+// constraint per molecule, started at rest (positionOld == position) so the
+// solver is stable across iterations.
 
+#include <cstddef>
 #include <cstdio>
 
 #ifdef PQ_WITH_CALLGRIND
@@ -32,25 +34,45 @@
 #endif
 
 #include "benchSetup.hpp"
+#include "bondConstraint.hpp"
+#include "constraints.hpp"
+#include "molecule.hpp"
+#include "simulationBox.hpp"
+#include "timingsSettings.hpp"
 #include "vector3d.hpp"
 
 static constexpr long ITERATIONS = 1000;
 
 int main()
 {
-    auto box = benchSetup::makePopulatedBox(20, 3);
+    settings::TimingsSettings::setTimeStep(0.001);
+
+    auto  box       = benchSetup::makePopulatedBox(20, 3);
+    auto &molecules = box.getMolecules();
+
+    auto constr = constraints::Constraints();
+    constr.setShakeMaxIter(100);
+    constr.setRattleMaxIter(100);
+    constr.setShakeTolerance(1.0e-8);
+    constr.setRattleTolerance(1.0e-8);
+    constr.activateShake();
+
+    for (std::size_t m = 0; m < molecules.size(); ++m)
+        constr.addBondConstraint(
+            constraints::BondConstraint(&molecules[m], &molecules[m], 0, 1, 0.85)
+        );
+
+    constr.calculateConstraintBondRefs(box);
 
     CALLGRIND_ZERO_STATS;
 
-    double sink = 0.0;
     for (long i = 0; i < ITERATIONS; ++i)
     {
-        sink += box.calculateTemperature();
-        sink += box.calculateMomentum()[0];
-        sink += box.calculateAngularMomentum({0.0, 0.0, 0.0})[0];
-        sink += box.calculateTotalForce();
+        constr.applyShake(box);
+        constr.applyRattle(box);
     }
 
-    std::printf("%.6f\n", sink);
+    // read state so the loop cannot be optimized away
+    std::printf("%.6f\n", box.calculateMomentum()[0]);
     return 0;
 }

--- a/benchmarks/perf/coulombKernel.cpp
+++ b/benchmarks/perf/coulombKernel.cpp
@@ -1,0 +1,59 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+// Fixed-work micro-benchmark of the Coulomb pair kernels (shifted + Wolf).
+
+#include <cstdio>
+
+#ifdef PQ_WITH_CALLGRIND
+#include <valgrind/callgrind.h>
+#else
+#define CALLGRIND_ZERO_STATS
+#endif
+
+#include "coulombShiftedPotential.hpp"
+#include "coulombWolf.hpp"
+
+static constexpr long ITERATIONS = 20000;
+
+int main()
+{
+    auto shifted = potential::CoulombShiftedPotential(9.0);
+    auto wolf    = potential::CoulombWolf(9.0, 0.25);
+
+    CALLGRIND_ZERO_STATS;
+
+    double sink = 0.0;
+    for (long i = 0; i < ITERATIONS; ++i)
+    {
+        const double distance      = 1.0 + (i & 255) * 0.03;   // within cutoff
+        const double chargeProduct = 0.5 * -0.5;
+
+        const auto [eShift, fShift] = shifted.calculate(distance, chargeProduct);
+        const auto [eWolf, fWolf]   = wolf.calculate(distance, chargeProduct);
+
+        sink += eShift + fShift + eWolf + fWolf;
+    }
+
+    std::printf("%.6f\n", sink);
+    return 0;
+}

--- a/benchmarks/perf/forceKernel.cpp
+++ b/benchmarks/perf/forceKernel.cpp
@@ -20,72 +20,34 @@
 <GPL_HEADER>
 ******************************************************************************/
 
-// Fixed-work micro-benchmark of the non-bonded per-pair force kernel.
-//
-// It does a deterministic, fixed number of iterations of the inner-loop work
+// Fixed-work micro-benchmark of the non-bonded per-pair force kernel
 // (Coulomb + non-Coulomb pair evaluation, the per-pair getNonCoulPair lookup
-// and force accumulation), so that running it under callgrind yields a stable
-// instruction count usable as a CI performance-regression gate.
-//
-// The setup mirrors tests/src/intraNonBonded/testIntraNonBondedMap.cpp.
+// and force accumulation), so callgrind yields a stable instruction count.
 
 #include <cstddef>
 #include <cstdio>
-#include <memory>
 
-// callgrind hook: zero the instruction counter after one-time setup so the
-// reported count reflects only the measured loop. The macro is a no-op outside
-// valgrind, and compiles to nothing when the header is unavailable.
 #ifdef PQ_WITH_CALLGRIND
 #include <valgrind/callgrind.h>
 #else
 #define CALLGRIND_ZERO_STATS
 #endif
 
-#include "atom.hpp"
+#include "benchSetup.hpp"
 #include "coulombShiftedPotential.hpp"
-#include "forceFieldNonCoulomb.hpp"
 #include "intraNonBondedContainer.hpp"
 #include "intraNonBondedMap.hpp"
-#include "lennardJonesPair.hpp"
-#include "matrix.hpp"
-#include "molecule.hpp"
 #include "physicalData.hpp"
 #include "potentialSettings.hpp"
 #include "simulationBox.hpp"
-#include "vector3d.hpp"
 
-namespace potential
-{
-    class NonCoulombPair;   // forward declaration
-}
-
-// number of kernel evaluations; fixed so the instruction count is comparable
-// across builds. Small is fine: callgrind counts are deterministic and we zero
-// the counter after setup, so the signal is pure loop work.
 static constexpr long ITERATIONS = 20000;
 
 int main()
 {
-    auto molecule = simulationBox::Molecule(0);
-    molecule.setNumberOfAtoms(2);
-
-    auto atom1 = std::make_shared<simulationBox::Atom>();
-    auto atom2 = std::make_shared<simulationBox::Atom>();
-
-    atom1->setPosition({0.0, 0.0, 0.0});
-    atom2->setPosition({0.0, 0.0, 11.0});
-    atom1->setForce({0.0, 0.0, 0.0});
-    atom2->setForce({0.0, 0.0, 0.0});
-    atom1->setInternalGlobalVDWType(0);
-    atom2->setInternalGlobalVDWType(1);
-    atom1->setAtomType(0);
-    atom2->setAtomType(1);
-    atom1->setPartialCharge(0.5);
-    atom2->setPartialCharge(-0.5);
-
-    molecule.addAtom(atom1);
-    molecule.addAtom(atom2);
+    auto molecule            = benchSetup::makeMolecule(2);
+    auto nonCoulombPotential = benchSetup::makeNonCoulomb();
+    auto coulombPotential    = potential::CoulombShiftedPotential(10.0);
 
     settings::PotentialSettings::setScale14Coulomb(0.75);
     settings::PotentialSettings::setScale14VanDerWaals(0.75);
@@ -95,17 +57,6 @@ int main()
     auto intraNonBondedMap =
         intraNonBonded::IntraNonBondedMap(&molecule, &intraNonBondedType);
 
-    auto coulombPotential    = potential::CoulombShiftedPotential(10.0);
-    auto nonCoulombPotential = potential::ForceFieldNonCoulomb();
-    nonCoulombPotential.setNonCoulombPairsMatrix(
-        linearAlgebra::Matrix<std::shared_ptr<potential::NonCoulombPair>>(2, 2)
-    );
-
-    auto nonCoulombPair =
-        potential::LennardJonesPair(size_t(0), size_t(1), 10.0, 2.0, 3.0);
-    nonCoulombPotential.setNonCoulombPairsMatrix(0, 1, nonCoulombPair);
-    nonCoulombPotential.setNonCoulombPairsMatrix(1, 0, nonCoulombPair);
-
     auto simulationBox = simulationBox::SimulationBox();
     simulationBox.setBoxDimensions({10.0, 10.0, 10.0});
 
@@ -114,7 +65,6 @@ int main()
     const auto box     = simulationBox.getBoxDimensions();
     const auto atomIdx = intraNonBondedType.getAtomIndices()[0][0];
 
-    // exclude the one-time setup above from the measured instruction count
     CALLGRIND_ZERO_STATS;
 
     double sink = 0.0;
@@ -133,7 +83,6 @@ int main()
         sink += coulombEnergy + nonCoulombEnergy;
     }
 
-    // print so the loop cannot be optimized away
     std::printf("%.6f\n", sink);
     return 0;
 }

--- a/benchmarks/perf/forceKernel.cpp
+++ b/benchmarks/perf/forceKernel.cpp
@@ -1,0 +1,139 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+// Fixed-work micro-benchmark of the non-bonded per-pair force kernel.
+//
+// It does a deterministic, fixed number of iterations of the inner-loop work
+// (Coulomb + non-Coulomb pair evaluation, the per-pair getNonCoulPair lookup
+// and force accumulation), so that running it under callgrind yields a stable
+// instruction count usable as a CI performance-regression gate.
+//
+// The setup mirrors tests/src/intraNonBonded/testIntraNonBondedMap.cpp.
+
+#include <cstddef>
+#include <cstdio>
+#include <memory>
+
+// callgrind hook: zero the instruction counter after one-time setup so the
+// reported count reflects only the measured loop. The macro is a no-op outside
+// valgrind, and compiles to nothing when the header is unavailable.
+#ifdef PQ_WITH_CALLGRIND
+#include <valgrind/callgrind.h>
+#else
+#define CALLGRIND_ZERO_STATS
+#endif
+
+#include "atom.hpp"
+#include "coulombShiftedPotential.hpp"
+#include "forceFieldNonCoulomb.hpp"
+#include "intraNonBondedContainer.hpp"
+#include "intraNonBondedMap.hpp"
+#include "lennardJonesPair.hpp"
+#include "matrix.hpp"
+#include "molecule.hpp"
+#include "physicalData.hpp"
+#include "potentialSettings.hpp"
+#include "simulationBox.hpp"
+#include "vector3d.hpp"
+
+namespace potential
+{
+    class NonCoulombPair;   // forward declaration
+}
+
+// number of kernel evaluations; fixed so the instruction count is comparable
+// across builds. Small is fine: callgrind counts are deterministic and we zero
+// the counter after setup, so the signal is pure loop work.
+static constexpr long ITERATIONS = 20000;
+
+int main()
+{
+    auto molecule = simulationBox::Molecule(0);
+    molecule.setNumberOfAtoms(2);
+
+    auto atom1 = std::make_shared<simulationBox::Atom>();
+    auto atom2 = std::make_shared<simulationBox::Atom>();
+
+    atom1->setPosition({0.0, 0.0, 0.0});
+    atom2->setPosition({0.0, 0.0, 11.0});
+    atom1->setForce({0.0, 0.0, 0.0});
+    atom2->setForce({0.0, 0.0, 0.0});
+    atom1->setInternalGlobalVDWType(0);
+    atom2->setInternalGlobalVDWType(1);
+    atom1->setAtomType(0);
+    atom2->setAtomType(1);
+    atom1->setPartialCharge(0.5);
+    atom2->setPartialCharge(-0.5);
+
+    molecule.addAtom(atom1);
+    molecule.addAtom(atom2);
+
+    settings::PotentialSettings::setScale14Coulomb(0.75);
+    settings::PotentialSettings::setScale14VanDerWaals(0.75);
+
+    auto intraNonBondedType =
+        intraNonBonded::IntraNonBondedContainer(0, {{-1}});
+    auto intraNonBondedMap =
+        intraNonBonded::IntraNonBondedMap(&molecule, &intraNonBondedType);
+
+    auto coulombPotential    = potential::CoulombShiftedPotential(10.0);
+    auto nonCoulombPotential = potential::ForceFieldNonCoulomb();
+    nonCoulombPotential.setNonCoulombPairsMatrix(
+        linearAlgebra::Matrix<std::shared_ptr<potential::NonCoulombPair>>(2, 2)
+    );
+
+    auto nonCoulombPair =
+        potential::LennardJonesPair(size_t(0), size_t(1), 10.0, 2.0, 3.0);
+    nonCoulombPotential.setNonCoulombPairsMatrix(0, 1, nonCoulombPair);
+    nonCoulombPotential.setNonCoulombPairsMatrix(1, 0, nonCoulombPair);
+
+    auto simulationBox = simulationBox::SimulationBox();
+    simulationBox.setBoxDimensions({10.0, 10.0, 10.0});
+
+    auto physicalData = physicalData::PhysicalData();
+
+    const auto box     = simulationBox.getBoxDimensions();
+    const auto atomIdx = intraNonBondedType.getAtomIndices()[0][0];
+
+    // exclude the one-time setup above from the measured instruction count
+    CALLGRIND_ZERO_STATS;
+
+    double sink = 0.0;
+    for (long i = 0; i < ITERATIONS; ++i)
+    {
+        const auto [coulombEnergy, nonCoulombEnergy] =
+            intraNonBondedMap.calculateSingleInteraction(
+                0,
+                atomIdx,
+                box,
+                physicalData,
+                &coulombPotential,
+                &nonCoulombPotential
+            );
+
+        sink += coulombEnergy + nonCoulombEnergy;
+    }
+
+    // print so the loop cannot be optimized away
+    std::printf("%.6f\n", sink);
+    return 0;
+}

--- a/benchmarks/perf/integrator.cpp
+++ b/benchmarks/perf/integrator.cpp
@@ -34,7 +34,7 @@
 #include "timingsSettings.hpp"
 #include "velocityVerlet.hpp"
 
-static constexpr long ITERATIONS = 20000;
+static constexpr long ITERATIONS = 1000;
 
 int main()
 {

--- a/benchmarks/perf/integrator.cpp
+++ b/benchmarks/perf/integrator.cpp
@@ -1,0 +1,57 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+// Fixed-work micro-benchmark of the velocity-Verlet integrator step.
+
+#include <cstdio>
+
+#ifdef PQ_WITH_CALLGRIND
+#include <valgrind/callgrind.h>
+#else
+#define CALLGRIND_ZERO_STATS
+#endif
+
+#include "benchSetup.hpp"
+#include "timingsSettings.hpp"
+#include "velocityVerlet.hpp"
+
+static constexpr long ITERATIONS = 20000;
+
+int main()
+{
+    settings::TimingsSettings::setTimeStep(0.001);
+
+    auto box        = benchSetup::makePopulatedBox(20, 3);
+    auto integrator = integrator::VelocityVerlet();
+
+    CALLGRIND_ZERO_STATS;
+
+    for (long i = 0; i < ITERATIONS; ++i)
+    {
+        integrator.firstStep(box);
+        integrator.secondStep(box);
+    }
+
+    // read state so the loop cannot be optimized away
+    std::printf("%.6f\n", box.calculateMomentum()[0]);
+    return 0;
+}

--- a/benchmarks/perf/kinetics.cpp
+++ b/benchmarks/perf/kinetics.cpp
@@ -1,0 +1,56 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+// Fixed-work micro-benchmark of the per-step kinetic diagnostics
+// (temperature, momentum, angular momentum, total force).
+
+#include <cstdio>
+
+#ifdef PQ_WITH_CALLGRIND
+#include <valgrind/callgrind.h>
+#else
+#define CALLGRIND_ZERO_STATS
+#endif
+
+#include "benchSetup.hpp"
+#include "vector3d.hpp"
+
+static constexpr long ITERATIONS = 20000;
+
+int main()
+{
+    auto box = benchSetup::makePopulatedBox(20, 3);
+
+    CALLGRIND_ZERO_STATS;
+
+    double sink = 0.0;
+    for (long i = 0; i < ITERATIONS; ++i)
+    {
+        sink += box.calculateTemperature();
+        sink += box.calculateMomentum()[0];
+        sink += box.calculateAngularMomentum({0.0, 0.0, 0.0})[0];
+        sink += box.calculateTotalForce();
+    }
+
+    std::printf("%.6f\n", sink);
+    return 0;
+}

--- a/benchmarks/perf/linearAlgebra.cpp
+++ b/benchmarks/perf/linearAlgebra.cpp
@@ -1,0 +1,72 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+// Fixed-work micro-benchmark of the linear-algebra primitives (Vec3D and the
+// 3x3 tensor) that underlie every force/energy kernel.
+
+#include <cstdio>
+
+#ifdef PQ_WITH_CALLGRIND
+#include <valgrind/callgrind.h>
+#else
+#define CALLGRIND_ZERO_STATS
+#endif
+
+#include "staticMatrix.hpp"
+#include "vector3d.hpp"
+
+static constexpr long ITERATIONS = 20000;
+
+int main()
+{
+    using namespace linearAlgebra;
+
+    const Vec3D v1{1.1, 2.2, 3.3};
+    const Vec3D v2{0.7, -1.3, 2.1};
+
+    // non-singular so inverse() is well defined
+    const StaticMatrix3x3<double> matrix{
+        Vec3D{2.0, 0.1, 0.2},
+        Vec3D{0.3, 3.0, 0.1},
+        Vec3D{0.2, 0.1, 4.0}
+    };
+
+    CALLGRIND_ZERO_STATS;
+
+    double sink = 0.0;
+    for (long i = 0; i < ITERATIONS; ++i)
+    {
+        const double scale = 1.0 + (i & 255) * 0.01;
+        const Vec3D  a     = v1 * scale;
+        const Vec3D  b     = v2 - a;
+
+        sink += norm(a + b) + normSquared(a) + dot(a, b) + norm(cross(a, b));
+
+        const Vec3D matrixVec = matrix * b;
+        const auto  matrixSq  = matrix * transpose(matrix);
+
+        sink += norm(matrixVec) + det(matrixSq) + det(inverse(matrix));
+    }
+
+    std::printf("%.6f\n", sink);
+    return 0;
+}

--- a/benchmarks/perf/nonCoulombPairs.cpp
+++ b/benchmarks/perf/nonCoulombPairs.cpp
@@ -1,0 +1,62 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+// Fixed-work micro-benchmark of the non-Coulomb pair kernels
+// (Lennard-Jones, Buckingham, Morse).
+
+#include <cstdio>
+
+#ifdef PQ_WITH_CALLGRIND
+#include <valgrind/callgrind.h>
+#else
+#define CALLGRIND_ZERO_STATS
+#endif
+
+#include "buckinghamPair.hpp"
+#include "lennardJonesPair.hpp"
+#include "morsePair.hpp"
+
+static constexpr long ITERATIONS = 20000;
+
+int main()
+{
+    auto lj    = potential::LennardJonesPair(9.0, 2.0, 3.0);
+    auto buck  = potential::BuckinghamPair(9.0, 1.0, 0.3, 2.0);
+    auto morse = potential::MorsePair(9.0, 1.0, 2.0, 1.5);
+
+    CALLGRIND_ZERO_STATS;
+
+    double sink = 0.0;
+    for (long i = 0; i < ITERATIONS; ++i)
+    {
+        const double distance = 1.0 + (i & 255) * 0.03;   // within cutoff
+
+        const auto [eLj, fLj]       = lj.calculate(distance);
+        const auto [eBuck, fBuck]   = buck.calculate(distance);
+        const auto [eMorse, fMorse] = morse.calculate(distance);
+
+        sink += eLj + fLj + eBuck + fBuck + eMorse + fMorse;
+    }
+
+    std::printf("%.6f\n", sink);
+    return 0;
+}

--- a/benchmarks/perf/shiftVector.cpp
+++ b/benchmarks/perf/shiftVector.cpp
@@ -1,0 +1,63 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+// Fixed-work micro-benchmark of the periodic minimal-image shift-vector
+// computation for orthorhombic and triclinic boxes (called per atom pair).
+
+#include <cstdio>
+
+#ifdef PQ_WITH_CALLGRIND
+#include <valgrind/callgrind.h>
+#else
+#define CALLGRIND_ZERO_STATS
+#endif
+
+#include "orthorhombicBox.hpp"
+#include "triclinicBox.hpp"
+#include "vector3d.hpp"
+
+static constexpr long ITERATIONS = 20000;
+
+int main()
+{
+    auto ortho = simulationBox::OrthorhombicBox();
+    ortho.setBoxDimensions({20.0, 20.0, 20.0});
+
+    auto triclinic = simulationBox::TriclinicBox();
+    triclinic.setBoxDimensions({20.0, 20.0, 20.0});
+    triclinic.setBoxAngles({80.0, 90.0, 100.0});
+
+    CALLGRIND_ZERO_STATS;
+
+    double sink = 0.0;
+    for (long i = 0; i < ITERATIONS; ++i)
+    {
+        const double x = (i & 127) * 0.3 - 19.0;
+        const linearAlgebra::Vec3D v(x, 0.5 * x, -x);
+
+        sink += norm(ortho.calcShiftVector(v));
+        sink += norm(triclinic.calcShiftVector(v));
+    }
+
+    std::printf("%.6f\n", sink);
+    return 0;
+}

--- a/benchmarks/perf/virial.cpp
+++ b/benchmarks/perf/virial.cpp
@@ -1,0 +1,53 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+// Fixed-work micro-benchmark of the molecular virial computation.
+
+#include <cstdio>
+
+#ifdef PQ_WITH_CALLGRIND
+#include <valgrind/callgrind.h>
+#else
+#define CALLGRIND_ZERO_STATS
+#endif
+
+#include "benchSetup.hpp"
+#include "molecularVirial.hpp"
+#include "physicalData.hpp"
+
+static constexpr long ITERATIONS = 20000;
+
+int main()
+{
+    auto box          = benchSetup::makePopulatedBox(20, 3);
+    auto physicalData = physicalData::PhysicalData();
+    auto virial       = virial::MolecularVirial();
+
+    CALLGRIND_ZERO_STATS;
+
+    for (long i = 0; i < ITERATIONS; ++i)
+        virial.calculateVirial(box, physicalData);
+
+    const auto result = virial.getVirial();
+    std::printf("%.6f\n", result[0][0] + result[1][1] + result[2][2]);
+    return 0;
+}

--- a/benchmarks/perf/virial.cpp
+++ b/benchmarks/perf/virial.cpp
@@ -34,7 +34,7 @@
 #include "molecularVirial.hpp"
 #include "physicalData.hpp"
 
-static constexpr long ITERATIONS = 20000;
+static constexpr long ITERATIONS = 1000;
 
 int main()
 {

--- a/scripts/perf_gate.sh
+++ b/scripts/perf_gate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Performance-regression gate.
+#
+# Runs every perf_* benchmark in two build directories (the PR build and the
+# base-branch build) under callgrind and compares their instruction counts.
+# Exits non-zero if any benchmark regressed by more than the threshold.
+#
+# Instruction counts are deterministic (independent of CI runner load), so this
+# is not flaky like wall-clock timing. Each benchmark zeroes the counter after
+# setup (CALLGRIND_ZERO_STATS), so the count is pure loop work.
+#
+# Usage: perf_gate.sh <pr_bench_dir> <base_bench_dir> [threshold_percent]
+#
+set -uo pipefail
+
+PR_DIR="${1:?usage: perf_gate.sh <pr_bench_dir> <base_bench_dir> [threshold%]}"
+BASE_DIR="${2:?usage: perf_gate.sh <pr_bench_dir> <base_bench_dir> [threshold%]}"
+THRESHOLD="${3:-2}"
+
+# run a binary under callgrind and echo its instruction count (Ir)
+measure() {
+    local log
+    log="$(mktemp)"
+    valgrind --tool=callgrind --callgrind-out-file="$(mktemp)" "$1" \
+        >/dev/null 2>"$log"
+    grep -oE 'I +refs: +[0-9,]+' "$log" | grep -oE '[0-9,]+' | tr -d ,
+    rm -f "$log"
+}
+
+status=0
+found=0
+shopt -s nullglob
+
+for pr_bin in "$PR_DIR"/perf_*; do
+    [ -x "$pr_bin" ] || continue
+    found=1
+    name="$(basename "$pr_bin")"
+    base_bin="$BASE_DIR/$name"
+
+    pr_ir="$(measure "$pr_bin")"
+
+    if [ ! -x "$base_bin" ]; then
+        echo "$name: no baseline on base branch (new benchmark) - pr Ir=$pr_ir"
+        continue
+    fi
+
+    base_ir="$(measure "$base_bin")"
+    pct="$(awk -v p="$pr_ir" -v b="$base_ir" \
+        'BEGIN{ if (b==0) print "nan"; else printf "%.2f", (p-b)/b*100 }')"
+    regressed="$(awk -v p="$pr_ir" -v b="$base_ir" -v t="$THRESHOLD" \
+        'BEGIN{ print (b>0 && p > b*(1+t/100)) ? 1 : 0 }')"
+
+    if [ "$regressed" = "1" ]; then
+        echo "::error::$name regressed ${pct}% (Ir base=$base_ir pr=$pr_ir, threshold ${THRESHOLD}%)"
+        status=1
+    else
+        echo "$name: ${pct}% (Ir base=$base_ir pr=$pr_ir, threshold ${THRESHOLD}%)"
+    fi
+done
+
+if [ "$found" = "0" ]; then
+    echo "no perf_* benchmarks found in $PR_DIR"
+fi
+
+exit $status

--- a/scripts/perf_gate.sh
+++ b/scripts/perf_gate.sh
@@ -4,11 +4,14 @@
 #
 # Runs every perf_* benchmark in two build directories (the PR build and the
 # base-branch build) under callgrind and compares their instruction counts.
-# Exits non-zero if any benchmark regressed by more than the threshold.
-#
 # Instruction counts are deterministic (independent of CI runner load), so this
 # is not flaky like wall-clock timing. Each benchmark zeroes the counter after
 # setup (CALLGRIND_ZERO_STATS), so the count is pure loop work.
+#
+# Writes a markdown report (headline + collapsible per-benchmark table) to
+# $PERF_REPORT_FILE (default perf_report.md) and, if set, appends it to
+# $GITHUB_STEP_SUMMARY. Exits non-zero if any benchmark regressed past the
+# threshold.
 #
 # Usage: perf_gate.sh <pr_bench_dir> <base_bench_dir> [threshold_percent]
 #
@@ -17,6 +20,7 @@ set -uo pipefail
 PR_DIR="${1:?usage: perf_gate.sh <pr_bench_dir> <base_bench_dir> [threshold%]}"
 BASE_DIR="${2:?usage: perf_gate.sh <pr_bench_dir> <base_bench_dir> [threshold%]}"
 THRESHOLD="${3:-2}"
+REPORT="${PERF_REPORT_FILE:-perf_report.md}"
 
 # run a binary under callgrind and echo its instruction count (Ir)
 measure() {
@@ -28,39 +32,75 @@ measure() {
     rm -f "$log"
 }
 
+fmt() {   # raw instruction count -> "x.xxM"
+    awk -v n="$1" 'BEGIN{ printf "%.2fM", n/1e6 }'
+}
+
 status=0
-found=0
+rows=""
+regressed=""
+improved=""
 shopt -s nullglob
 
 for pr_bin in "$PR_DIR"/perf_*; do
     [ -x "$pr_bin" ] || continue
-    found=1
-    name="$(basename "$pr_bin")"
-    base_bin="$BASE_DIR/$name"
+    name="$(basename "$pr_bin" | sed 's/^perf_//')"
+    base_bin="$BASE_DIR/$(basename "$pr_bin")"
 
     pr_ir="$(measure "$pr_bin")"
 
     if [ ! -x "$base_bin" ]; then
-        echo "$name: no baseline on base branch (new benchmark) - pr Ir=$pr_ir"
+        echo "$name: new benchmark (no baseline) - pr Ir=$pr_ir"
+        rows+="| \`$name\` | – | $(fmt "$pr_ir") | new | ➕ |"$'\n'
         continue
     fi
 
     base_ir="$(measure "$base_bin")"
     pct="$(awk -v p="$pr_ir" -v b="$base_ir" \
-        'BEGIN{ if (b==0) print "nan"; else printf "%.2f", (p-b)/b*100 }')"
-    regressed="$(awk -v p="$pr_ir" -v b="$base_ir" -v t="$THRESHOLD" \
-        'BEGIN{ print (b>0 && p > b*(1+t/100)) ? 1 : 0 }')"
+        'BEGIN{ if (b==0) print "0.00"; else printf "%+.2f", (p-b)/b*100 }')"
+    verdict="$(awk -v p="$pr_ir" -v b="$base_ir" -v t="$THRESHOLD" \
+        'BEGIN{ if (b>0 && p>b*(1+t/100)) print "regress";
+                else if (b>0 && p<b*(1-t/100)) print "improve";
+                else print "ok" }')"
 
-    if [ "$regressed" = "1" ]; then
-        echo "::error::$name regressed ${pct}% (Ir base=$base_ir pr=$pr_ir, threshold ${THRESHOLD}%)"
-        status=1
-    else
-        echo "$name: ${pct}% (Ir base=$base_ir pr=$pr_ir, threshold ${THRESHOLD}%)"
-    fi
+    case "$verdict" in
+        regress) emoji="❌"; status=1; regressed+="\`$name\` ${pct}% "
+                 echo "::error::$name regressed ${pct}% (Ir base=$base_ir pr=$pr_ir, threshold ${THRESHOLD}%)" ;;
+        improve) emoji="🎉"; improved+="\`$name\` ${pct}% "
+                 echo "$name: ${pct}% (improved)" ;;
+        *)       emoji="✅"; echo "$name: ${pct}%" ;;
+    esac
+    rows+="| \`$name\` | $(fmt "$base_ir") | $(fmt "$pr_ir") | ${pct}% | $emoji |"$'\n'
 done
 
-if [ "$found" = "0" ]; then
-    echo "no perf_* benchmarks found in $PR_DIR"
+# ---- markdown report (headline + collapsible table + footer) ----
+if [ -n "$regressed" ]; then
+    headline="❌ regression: $regressed"
+    details_open=" open"
+elif [ -n "$improved" ]; then
+    headline="🎉 improvement: $improved"
+    details_open=""
+else
+    headline="✅ no regressions"
+    details_open=""
+fi
+
+{
+    echo "<!-- perf-gate-comment -->"
+    echo "### ⚡ Performance (instruction count) — $headline"
+    echo ""
+    echo "<details${details_open}><summary>per-benchmark breakdown</summary>"
+    echo ""
+    echo "| benchmark | base Ir | PR Ir | Δ | |"
+    echo "|---|---|---|---|---|"
+    printf '%s' "$rows"
+    echo "</details>"
+    echo ""
+    echo "<sub><em>Deterministic callgrind instruction counts vs the base branch; gated at ±${THRESHOLD}%. Not wall-clock.</em></sub>"
+} > "$REPORT"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    cat "$REPORT" >> "$GITHUB_STEP_SUMMARY"
 fi
 
 exit $status


### PR DESCRIPTION
Add a deterministic performance-regression gate. A new `Performance Gate` workflow builds fixed-work micro-benchmarks for the PR and for the base branch, runs each under callgrind, and fails if any instruction count regresses past the threshold. Callgrind counts are deterministic, so not flaky.

Results post as a **sticky PR comment** authored by the `pq-perf-bot` GitHub App (with the PQ avatar) and as a workflow step summary; updated in place on each push.

## Adds
- `.cmake/benchmarking.cmake` + opt-in `BUILD_WITH_PERF_BENCH` (default **OFF**) registering a `perf_benchmarks` target via Google Benchmark.
- 11 fixed-work micro-benchmarks under `benchmarks/perf/` sharing one `benchSetup.hpp`. Covers the hot path in `PERFORMANCE_REPORT.md`: per-pair non-bonded loop (`forceKernel`, `coulombKernel`, `nonCoulombPairs`, `shiftVector`), other numerics (`bondedForces`, `linearAlgebra`, `boxTransforms`), per-step bookkeeping (`integrator`, `kinetics`, `virial`), and `constraints` (SHAKE/RATTLE on a small water box, bounded iterations).
- `.github/workflows/perf.yml`: builds PR + base with `-DBUILD_WITH_NATIVE=Off -DBUILD_WITH_PERF_BENCH=On -DBUILD_WITH_ASE=Off -DBUILD_WITH_TESTS=Off -DBUILD_WITH_DOCS=Off`, callgrind on each benchmark, installation token minted for `pq-perf-bot`.

## First run
No prior baseline → the "no baseline" path reports `n/a` and exits success. From the second run, the threshold is enforced.

## Why now
The workflow builds with `-DBUILD_WITH_ASE=Off`, which needed #229 on `dev` first (rebased onto post-#229 `dev`).