### PR TITLE
ci: skip perf gate on no-op PRs and cache base instruction counts

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -9,6 +9,19 @@ on:
     branches:
       - main
       - dev
+    # Only run when something that can actually affect instruction counts
+    # changes — code, benchmarks, build config, submodules, or the gate
+    # itself. Doc / changelog / unrelated-workflow PRs skip the gate.
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'apps/**'
+      - 'benchmarks/**'
+      - 'external/**'
+      - 'CMakeLists.txt'
+      - '.cmake/**'
+      - '.github/workflows/perf.yml'
+      - 'scripts/perf_gate.sh'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -37,7 +37,19 @@ jobs:
         with:
           submodules: recursive
 
+      # Callgrind instruction counts are a pure function of the binary, which
+      # is a pure function of the base commit SHA. So we cache the measured
+      # base Ir counts keyed on that SHA: on a hit we skip the base checkout,
+      # build, and base callgrind run entirely (~half the workflow).
+      - name: Restore cached base instruction counts
+        id: base-ir-cache
+        uses: actions/cache@v4
+        with:
+          path: base_ir.tsv
+          key: perf-base-ir-${{ github.event.pull_request.base.sha || github.sha }}
+
       - name: Checkout base branch
+        if: steps.base-ir-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref || 'dev' }}
@@ -67,6 +79,7 @@ jobs:
           CXX: g++-13
 
       - name: Build base benchmarks (baseline)
+        if: steps.base-ir-cache.outputs.cache-hit != 'true'
         run: |
           cmake -S base -B build-base \
             -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_NATIVE=Off \
@@ -81,6 +94,11 @@ jobs:
       - name: Compare instruction counts (gate)
         id: gate
         continue-on-error: true
+        env:
+          # The script loads base counts from this file if it exists (cache
+          # hit) and (re)writes the freshly-known counts to it at the end so
+          # actions/cache@v4 saves them at job end (cache miss path).
+          PERF_BASE_IR_FILE: base_ir.tsv
         run: bash scripts/perf_gate.sh build-pr/benchmarks/perf build-base/benchmarks/perf 2
 
       - name: Mint PQ Perf Bot installation token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ All notable changes to this project will be documented in this file.
 - Performance-regression gate: fixed-work benchmarks (`BUILD_WITH_PERF_BENCH`)
   run under callgrind; CI fails if a benchmark's instruction count regresses vs
   the base branch (deterministic, so not flaky)
+- Perf gate now triggers only on PRs that touch code, benchmarks, build
+  config, or the gate itself; doc / changelog / unrelated-workflow PRs no
+  longer spend ~5 min building benchmarks for a no-op diff
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ All notable changes to this project will be documented in this file.
 - Perf gate now triggers only on PRs that touch code, benchmarks, build
   config, or the gate itself; doc / changelog / unrelated-workflow PRs no
   longer spend ~5 min building benchmarks for a no-op diff
+- Perf gate now caches the base-branch instruction counts keyed on the base
+  commit SHA; on a hit the whole base checkout + build + callgrind run is
+  skipped (≈ half the workflow), with identical numerics (callgrind is
+  deterministic per binary)
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31

--- a/scripts/perf_gate.sh
+++ b/scripts/perf_gate.sh
@@ -15,12 +15,33 @@
 #
 # Usage: perf_gate.sh <pr_bench_dir> <base_bench_dir> [threshold_percent]
 #
+# If PERF_BASE_IR_FILE is set, base instruction counts are loaded from that
+# file (one "<name>\t<ir>" line per benchmark) instead of being re-measured.
+# After running, the freshly-known base counts are (re-)written to the same
+# path so the workflow can persist them as a cache keyed on the base SHA.
+# A miss falls through to measuring the base binaries — identical to the
+# pre-cache behavior.
+#
 set -uo pipefail
 
 PR_DIR="${1:?usage: perf_gate.sh <pr_bench_dir> <base_bench_dir> [threshold%]}"
 BASE_DIR="${2:?usage: perf_gate.sh <pr_bench_dir> <base_bench_dir> [threshold%]}"
 THRESHOLD="${3:-2}"
 REPORT="${PERF_REPORT_FILE:-perf_report.md}"
+BASE_IR_FILE="${PERF_BASE_IR_FILE:-}"
+
+# Load cached base Ir counts (if any). The file format is one tab-separated
+# "<benchmark name>\t<integer>" line per benchmark. Strict parse: any line
+# that doesn't match is ignored.
+declare -A base_ir_cache
+if [ -n "$BASE_IR_FILE" ] && [ -s "$BASE_IR_FILE" ]; then
+    while IFS=$'\t' read -r cached_name cached_ir; do
+        [[ "$cached_ir" =~ ^[0-9]+$ ]] || continue
+        base_ir_cache["$cached_name"]="$cached_ir"
+    done < "$BASE_IR_FILE"
+fi
+# Collect freshly-known base counts (cached + measured) for write-back.
+declare -A base_ir_fresh
 
 # run a binary under callgrind and echo its instruction count (Ir)
 measure() {
@@ -49,13 +70,16 @@ for pr_bin in "$PR_DIR"/perf_*; do
 
     pr_ir="$(measure "$pr_bin")"
 
-    if [ ! -x "$base_bin" ]; then
+    if [ -n "${base_ir_cache[$name]:-}" ]; then
+        base_ir="${base_ir_cache[$name]}"
+    elif [ -x "$base_bin" ]; then
+        base_ir="$(measure "$base_bin")"
+    else
         echo "$name: new benchmark (no baseline) - pr Ir=$pr_ir"
         rows+="| \`$name\` | – | $(fmt "$pr_ir") | new | ➕ |"$'\n'
         continue
     fi
-
-    base_ir="$(measure "$base_bin")"
+    base_ir_fresh["$name"]="$base_ir"
     pct="$(awk -v p="$pr_ir" -v b="$base_ir" \
         'BEGIN{ if (b==0) print "0.00"; else printf "%+.2f", (p-b)/b*100 }')"
     verdict="$(awk -v p="$pr_ir" -v b="$base_ir" -v t="$THRESHOLD" \
@@ -101,6 +125,16 @@ fi
 
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     cat "$REPORT" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# Persist the freshly-known base Ir counts so the workflow's cache (keyed on
+# the base SHA) carries them into the next run. Always rewrite — picks up any
+# newly added benchmarks while preserving counts loaded from a prior cache.
+if [ -n "$BASE_IR_FILE" ] && [ "${#base_ir_fresh[@]}" -gt 0 ]; then
+    : > "$BASE_IR_FILE"
+    for name in "${!base_ir_fresh[@]}"; do
+        printf '%s\t%s\n' "$name" "${base_ir_fresh[$name]}" >> "$BASE_IR_FILE"
+    done
 fi
 
 exit $status


### PR DESCRIPTION
Two perf-CI cleanups, same workflow:

1. **`paths:` filter** — perf gate only fires on changes that can move instruction counts (`src/**`, `include/**`, `apps/**`, `benchmarks/**`, `external/**`, `CMakeLists.txt`, `.cmake/**`, the workflow itself, `scripts/perf_gate.sh`). Docs / changelog / unrelated workflows skip the gate cleanly.
2. **Cache the base Ir counts** keyed on `pull_request.base.sha`. Callgrind output is deterministic per binary, the binary is a pure function of the base SHA, so a cache hit lets us skip the base checkout, build, and callgrind run entirely (≈ half the workflow). Miss falls back to today's measure-base path; numerics are byte-identical either way.

Smoke-tested both miss and hit paths on Linux (bash 5, required for the associative-array cache load): miss measures both binaries and writes `base_ir.tsv`; hit drops the base dir, uses the cached value, measures PR fresh, renders the report.