### PR TITLE
fix: guard BerendsenThermostat against zero-temperature NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ All notable changes to this project will be documented in this file.
   skipped (≈ half the workflow), with identical numerics (callgrind is
   deterministic per binary)
 
+### Bug Fixes
+
+- `BerendsenThermostat::applyThermostat` no longer produces NaN
+  velocities when called with zero kinetic energy: the `T_target / T`
+  ratio would diverge and `0.0 * Inf = NaN` corrupted every atom's
+  velocity. The thermostat now skips silently when `_temperature` is
+  (approximately) zero, mirroring the velocity-rescaling NaN guard
+  added in v0.6.2
+
 ### Internal
 
 - Added missing trailing newline at end of `src/simulationBox/simulationBox.cpp`
@@ -55,6 +64,9 @@ All notable changes to this project will be documented in this file.
 - Cell-list rebuild no longer constructs a temporary `std::vector<size_t>`
   per atom: `try_emplace(cellIndexScalar, std::vector<size_t>({j}))` +
   fallback `push_back` replaced by a single `mapCellIndexToAtomIndex[cellIndexScalar].push_back(j)`
+- `utilities::isZero<T>(a)` helper added to `mathUtilities.hpp`,
+  centralizing the exact-zero check (`a == T(0)`). Callers that need a
+  tolerance can still use `compare(a, T(0), tol)`
 
 ### Tests
 

--- a/include/utilities/mathUtilities.hpp
+++ b/include/utilities/mathUtilities.hpp
@@ -72,6 +72,24 @@ namespace utilities
     [[nodiscard]] bool compare(const pq::Vec3D &a, const pq::Vec3D &b);
 
     /**
+     * @brief check whether a number is exactly zero
+     *
+     * @details Uses exact equality (`a == T(0)`) rather than an epsilon
+     * comparison: callers that guard against division-by-zero or `0 * Inf`
+     * NaN propagation only need to catch literal zero. Use the explicit
+     * `compare(a, T(0), tol)` overload when a tolerance is wanted.
+     *
+     * @tparam T
+     * @param a
+     * @return true if a == T(0), false otherwise
+     */
+    template <typename T>
+    [[nodiscard]] bool isZero(const T &a)
+    {
+        return a == T(0);
+    }
+
+    /**
      * @brief calculates the sign of a number
      *
      * @tparam T

--- a/src/thermostat/berendsenThermostat.cpp
+++ b/src/thermostat/berendsenThermostat.cpp
@@ -27,6 +27,7 @@
 #include <vector>   // for vector
 
 #include "atom.hpp"                 // for Atom
+#include "mathUtilities.hpp"        // for isZero
 #include "physicalData.hpp"         // for PhysicalData
 #include "simulationBox.hpp"        // for SimulationBox
 #include "thermostatSettings.hpp"   // for ThermostatType
@@ -36,6 +37,7 @@ using thermostat::BerendsenThermostat;
 using namespace settings;
 using namespace simulationBox;
 using namespace physicalData;
+using namespace utilities;
 
 /**
  * @brief Construct a new Berendsen Thermostat object
@@ -69,6 +71,15 @@ void BerendsenThermostat::applyThermostat(
     data.calculateTemperature(simulationBox);
 
     _temperature = data.getTemperature();
+
+    // If the kinetic energy is (approximately) zero, there is nothing to
+    // thermostat: dividing by _temperature would NaN all velocities
+    // (1 / 0 -> Inf, then vel * Inf = NaN when vel is 0). Skip silently.
+    if (isZero(_temperature))
+    {
+        stopTimingsSection("Berendsen");
+        return;
+    }
 
     const auto dt        = TimingsSettings::getTimeStep();
     const auto tempRatio = _targetTemperature / _temperature;

--- a/tests/src/thermostat/testThermostat.cpp
+++ b/tests/src/thermostat/testThermostat.cpp
@@ -196,6 +196,31 @@ TEST_F(TestThermostat, velocityRescaling_applyDoesNotNaN)
         }
 }
 
+// Regression test: starting from zero kinetic energy (T == 0) used to
+// produce NaN velocities, because tempRatio = T_target / 0 = Inf and
+// the velocity scaling 0 * Inf = NaN. The guard skips the scaling and
+// leaves velocities at zero.
+TEST_F(TestThermostat, applyBerendsen_zeroTemperatureNoNaN)
+{
+    delete _thermostat;
+    _thermostat = new thermostat::BerendsenThermostat(300.0, 100.0);
+    settings::TimingsSettings::setTimeStep(0.1);
+
+    for (auto &atom : _simulationBox->getAtoms())
+        atom->setVelocity({0.0, 0.0, 0.0});
+
+    _thermostat->applyThermostat(*_simulationBox, *_data);
+
+    EXPECT_FALSE(std::isnan(_data->getTemperature()));
+    EXPECT_FALSE(std::isinf(_data->getTemperature()));
+    for (const auto &atom : _simulationBox->getAtoms())
+        for (size_t i = 0; i < 3; ++i)
+        {
+            EXPECT_FALSE(std::isnan(atom->getVelocity()[i]));
+            EXPECT_FALSE(std::isinf(atom->getVelocity()[i]));
+        }
+}
+
 /* ---------- LangevinThermostat ---------- */
 
 TEST_F(TestThermostat, langevin_constructorComputesSigma)

--- a/tests/src/utilities/testMathUtilities.cpp
+++ b/tests/src/utilities/testMathUtilities.cpp
@@ -101,3 +101,16 @@ TEST(TestMathUtilities, kroneckerDelta)
     EXPECT_EQ(kroneckerDelta(0u, 1u), 0u);
     EXPECT_EQ(kroneckerDelta(5u, 7u), 0u);
 }
+
+/**
+ * @brief tests isZero template function for the double data type. Uses
+ * exact equality, so subnormal but non-zero values are not "zero".
+ */
+TEST(TestMathUtilities, isZero)
+{
+    EXPECT_TRUE(isZero(0.0));
+    EXPECT_TRUE(isZero(-0.0));
+    EXPECT_FALSE(isZero(1.0));
+    EXPECT_FALSE(isZero(std::numeric_limits<double>::epsilon()));
+    EXPECT_FALSE(isZero(std::numeric_limits<double>::min()));
+}


### PR DESCRIPTION
Re-opened after #244. Needs 97gamjak's re-review on the `isZero` helper variant.

`BerendsenThermostat::applyThermostat` computed `tempRatio = _targetTemperature / _temperature` without checking that `_temperature` was non-zero. With zero kinetic energy, `tempRatio` is Inf, `berendsenFactor` is Inf, and velocity scaling produces NaN (`0 * Inf = NaN`); the trajectory is then permanently poisoned. Empirically confirmed by zeroing fixture velocities and observing NaN on every atom after one apply.

The guard is routed through a new `utilities::isZero<T>(a)` helper added to `mathUtilities.hpp` — centralized exact-zero check (`a == T(0)`). Callers needing a tolerance can still use `compare(a, T(0), tol)`. Exact equality is the right semantic here: the NaN trigger is literal zero; subnormal but non-zero temperatures still produce huge-but-finite scaled velocities. Using the machine-epsilon variant broke the existing `applyThermostatBerendsen` test on a legitimately small (4e-24) temperature.

Adds `TestMathUtilities.isZero` + `TestThermostat.applyBerendsen_zeroTemperatureNoNaN` regression tests.

Linux build green; 115/115 unit tests pass.