### PR TITLE
refactor: inline Coulomb cutoff getters in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ All notable changes to this project will be documented in this file.
 ### Internal
 
 - Added missing trailing newline at end of `src/simulationBox/simulationBox.cpp`
+- `CoulombPotential::getCoulombRadiusCutOff()`, `getCoulombEnergyCutOff()`
+  and `getCoulombForceCutOff()` are now `inline` in the header so the
+  per-pair call in `Potential::calculateSingleInteraction` can be elided
+  without LTO
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31

--- a/include/potential/coulomb/coulombPotential.hpp
+++ b/include/potential/coulomb/coulombPotential.hpp
@@ -71,9 +71,18 @@ namespace potential
          * standard getter methods *
          ***************************/
 
-        [[nodiscard]] static double getCoulombRadiusCutOff();
-        [[nodiscard]] static double getCoulombEnergyCutOff();
-        [[nodiscard]] static double getCoulombForceCutOff();
+        [[nodiscard]] inline static double getCoulombRadiusCutOff()
+        {
+            return _coulombRadiusCutOff;
+        }
+        [[nodiscard]] inline static double getCoulombEnergyCutOff()
+        {
+            return _coulombEnergyCutOff;
+        }
+        [[nodiscard]] inline static double getCoulombForceCutOff()
+        {
+            return _coulombForceCutOff;
+        }
     };
 
 }   // namespace potential

--- a/src/potential/coulomb/coulombPotential.cpp
+++ b/src/potential/coulomb/coulombPotential.cpp
@@ -82,35 +82,5 @@ void CoulombPotential::setCoulombForceCutOff(const double coulombForceCutOff)
     _coulombForceCutOff = coulombForceCutOff;
 }
 
-/***************************
- *                         *
- * standard getter methods *
- *                         *
- ***************************/
-
-/**
- * @brief get the coulombRadiusCutOff
- *
- * @return double
- */
-double CoulombPotential::getCoulombRadiusCutOff()
-{
-    return _coulombRadiusCutOff;
-}
-
-/**
- * @brief get the coulombEnergyCutOff
- *
- * @return double
- */
-double CoulombPotential::getCoulombEnergyCutOff()
-{
-    return _coulombEnergyCutOff;
-}
-
-/**
- * @brief get the coulombForceCutOff
- *
- * @return double
- */
-double CoulombPotential::getCoulombForceCutOff() { return _coulombForceCutOff; }
+// Coulomb cutoff getters are inline in the header so the per-pair call
+// in Potential::calculateSingleInteraction can be elided without LTO.


### PR DESCRIPTION
`CoulombPotential::getCoulombRadiusCutOff()` / `getCoulombEnergyCutOff()` / `getCoulombForceCutOff()` were declared in the header and defined out-of-line in `coulombPotential.cpp`, each as a one-line return of a static member. `Potential::calculateSingleInteraction` (`potential.cpp:69`) calls `getCoulombRadiusCutOff()` per atom pair per step, so without LTO (opt-in default OFF since #227) every pair pays a cross-TU function call the compiler can't inline.

Move the three trivial bodies into the header as `inline static`; remove the out-of-line definitions to avoid drift. Behavior-identical.

Linux build green; 114/114 unit tests pass.