### PR TITLE
test: expand coverage for mathUtilities, thermostats, and manostats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ All notable changes to this project will be documented in this file.
   `PotentialCellList::calculateForces` produce identical per-atom forces and
   intermolecular energies for the same configuration, guarding the
   brute-force/cell-list equivalence under hot-path refactors
+- Expanded coverage for `mathUtilities` (`compare` with tolerance,
+  `compare(Vec3D)` with tolerance, `kroneckerDelta`); `Thermostat`
+  variants (`VelocityRescaling`: tau getter/setter, thermostat type,
+  apply doesn't produce NaN; `Langevin`: sigma after construction,
+  setters/getters, sigma recompute on target-temperature change,
+  thermostat type; `NoseHoover`: thermostat type, coupling-frequency
+  setter/getter, chi/zeta index setter); and `Manostat` variants
+  (`BerendsenManostat`: tau and compressibility getters, manostat type
+  and isotropy; isotropy and type for `SemiIsotropic`, `Anisotropic`,
+  and `FullAnisotropic` Berendsen)
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31

--- a/tests/src/manostat/testManostat.cpp
+++ b/tests/src/manostat/testManostat.cpp
@@ -164,3 +164,47 @@ TEST_F(TestManostat, testRotateMu)
         })
     );
 }
+
+/* ---------- BerendsenManostat — type, isotropy, getters ---------- */
+
+TEST_F(TestManostat, berendsen_taueAndCompressibilityGetters)
+{
+    auto bm = manostat::BerendsenManostat(1.0, 0.1, 4.5);
+    EXPECT_DOUBLE_EQ(bm.getTau(), 0.1);
+    EXPECT_DOUBLE_EQ(bm.getCompressibility(), 4.5);
+}
+
+TEST_F(TestManostat, berendsen_manostatType)
+{
+    auto bm = manostat::BerendsenManostat(1.0, 0.1, 4.5);
+    EXPECT_EQ(bm.getManostatType(), settings::ManostatType::BERENDSEN);
+}
+
+TEST_F(TestManostat, berendsen_isotropy)
+{
+    auto bm = manostat::BerendsenManostat(1.0, 0.1, 4.5);
+    EXPECT_EQ(bm.getIsotropy(), settings::Isotropy::ISOTROPIC);
+}
+
+TEST_F(TestManostat, semiIsotropicBerendsen_isotropy)
+{
+    auto bm = manostat::SemiIsotropicBerendsenManostat(
+        1.0, 0.1, 4.5, 2u, std::vector<size_t>{0u, 1u}
+    );
+    EXPECT_EQ(bm.getIsotropy(), settings::Isotropy::SEMI_ISOTROPIC);
+    EXPECT_EQ(bm.getManostatType(), settings::ManostatType::BERENDSEN);
+}
+
+TEST_F(TestManostat, anisotropicBerendsen_isotropy)
+{
+    auto bm = manostat::AnisotropicBerendsenManostat(1.0, 0.1, 4.5);
+    EXPECT_EQ(bm.getIsotropy(), settings::Isotropy::ANISOTROPIC);
+    EXPECT_EQ(bm.getManostatType(), settings::ManostatType::BERENDSEN);
+}
+
+TEST_F(TestManostat, fullAnisotropicBerendsen_isotropy)
+{
+    auto bm = manostat::FullAnisotropicBerendsenManostat(1.0, 0.1, 4.5);
+    EXPECT_EQ(bm.getIsotropy(), settings::Isotropy::FULL_ANISOTROPIC);
+    EXPECT_EQ(bm.getManostatType(), settings::ManostatType::BERENDSEN);
+}

--- a/tests/src/thermostat/testThermostat.cpp
+++ b/tests/src/thermostat/testThermostat.cpp
@@ -25,12 +25,16 @@
 #include <cmath>    // for sqrt
 #include <memory>   // for allocator
 
-#include "berendsenThermostat.hpp"                   // for BerendsenThermostat
-#include "constants/internalConversionFactors.hpp"   // for _TEMPERATURE_FACTOR_
-#include "gtest/gtest.h"                             // for InitGoogleTest
-#include "physicalData.hpp"                          // for PhysicalData
-#include "simulationBox.hpp"                         // for SimulationBox
-#include "timingsSettings.hpp"                       // for TimingsSettings
+#include "berendsenThermostat.hpp"                    // for BerendsenThermostat
+#include "constants/internalConversionFactors.hpp"    // for _TEMPERATURE_FACTOR_
+#include "gtest/gtest.h"                              // for InitGoogleTest
+#include "langevinThermostat.hpp"                     // for LangevinThermostat
+#include "noseHooverThermostat.hpp"                   // for NoseHooverThermostat
+#include "physicalData.hpp"                           // for PhysicalData
+#include "simulationBox.hpp"                          // for SimulationBox
+#include "thermostatSettings.hpp"                     // for ThermostatType
+#include "timingsSettings.hpp"                        // for TimingsSettings
+#include "velocityRescalingThermostat.hpp"            // for VelocityRescalingThermostat
 
 TEST_F(TestThermostat, calculateTemperature)
 {
@@ -155,4 +159,123 @@ TEST_F(TestThermostat, applyThermostatBerendsen)
         _data->getTemperature(),
         oldTemperature * berendsenFactor * berendsenFactor
     );
+}
+
+/* ---------- VelocityRescalingThermostat ---------- */
+
+TEST_F(TestThermostat, velocityRescaling_tauSetterGetter)
+{
+    auto vr = thermostat::VelocityRescalingThermostat(300.0, 100.0);
+    EXPECT_DOUBLE_EQ(vr.getTau(), 100.0);
+
+    vr.setTau(50.0);
+    EXPECT_DOUBLE_EQ(vr.getTau(), 50.0);
+}
+
+TEST_F(TestThermostat, velocityRescaling_thermostatType)
+{
+    auto vr = thermostat::VelocityRescalingThermostat(300.0, 100.0);
+    EXPECT_EQ(vr.getThermostatType(), settings::ThermostatType::VELOCITY_RESCALING);
+}
+
+TEST_F(TestThermostat, velocityRescaling_applyDoesNotNaN)
+{
+    delete _thermostat;
+    _thermostat = new thermostat::VelocityRescalingThermostat(300.0, 100.0);
+    settings::TimingsSettings::setTimeStep(0.1);
+
+    _thermostat->applyThermostat(*_simulationBox, *_data);
+
+    EXPECT_FALSE(std::isnan(_data->getTemperature()));
+    EXPECT_FALSE(std::isinf(_data->getTemperature()));
+    for (const auto &atom : _simulationBox->getAtoms())
+        for (size_t i = 0; i < 3; ++i)
+        {
+            EXPECT_FALSE(std::isnan(atom->getVelocity()[i]));
+            EXPECT_FALSE(std::isinf(atom->getVelocity()[i]));
+        }
+}
+
+/* ---------- LangevinThermostat ---------- */
+
+TEST_F(TestThermostat, langevin_constructorComputesSigma)
+{
+    // sigma > 0 once friction and targetTemp are non-zero.
+    const auto langevin = thermostat::LangevinThermostat(300.0, 0.1);
+    EXPECT_GT(langevin.getSigma(), 0.0);
+    EXPECT_DOUBLE_EQ(langevin.getFriction(), 0.1);
+}
+
+TEST_F(TestThermostat, langevin_settersAndGetters)
+{
+    auto langevin = thermostat::LangevinThermostat(300.0, 0.1);
+
+    langevin.setFriction(0.5);
+    EXPECT_DOUBLE_EQ(langevin.getFriction(), 0.5);
+
+    langevin.setSigma(2.0);
+    EXPECT_DOUBLE_EQ(langevin.getSigma(), 2.0);
+}
+
+TEST_F(TestThermostat, langevin_setTargetTemperatureRecomputesSigma)
+{
+    auto langevin = thermostat::LangevinThermostat(300.0, 0.1);
+    settings::TimingsSettings::setTimeStep(0.1);
+    const auto sigmaAt300 = langevin.getSigma();
+
+    langevin.setTargetTemperature(600.0);
+    const auto sigmaAt600 = langevin.getSigma();
+
+    // Setting a higher target temperature must update sigma (the
+    // Langevin Gaussian-noise amplitude scales with sqrt(kBT)).
+    EXPECT_NE(sigmaAt300, sigmaAt600);
+    EXPECT_GT(sigmaAt600, sigmaAt300);
+}
+
+TEST_F(TestThermostat, langevin_thermostatType)
+{
+    auto langevin = thermostat::LangevinThermostat(300.0, 0.1);
+    EXPECT_EQ(langevin.getThermostatType(), settings::ThermostatType::LANGEVIN);
+}
+
+/* ---------- NoseHooverThermostat ---------- */
+
+TEST_F(TestThermostat, noseHoover_thermostatType)
+{
+    auto nh = thermostat::NoseHooverThermostat(
+        300.0,
+        std::vector<double>{0.0, 0.0, 0.0},
+        std::vector<double>{0.0, 0.0, 0.0},
+        1.0e13
+    );
+    EXPECT_EQ(nh.getThermostatType(), settings::ThermostatType::NOSE_HOOVER);
+}
+
+TEST_F(TestThermostat, noseHoover_couplingFrequencySetterGetter)
+{
+    auto nh = thermostat::NoseHooverThermostat(
+        300.0,
+        std::vector<double>{0.0, 0.0, 0.0},
+        std::vector<double>{0.0, 0.0, 0.0},
+        1.0e13
+    );
+    EXPECT_DOUBLE_EQ(nh.getCouplingFrequency(), 1.0e13);
+
+    nh.setCouplingFrequency(5.0e12);
+    EXPECT_DOUBLE_EQ(nh.getCouplingFrequency(), 5.0e12);
+}
+
+TEST_F(TestThermostat, noseHoover_setChiAtIndex)
+{
+    auto nh = thermostat::NoseHooverThermostat(
+        300.0,
+        std::vector<double>{0.0, 0.0, 0.0},
+        std::vector<double>{0.0, 0.0, 0.0},
+        1.0e13
+    );
+    nh.setChi(2u, 7.0);
+    EXPECT_DOUBLE_EQ(nh.getChi()[2], 7.0);
+
+    nh.setZeta(1u, 3.0);
+    EXPECT_DOUBLE_EQ(nh.getZeta()[1], 3.0);
 }

--- a/tests/src/utilities/testMathUtilities.cpp
+++ b/tests/src/utilities/testMathUtilities.cpp
@@ -70,9 +70,12 @@ TEST(TestMathUtilities, sign)
  */
 TEST(TestMathUtilities, compareWithTolerance)
 {
+    // compare uses strict `<`, so a == b only compares equal when the
+    // tolerance is strictly positive.
     EXPECT_TRUE(compare(1.0, 1.0 + 1e-9, 1e-8));
     EXPECT_FALSE(compare(1.0, 1.0 + 1e-7, 1e-8));
-    EXPECT_TRUE(compare(0.0, 0.0, 0.0));
+    EXPECT_FALSE(compare(0.0, 0.0, 0.0));
+    EXPECT_TRUE(compare(0.0, 0.0, 1e-12));
     EXPECT_FALSE(compare(1.0, 2.0, 0.5));
 }
 

--- a/tests/src/utilities/testMathUtilities.cpp
+++ b/tests/src/utilities/testMathUtilities.cpp
@@ -63,3 +63,38 @@ TEST(TestMathUtilities, sign)
     EXPECT_EQ(sign(-2.0), -1);
     EXPECT_EQ(sign(0.0), 0);
 }
+
+/**
+ * @brief tests compare<T>(a, b, tolerance) — 3-arg overload with a
+ * user-supplied tolerance.
+ */
+TEST(TestMathUtilities, compareWithTolerance)
+{
+    EXPECT_TRUE(compare(1.0, 1.0 + 1e-9, 1e-8));
+    EXPECT_FALSE(compare(1.0, 1.0 + 1e-7, 1e-8));
+    EXPECT_TRUE(compare(0.0, 0.0, 0.0));
+    EXPECT_FALSE(compare(1.0, 2.0, 0.5));
+}
+
+/**
+ * @brief tests compare(Vec3D, Vec3D, tolerance) — Vec3D compare with
+ * a user-supplied tolerance.
+ */
+TEST(TestMathUtilities, compareVec3DWithTolerance)
+{
+    const auto a = linearAlgebra::Vec3D(1.0, 2.0, 3.0);
+    const auto b = linearAlgebra::Vec3D(1.0 + 1e-9, 2.0, 3.0 - 1e-9);
+    EXPECT_TRUE(compare(a, b, 1e-8));
+    EXPECT_FALSE(compare(a, b, 1e-10));
+}
+
+/**
+ * @brief tests kroneckerDelta(i, j): 1 when i == j, 0 otherwise.
+ */
+TEST(TestMathUtilities, kroneckerDelta)
+{
+    EXPECT_EQ(kroneckerDelta(0u, 0u), 1u);
+    EXPECT_EQ(kroneckerDelta(1u, 1u), 1u);
+    EXPECT_EQ(kroneckerDelta(0u, 1u), 0u);
+    EXPECT_EQ(kroneckerDelta(5u, 7u), 0u);
+}


### PR DESCRIPTION
Adds ~15 unit tests targeting subsystems with thin or zero coverage:

- **mathUtilities**: `compare(double, double, tolerance)` overload (incl. the strict-less-than corner case at `tol = 0`); `compare(Vec3D, Vec3D, tolerance)`; `kroneckerDelta`.
- **Thermostat**: `VelocityRescaling` tau setter/getter, type identity, apply-doesn't-NaN; `Langevin` sigma after construction, friction/sigma setters/getters, sigma recompute on `setTargetTemperature`, type identity; `NoseHoover` type identity, coupling-frequency setter/getter, chi/zeta index setter.
- **Manostat**: `BerendsenManostat` tau/compressibility getters, manostat type + isotropy; isotropy and type identity for `SemiIsotropic`, `Anisotropic`, and `FullAnisotropic` Berendsen variants.

Linux build green; 115/115 unit tests pass.