### PR TITLE
refactor: avoid temp vector in cell-list molecule rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ All notable changes to this project will be documented in this file.
   and `getCoulombForceCutOff()` are now `inline` in the header so the
   per-pair call in `Potential::calculateSingleInteraction` can be elided
   without LTO
+- Cell-list rebuild no longer constructs a temporary `std::vector<size_t>`
+  per atom: `try_emplace(cellIndexScalar, std::vector<size_t>({j}))` +
+  fallback `push_back` replaced by a single `mapCellIndexToAtomIndex[cellIndexScalar].push_back(j)`
 
 ### Tests
 

--- a/src/simulationBox/celllist.cpp
+++ b/src/simulationBox/celllist.cpp
@@ -255,13 +255,7 @@ void CellList::addMoleculesToCells(SimulationBox &simulationBox)
             const auto atomCellIndices = getCellIndexOfAtom(box, position);
             const auto cellIndexScalar = getCellIndex(atomCellIndices);
 
-            const auto &[_, successful] = mapCellIndexToAtomIndex.try_emplace(
-                cellIndexScalar,
-                std::vector<size_t>({j})
-            );
-
-            if (!successful)
-                mapCellIndexToAtomIndex[cellIndexScalar].push_back(j);
+            mapCellIndexToAtomIndex[cellIndexScalar].push_back(j);
         }
 
         auto addMoleculeAndAtomIndicesToCell = [this, molecule](auto &pair)


### PR DESCRIPTION
Re-opened after #244 reverted the rushed merge as the original #238 didn't wait for CI to finish on the rebased branch.

`CellList::addMoleculesToCells` used `try_emplace(cellIndexScalar, std::vector<size_t>({j}))` followed by a `push_back` on miss. The vector temporary is materialized at the call site before `try_emplace` decides whether to insert it, so a one-element heap allocation happens for every atom on every cell-list rebuild — and is discarded when the key already exists (the common case for multi-atom molecules whose atoms cluster in the same cell).

`operator[]` default-constructs an empty vector on miss (no heap until the first `push_back`) and returns a reference either way, so a single `push_back` collapses both branches with no temp. Behavior-identical.

Linux build green; 115/115 unit tests pass.