### PR TITLE
perf: skip zero-coefficient terms in GuffPair::calculate

### DIFF
--- a/changes/241.internal.md
+++ b/changes/241.internal.md
@@ -1,0 +1,2 @@
+- `GuffPair::calculate` gates each `pow`/`exp` term on its coefficient being
+  non-zero, skipping the transcendental call when the term contributes nothing

--- a/src/potential/nonCoulomb/guffPair.cpp
+++ b/src/potential/nonCoulomb/guffPair.cpp
@@ -59,74 +59,96 @@ GuffPair::GuffPair(
 /**
  * @brief calculates the energy and force of a GuffPair
  *
+ * Each contribution is gated on its leading coefficient being non-zero. This
+ * skips expensive pow/exp calls for terms that contribute nothing, which is
+ * common in sparse .guff parametrizations, while keeping behavior identical
+ * for any distance > 0.
+ *
  * @param distance
  * @return std::pair<double, double>
  */
 std::pair<double, double> GuffPair::calculate(const double distance) const
 {
-    const double c1 = _coefficients[0];
-    const double n2 = _coefficients[1];
-    const double c3 = _coefficients[2];
-    const double n4 = _coefficients[3];
+    double energy = 0.0;
+    double force  = 0.0;
 
-    const double distance_n2 = ::pow(distance, n2);
-    const double distance_n4 = ::pow(distance, n4);
+    if (const double c1 = _coefficients[0]; c1 != 0.0)
+    {
+        const double n2          = _coefficients[1];
+        const double distance_n2 = ::pow(distance, n2);
+        energy += c1 / distance_n2;
+        force  += n2 * c1 / (distance_n2 * distance);
+    }
+    if (const double c3 = _coefficients[2]; c3 != 0.0)
+    {
+        const double n4          = _coefficients[3];
+        const double distance_n4 = ::pow(distance, n4);
+        energy += c3 / distance_n4;
+        force  += n4 * c3 / (distance_n4 * distance);
+    }
 
-    auto energy  = c1 / distance_n2 + c3 / distance_n4;
-    auto force   = n2 * c1 / (distance_n2 * distance);
-    force       += n4 * c3 / (distance_n4 * distance);
+    if (const double c5 = _coefficients[4]; c5 != 0.0)
+    {
+        const double n6          = _coefficients[5];
+        const double distance_n6 = ::pow(distance, n6);
+        energy += c5 / distance_n6;
+        force  += n6 * c5 / (distance_n6 * distance);
+    }
+    if (const double c7 = _coefficients[6]; c7 != 0.0)
+    {
+        const double n8          = _coefficients[7];
+        const double distance_n8 = ::pow(distance, n8);
+        energy += c7 / distance_n8;
+        force  += n8 * c7 / (distance_n8 * distance);
+    }
 
-    const double c5 = _coefficients[4];
-    const double n6 = _coefficients[5];
-    const double c7 = _coefficients[6];
-    const double n8 = _coefficients[7];
+    if (const double c9 = _coefficients[8]; c9 != 0.0)
+    {
+        const double cexp10 = _coefficients[9];
+        const double rExp11 = _coefficients[10];
 
-    const double distance_n6 = ::pow(distance, n6);
-    const double distance_n8 = ::pow(distance, n8);
+        const double helper = ::exp(cexp10 * (distance - rExp11));
 
-    energy += c5 / distance_n6 + c7 / distance_n8;
-    force  += n6 * c5 / (distance_n6 * distance);
-    force  += n8 * c7 / (distance_n8 * distance);
+        energy += c9 / (1 + helper);
+        force  += c9 * cexp10 * helper / ((1 + helper) * (1 + helper));
+    }
 
-    const double c9     = _coefficients[8];
-    const double cexp10 = _coefficients[9];
-    const double rExp11 = _coefficients[10];
+    if (const double c12 = _coefficients[11]; c12 != 0.0)
+    {
+        const double cexp13 = _coefficients[12];
+        const double rExp14 = _coefficients[13];
 
-    double helper = ::exp(cexp10 * (distance - rExp11));
+        const double helper = ::exp(cexp13 * (distance - rExp14));
 
-    energy += c9 / (1 + helper);
-    force  += c9 * cexp10 * helper / ((1 + helper) * (1 + helper));
+        energy += c12 / (1 + helper);
+        force  += c12 * cexp13 * helper / ((1 + helper) * (1 + helper));
+    }
 
-    const double c12    = _coefficients[11];
-    const double cexp13 = _coefficients[12];
-    const double rExp14 = _coefficients[13];
+    if (const double c15 = _coefficients[14]; c15 != 0.0)
+    {
+        const double cexp16 = _coefficients[15];
+        const double rExp17 = _coefficients[16];
+        const double n18    = _coefficients[17];
 
-    helper = ::exp(cexp13 * (distance - rExp14));
+        const double distance_n18 = ::pow(distance - rExp17, n18);
+        const double helper       = c15 * ::exp(cexp16 * distance_n18);
 
-    energy += c12 / (1 + helper);
-    force  += c12 * cexp13 * helper / ((1 + helper) * (1 + helper));
+        energy += helper;
+        force  += -cexp16 * n18 * distance_n18 / (distance - rExp17) * helper;
+    }
 
-    const double c15    = _coefficients[14];
-    const double cexp16 = _coefficients[15];
-    const double rExp17 = _coefficients[16];
-    const double n18    = _coefficients[17];
+    if (const double c19 = _coefficients[18]; c19 != 0.0)
+    {
+        const double cexp20 = _coefficients[19];
+        const double rExp21 = _coefficients[20];
+        const double n22    = _coefficients[21];
 
-    const double distance_n18 = ::pow(distance - rExp17, n18);
-    helper                    = c15 * ::exp(cexp16 * distance_n18);
+        const double distance_n22 = ::pow(distance - rExp21, n22);
+        const double helper       = c19 * ::exp(cexp20 * distance_n22);
 
-    energy += helper;
-    force  += -cexp16 * n18 * distance_n18 / (distance - rExp17) * helper;
-
-    const double c19    = _coefficients[18];
-    const double cexp20 = _coefficients[19];
-    const double rExp21 = _coefficients[20];
-    const double n22    = _coefficients[21];
-
-    const double distance_n22 = ::pow(distance - rExp21, n22);
-    helper                    = c19 * ::exp(cexp20 * distance_n22);
-
-    energy += helper;
-    force  += -cexp20 * n22 * distance_n22 / (distance - rExp21) * helper;
+        energy += helper;
+        force  += -cexp20 * n22 * distance_n22 / (distance - rExp21) * helper;
+    }
 
     energy += -_energyCutOff - _forceCutOff * (_radialCutOff - distance);
     force  += -_forceCutOff;

--- a/tests/src/potential/nonCoulomb/testGuffPair.cpp
+++ b/tests/src/potential/nonCoulomb/testGuffPair.cpp
@@ -104,3 +104,59 @@ TEST(TestGuffPair, calculateEnergyAndForces)
     EXPECT_DOUBLE_EQ(energy, energyREF);
     EXPECT_DOUBLE_EQ(force, forceREF);
 }
+
+/**
+ * @brief regression test for the zero-coefficient gating: terms with a zero
+ * leading coefficient must not contribute, and must not call pow/exp on
+ * pathological inputs (e.g. pow(distance - rExp, n) when rExp == distance).
+ */
+TEST(TestGuffPair, calculateWithSparseCoefficients)
+{
+    const auto distance     = 2.0;
+    const auto rncCutoff    = 3.0;
+    const auto energyCutoff = 0.0;
+    const auto forceCutoff  = 0.0;
+
+    // Only c1 (inverse-power term) and c9 (sigmoid term) are non-zero. The
+    // remaining six contribution blocks must be skipped entirely. The c15
+    // and c19 blocks would otherwise compute pow(distance - rExp17/21, n)
+    // with rExp17 == rExp21 == distance, which is 0^0 = NaN-prone; the gate
+    // keeps the result finite.
+    auto coefficients = std::vector<double>(22, 0.0);
+    coefficients[0]  = 4.0;        // c1
+    coefficients[1]  = 6.0;        // n2
+    coefficients[8]  = 1.5;        // c9
+    coefficients[9]  = 2.0;        // cexp10
+    coefficients[10] = 1.0;        // rExp11
+    coefficients[16] = distance;   // rExp17  - would make distance - rExp17 == 0
+    coefficients[17] = 3.0;        // n18
+    coefficients[20] = distance;   // rExp21
+    coefficients[21] = 3.0;        // n22
+
+    const auto pair =
+        potential::GuffPair(rncCutoff, energyCutoff, forceCutoff, coefficients);
+
+    const auto [energy, force] = pair.calculate(distance);
+
+    // Only the two non-zero terms contribute. Distance cutoff terms are zero
+    // because energyCutoff = forceCutoff = 0.
+    const auto expectedEnergy =
+        coefficients[0] / ::pow(distance, coefficients[1]) +
+        coefficients[8] /
+            (1 + ::exp(coefficients[9] * (distance - coefficients[10])));
+
+    const auto expectedForce =
+        coefficients[1] * coefficients[0] /
+            (::pow(distance, coefficients[1]) * distance) +
+        coefficients[8] * coefficients[9] *
+            ::exp(coefficients[9] * (distance - coefficients[10])) /
+            ::pow(
+                1 + ::exp(coefficients[9] * (distance - coefficients[10])),
+                2
+            );
+
+    EXPECT_DOUBLE_EQ(energy, expectedEnergy);
+    EXPECT_DOUBLE_EQ(force, expectedForce);
+    EXPECT_FALSE(std::isnan(energy));
+    EXPECT_FALSE(std::isnan(force));
+}


### PR DESCRIPTION
`GuffPair::calculate` now skips zero-coefficient GUFF terms before evaluating the corresponding `pow()`/`exp()` calls. This avoids wasted transcendental work for sparse `.guff` parameter blocks while preserving the existing result for contributing terms.

Adds a regression test for sparse coefficients, including skipped terms that would otherwise evaluate NaN-prone inputs.

Checks:
- `ctest --test-dir build-pr241-static -R '^testGuffPair$' --output-on-failure`
- GitHub CI green on `73c5ac1e`
