### PR TITLE
ci: warm CI cache by running build on push to dev/main

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -13,6 +13,19 @@ on:
       - 'integration_tests/**'
       - 'tests/**'
       - 'CMakeLists.txt'
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - '.github/workflows/ci_build.yml'
+      - '.cmake/**'
+      - 'apps/**'
+      - 'include/**'
+      - 'src/**'
+      - 'integration_tests/**'
+      - 'tests/**'
+      - 'CMakeLists.txt'
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ All notable changes to this project will be documented in this file.
 - Enabled compilation with Clang/Apple Clang (matched the `requires`-clause form
   on Vector3D compound-assignment operators and fixed a narrowing conversion in
   TriclinicBox)
+- Faster CI: also trigger the build workflow on push to `dev`/`main` so the
+  `ccache` and conda-env caches get populated on the base branch and
+  subsequently-opened PRs start warm instead of cold
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31


### PR DESCRIPTION
PR builds cold-start despite the ccache + conda-env cache setup from #228. The workflow only ran on `pull_request`, so no run ever populated the caches in `dev`'s scope, and Actions cache reads only fall back to the base / default branch — never to another PR's scope.

Adds a `push: { branches: [dev, main] }` trigger with the same path filter, so every merge populates `dev`'s scope; PRs opened against `dev` afterwards read it on the first build step.

Safe because `ccache` is content-addressed (a wrong/stale cache cannot produce a wrong `.o`, only a miss), and `BUILD_WITH_NATIVE=Off` from #228 already makes cross-runner caching reliable. Cost: one extra build per merge into `dev`/`main`.