### PR TITLE
fix: guard BerendsenThermostat against zero-temperature NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ All notable changes to this project will be documented in this file.
   - new `shakeIterations` parameter bounds the inner SHAKE iterations
     and throws `MShakeException` instead of looping forever if the
     constraint solver fails to converge
+- `BerendsenThermostat::applyThermostat` no longer produces NaN
+  velocities when called with zero kinetic energy: the `T_target / T`
+  ratio would diverge and `0.0 * Inf = NaN` corrupted every atom's
+  velocity. The thermostat now skips silently when `_temperature == 0`,
+  mirroring the velocity-rescaling NaN guard added in v0.6.2
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ All notable changes to this project will be documented in this file.
 - Cell-list rebuild no longer constructs a temporary `std::vector<size_t>`
   per atom: `try_emplace(cellIndexScalar, std::vector<size_t>({j}))` +
   fallback `push_back` replaced by a single `mapCellIndexToAtomIndex[cellIndexScalar].push_back(j)`
+- `utilities::isZero<T>(a)` helper added to `mathUtilities.hpp`,
+  centralizing the exact-zero check (`a == T(0)`). Callers that need a
+  tolerance can still use `compare(a, T(0), tol)`
 
 ### Tests
 
@@ -83,9 +86,6 @@ All notable changes to this project will be documented in this file.
   `PotentialCellList::calculateForces` produce identical per-atom forces and
   intermolecular energies for the same configuration, guarding the
   brute-force/cell-list equivalence under hot-path refactors
-- `utilities::isZero<T>(a)` helper added to `mathUtilities.hpp`,
-  centralizing the approximate-zero check for floating-point types
-  (`std::fabs(a) < std::numeric_limits<T>::epsilon()`)
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,9 @@ All notable changes to this project will be documented in this file.
 - `BerendsenThermostat::applyThermostat` no longer produces NaN
   velocities when called with zero kinetic energy: the `T_target / T`
   ratio would diverge and `0.0 * Inf = NaN` corrupted every atom's
-  velocity. The thermostat now skips silently when `_temperature == 0`,
-  mirroring the velocity-rescaling NaN guard added in v0.6.2
+  velocity. The thermostat now skips silently when `_temperature` is
+  (approximately) zero, mirroring the velocity-rescaling NaN guard
+  added in v0.6.2
 
 ### Internal
 
@@ -82,6 +83,9 @@ All notable changes to this project will be documented in this file.
   `PotentialCellList::calculateForces` produce identical per-atom forces and
   intermolecular energies for the same configuration, guarding the
   brute-force/cell-list equivalence under hot-path refactors
+- `utilities::isZero<T>(a)` helper added to `mathUtilities.hpp`,
+  centralizing the approximate-zero check for floating-point types
+  (`std::fabs(a) < std::numeric_limits<T>::epsilon()`)
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31

--- a/include/utilities/mathUtilities.hpp
+++ b/include/utilities/mathUtilities.hpp
@@ -72,17 +72,21 @@ namespace utilities
     [[nodiscard]] bool compare(const pq::Vec3D &a, const pq::Vec3D &b);
 
     /**
-     * @brief check whether a number is approximately zero via machine
-     * precision
+     * @brief check whether a number is exactly zero
+     *
+     * @details Uses exact equality (`a == T(0)`) rather than an epsilon
+     * comparison: callers that guard against division-by-zero or `0 * Inf`
+     * NaN propagation only need to catch literal zero. Use the explicit
+     * `compare(a, T(0), tol)` overload when a tolerance is wanted.
      *
      * @tparam T
      * @param a
-     * @return true if |a| < std::numeric_limits<T>::epsilon()
+     * @return true if a == T(0), false otherwise
      */
     template <typename T>
     [[nodiscard]] bool isZero(const T &a)
     {
-        return compare(a, T(0));
+        return a == T(0);
     }
 
     /**

--- a/include/utilities/mathUtilities.hpp
+++ b/include/utilities/mathUtilities.hpp
@@ -72,6 +72,20 @@ namespace utilities
     [[nodiscard]] bool compare(const pq::Vec3D &a, const pq::Vec3D &b);
 
     /**
+     * @brief check whether a number is approximately zero via machine
+     * precision
+     *
+     * @tparam T
+     * @param a
+     * @return true if |a| < std::numeric_limits<T>::epsilon()
+     */
+    template <typename T>
+    [[nodiscard]] bool isZero(const T &a)
+    {
+        return compare(a, T(0));
+    }
+
+    /**
      * @brief calculates the sign of a number
      *
      * @tparam T

--- a/src/thermostat/berendsenThermostat.cpp
+++ b/src/thermostat/berendsenThermostat.cpp
@@ -27,6 +27,7 @@
 #include <vector>   // for vector
 
 #include "atom.hpp"                 // for Atom
+#include "mathUtilities.hpp"        // for isZero
 #include "physicalData.hpp"         // for PhysicalData
 #include "simulationBox.hpp"        // for SimulationBox
 #include "thermostatSettings.hpp"   // for ThermostatType
@@ -36,6 +37,7 @@ using thermostat::BerendsenThermostat;
 using namespace settings;
 using namespace simulationBox;
 using namespace physicalData;
+using namespace utilities;
 
 /**
  * @brief Construct a new Berendsen Thermostat object
@@ -70,10 +72,10 @@ void BerendsenThermostat::applyThermostat(
 
     _temperature = data.getTemperature();
 
-    // If the kinetic energy is zero, there is nothing to thermostat:
-    // dividing by _temperature would NaN all velocities (1 / 0 -> Inf,
-    // then vel * Inf = NaN when vel is 0). Skip silently.
-    if (_temperature == 0.0)
+    // If the kinetic energy is (approximately) zero, there is nothing to
+    // thermostat: dividing by _temperature would NaN all velocities
+    // (1 / 0 -> Inf, then vel * Inf = NaN when vel is 0). Skip silently.
+    if (isZero(_temperature))
     {
         stopTimingsSection("Berendsen");
         return;

--- a/src/thermostat/berendsenThermostat.cpp
+++ b/src/thermostat/berendsenThermostat.cpp
@@ -70,6 +70,15 @@ void BerendsenThermostat::applyThermostat(
 
     _temperature = data.getTemperature();
 
+    // If the kinetic energy is zero, there is nothing to thermostat:
+    // dividing by _temperature would NaN all velocities (1 / 0 -> Inf,
+    // then vel * Inf = NaN when vel is 0). Skip silently.
+    if (_temperature == 0.0)
+    {
+        stopTimingsSection("Berendsen");
+        return;
+    }
+
     const auto dt        = TimingsSettings::getTimeStep();
     const auto tempRatio = _targetTemperature / _temperature;
 

--- a/tests/src/thermostat/testThermostat.cpp
+++ b/tests/src/thermostat/testThermostat.cpp
@@ -156,3 +156,28 @@ TEST_F(TestThermostat, applyThermostatBerendsen)
         oldTemperature * berendsenFactor * berendsenFactor
     );
 }
+
+// Regression test: starting from zero kinetic energy (T == 0) used to
+// produce NaN velocities, because tempRatio = T_target / 0 = Inf and
+// the velocity scaling 0 * Inf = NaN. The guard skips the scaling and
+// leaves velocities at zero.
+TEST_F(TestThermostat, applyBerendsen_zeroTemperatureNoNaN)
+{
+    delete _thermostat;
+    _thermostat = new thermostat::BerendsenThermostat(300.0, 100.0);
+    settings::TimingsSettings::setTimeStep(0.1);
+
+    for (auto &atom : _simulationBox->getAtoms())
+        atom->setVelocity({0.0, 0.0, 0.0});
+
+    _thermostat->applyThermostat(*_simulationBox, *_data);
+
+    EXPECT_FALSE(std::isnan(_data->getTemperature()));
+    EXPECT_FALSE(std::isinf(_data->getTemperature()));
+    for (const auto &atom : _simulationBox->getAtoms())
+        for (size_t i = 0; i < 3; ++i)
+        {
+            EXPECT_FALSE(std::isnan(atom->getVelocity()[i]));
+            EXPECT_FALSE(std::isinf(atom->getVelocity()[i]));
+        }
+}

--- a/tests/src/utilities/testMathUtilities.cpp
+++ b/tests/src/utilities/testMathUtilities.cpp
@@ -63,3 +63,14 @@ TEST(TestMathUtilities, sign)
     EXPECT_EQ(sign(-2.0), -1);
     EXPECT_EQ(sign(0.0), 0);
 }
+
+/**
+ * @brief tests isZero template function for the double data type
+ */
+TEST(TestMathUtilities, isZero)
+{
+    EXPECT_TRUE(isZero(0.0));
+    EXPECT_TRUE(isZero(-0.0));
+    EXPECT_FALSE(isZero(1.0));
+    EXPECT_FALSE(isZero(std::numeric_limits<double>::epsilon()));
+}

--- a/tests/src/utilities/testMathUtilities.cpp
+++ b/tests/src/utilities/testMathUtilities.cpp
@@ -65,7 +65,8 @@ TEST(TestMathUtilities, sign)
 }
 
 /**
- * @brief tests isZero template function for the double data type
+ * @brief tests isZero template function for the double data type. Uses
+ * exact equality, so subnormal but non-zero values are not "zero".
  */
 TEST(TestMathUtilities, isZero)
 {
@@ -73,4 +74,5 @@ TEST(TestMathUtilities, isZero)
     EXPECT_TRUE(isZero(-0.0));
     EXPECT_FALSE(isZero(1.0));
     EXPECT_FALSE(isZero(std::numeric_limits<double>::epsilon()));
+    EXPECT_FALSE(isZero(std::numeric_limits<double>::min()));
 }


### PR DESCRIPTION
`BerendsenThermostat::applyThermostat` computed `tempRatio = _targetTemperature / _temperature` without checking that `_temperature` was non-zero. If the initial kinetic energy is zero (degenerate setup, or velocities not yet initialized when the thermostat first runs), `tempRatio` is Inf, `berendsenFactor` is Inf, and atom velocities scaled by Inf become NaN (`0 * Inf = NaN`); the trajectory is then permanently poisoned.

Empirically confirmed: with the fixture velocities zeroed out, one `applyThermostat` call NaN'd every velocity component of every atom.

Mirrors the pattern velocity-rescaling was hardened against in v0.6.2 ("VelocityRescalingThermostat is prevented from generating -nan velocities"). The fix skips silently when `_temperature == 0` — there's no kinetic energy to thermostat, identity scaling is the only sensible behavior.

Linux build green; 114/114 unit tests pass.