### PR TITLE
fix: guard ExternalQMRunner against NaN/Inf in QM force file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ All notable changes to this project will be documented in this file.
   was therefore storing wrong reference squared bond lengths, so
   `applyMShake` was driving the constraint toward an incorrect target
   and could not converge
+- `ExternalQMRunner::readForceFile` now throws `QMRunnerException` if the
+  QM energy or any force component read from the external force file is
+  NaN/Inf, mirroring the v0.6.2 NaN/Inf input-file guard. Previously a
+  failed/garbage QM calculation silently propagated NaN into the
+  trajectory
 
 ### Internal
 

--- a/src/QM/external/externalQMRunner.cpp
+++ b/src/QM/external/externalQMRunner.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>    // for __for_each_fn, for_each
 #include <chrono>       // for seconds
+#include <cmath>        // for isnan, isinf
 #include <format>       // for format
 #include <fstream>      // for ofstream
 #include <functional>   // for identity
@@ -111,13 +112,29 @@ void ExternalQMRunner::readForceFile(
 
     forceFile >> energy;
 
+    if (std::isnan(energy) || std::isinf(energy))
+        throw QMRunnerException(std::format(
+            "Invalid QM energy (NaN/Inf) in {} force file \"{}\"",
+            string(QMSettings::getQMMethod()),
+            forceFileName
+        ));
+
     physicalData.setQMEnergy(energy * _HARTREE_TO_KCAL_PER_MOL_);
 
-    auto readForces = [&forceFile](auto &atom)
+    auto readForces = [&forceFile, &forceFileName](auto &atom)
     {
         auto grad = linearAlgebra::Vec3D();
 
         forceFile >> grad[0] >> grad[1] >> grad[2];
+
+        for (size_t i = 0; i < 3; ++i)
+            if (std::isnan(grad[i]) || std::isinf(grad[i]))
+                throw QMRunnerException(std::format(
+                    "Invalid QM force component (NaN/Inf) in {} force file "
+                    "\"{}\"",
+                    string(QMSettings::getQMMethod()),
+                    forceFileName
+                ));
 
         atom->setForce(-grad * _HARTREE_PER_BOHR_TO_KCAL_PER_MOL_PER_ANGSTROM_);
     };


### PR DESCRIPTION
`ExternalQMRunner::readForceFile` read the QM energy and per-atom forces from the external force file with no `std::isnan`/`std::isinf` check before propagating into `PhysicalData` and atom forces — a crashed or garbage QM run would silently poison the trajectory.

Throw `QMRunnerException` on NaN/Inf, mirroring the v0.6.2 fix for `.rst` file input.

Linux build green; 115/115 unit tests pass.