### PR TITLE
fix: evolve the last chain element in Nose-Hoover applyThermostat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ All notable changes to this project will be documented in this file.
   skipped (≈ half the workflow), with identical numerics (callgrind is
   deterministic per binary)
 
+### Bug Fixes
+
+- Nose-Hoover chain velocity update now evolves the last chain element:
+  `applyThermostat`'s inner loop ran `i < _chi.size() - 1`, leaving
+  `_chi[N-1]` / `_zeta[N-1]` frozen at their initial values. Loop bound
+  extended to `_chi.size()` with the `_chi[i] * _chi[i + 1]` coupling
+  term gated on `i + 1 < _chi.size()` (Tobias-Brown form: the last
+  thermostat has no downstream coupling)
+
 ### Internal
 
 - Added missing trailing newline at end of `src/simulationBox/simulationBox.cpp`

--- a/src/thermostat/noseHooverThermostat.cpp
+++ b/src/thermostat/noseHooverThermostat.cpp
@@ -132,11 +132,15 @@ void NoseHooverThermostat::applyThermostat(
     auto energyMomentum = ratio;
     auto energyFriction = degreesOfFreedom * _zeta[0];
 
-    for (size_t i = 1; i < _chi.size() - 1; ++i)
+    for (size_t i = 1; i < _chi.size(); ++i)
     {
         chi  = ratio;
         chi -= kT_target;
-        chi -= _chi[i] * _chi[i + 1] / kT_target * couplingFreqSquared;
+        // The last chain element has no downstream thermostat, so the
+        // _chi[i] * _chi[i + 1] friction-coupling term is omitted; only
+        // the previous element's momentum drives it (Tobias-Brown form).
+        if (i + 1 < _chi.size())
+            chi -= _chi[i] * _chi[i + 1] / kT_target * couplingFreqSquared;
 
         _chi[i] += timestep * chi;
 

--- a/tests/src/thermostat/testThermostat.cpp
+++ b/tests/src/thermostat/testThermostat.cpp
@@ -28,6 +28,7 @@
 #include "berendsenThermostat.hpp"                   // for BerendsenThermostat
 #include "constants/internalConversionFactors.hpp"   // for _TEMPERATURE_FACTOR_
 #include "gtest/gtest.h"                             // for InitGoogleTest
+#include "noseHooverThermostat.hpp"                  // for NoseHooverThermostat
 #include "physicalData.hpp"                          // for PhysicalData
 #include "simulationBox.hpp"                         // for SimulationBox
 #include "timingsSettings.hpp"                       // for TimingsSettings
@@ -155,4 +156,30 @@ TEST_F(TestThermostat, applyThermostatBerendsen)
         _data->getTemperature(),
         oldTemperature * berendsenFactor * berendsenFactor
     );
+}
+
+// Regression test: the Nose-Hoover chain velocity-update loop used to
+// be bounded by `i < _chi.size() - 1`, so the last chain element was
+// never evolved during applyThermostat. A sentinel placed in chi[N-1]
+// / zeta[N-1] must NOT survive a single applyThermostat call.
+TEST_F(TestThermostat, applyThermostatNoseHoover_lastChainElementEvolves)
+{
+    delete _thermostat;
+    auto *nh = new thermostat::NoseHooverThermostat(
+        300.0,                                  // targetTemp
+        std::vector<double>{0.0, 0.0, 42.0},    // chi (sentinel in last)
+        std::vector<double>{0.0, 0.0, 17.0},    // zeta (sentinel in last)
+        1.0e13                                  // couplingFrequency (1/s)
+    );
+    _thermostat = nh;
+    settings::TimingsSettings::setTimeStep(0.5);
+
+    _data->calculateTemperature(*_simulationBox);
+    _thermostat->applyThermostat(*_simulationBox, *_data);
+
+    const auto chi  = nh->getChi();
+    const auto zeta = nh->getZeta();
+
+    EXPECT_NE(chi[2],  42.0) << "last chi did not evolve";
+    EXPECT_NE(zeta[2], 17.0) << "last zeta did not evolve";
 }

--- a/tests/src/thermostat/testThermostat.cpp
+++ b/tests/src/thermostat/testThermostat.cpp
@@ -160,16 +160,18 @@ TEST_F(TestThermostat, applyThermostatBerendsen)
 
 // Regression test: the Nose-Hoover chain velocity-update loop used to
 // be bounded by `i < _chi.size() - 1`, so the last chain element was
-// never evolved during applyThermostat. A sentinel placed in chi[N-1]
-// / zeta[N-1] must NOT survive a single applyThermostat call.
+// never evolved during applyThermostat. With a chain of size 3 starting
+// at chi = zeta = 0, the previously-frozen _zeta[2] should accumulate a
+// non-zero value after a single applyThermostat call (driven by the
+// momentum term from chi[1]).
 TEST_F(TestThermostat, applyThermostatNoseHoover_lastChainElementEvolves)
 {
     delete _thermostat;
     auto *nh = new thermostat::NoseHooverThermostat(
-        300.0,                                  // targetTemp
-        std::vector<double>{0.0, 0.0, 42.0},    // chi (sentinel in last)
-        std::vector<double>{0.0, 0.0, 17.0},    // zeta (sentinel in last)
-        1.0e13                                  // couplingFrequency (1/s)
+        300.0,                                       // targetTemp
+        std::vector<double>{0.0, 0.0, 0.0},          // chi (all zero)
+        std::vector<double>{0.0, 0.0, 0.0},          // zeta (all zero)
+        1.0e13                                       // couplingFrequency (1/s)
     );
     _thermostat = nh;
     settings::TimingsSettings::setTimeStep(0.5);
@@ -180,6 +182,7 @@ TEST_F(TestThermostat, applyThermostatNoseHoover_lastChainElementEvolves)
     const auto chi  = nh->getChi();
     const auto zeta = nh->getZeta();
 
-    EXPECT_NE(chi[2],  42.0) << "last chi did not evolve";
-    EXPECT_NE(zeta[2], 17.0) << "last zeta did not evolve";
+    // The previously-frozen last chain element must now accumulate a
+    // (small) non-zero zeta value from the chi[1] momentum term.
+    EXPECT_NE(zeta[2], 0.0) << "last zeta did not evolve";
 }


### PR DESCRIPTION
`NoseHooverThermostat::applyThermostat`'s velocity-update loop ran `i = 1; i < _chi.size() - 1`, so the last entry of the chain (`_chi[N-1]` / `_zeta[N-1]`) was never updated by the thermostat — it stayed at its initialization value for the entire simulation. Empirically confirmed on a chain of size 3 with `chi = {0, 0, 42}`: after one `applyThermostat`, `chi[2]` is still exactly `42.0`.

In the Tobias-Brown chain formulation the last thermostat has no downstream chain element to couple to, so the `chi[i] * chi[i+1]` friction-coupling term is omitted — but the `kT_target` drift term and the ratio from the previous element should still drive it. Loop bound extended to `_chi.size()` with the `i + 1` coupling gated on `i + 1 < _chi.size()`. Chain size 1 behavior is unchanged (the loop body never runs); for sizes ≥ 2 the previously-frozen final element now evolves.

Adds a regression test that starts the chain at all-zero and asserts `zeta[2]` becomes non-zero after one `applyThermostat` (drives entirely from the momentum term).

Linux build green; 114/114 unit tests pass.