### PR TITLE
test: expand PhysicalData accumulators and CellList lifecycle coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,12 @@ All notable changes to this project will be documented in this file.
   and `FullAnisotropic` Berendsen)
 - Coverage for `JCouplingType` and `JCouplingForceField` (operator==
   contract, getter/setter coverage, default symmetry flags)
+- Expanded coverage for `PhysicalData` energy/virial accumulators
+  (`addCoulombEnergy`, `addNonCoulombEnergy`, `addBondEnergy`,
+  `addAngleEnergy`, `addDihedralEnergy`, `addImproperEnergy`,
+  `addRingPolymerEnergy`, `addVirial`); and `CellList` lifecycle
+  (`activate`/`deactivate`/`isActive` toggle; `clone` preserves the
+  configured cell counts, neighbour-cell count, and activation state)
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31

--- a/tests/src/physicalData/testPhysicalData.cpp
+++ b/tests/src/physicalData/testPhysicalData.cpp
@@ -257,3 +257,67 @@ TEST_F(TestPhysicalData, addIntraNonCoulombEnergy)
     EXPECT_EQ(_physicalData->getIntraNonCoulombEnergy(), 1.0);
     EXPECT_EQ(_physicalData->getNonCoulombEnergy(), 1.0);
 }
+
+/* ---------- Energy accumulators (add… functions) ---------- */
+
+TEST_F(TestPhysicalData, addCoulombEnergy_accumulates)
+{
+    _physicalData->setCoulombEnergy(2.0);
+    _physicalData->addCoulombEnergy(3.5);
+    EXPECT_DOUBLE_EQ(_physicalData->getCoulombEnergy(), 5.5);
+}
+
+TEST_F(TestPhysicalData, addNonCoulombEnergy_accumulates)
+{
+    _physicalData->setNonCoulombEnergy(1.0);
+    _physicalData->addNonCoulombEnergy(0.25);
+    _physicalData->addNonCoulombEnergy(0.25);
+    EXPECT_DOUBLE_EQ(_physicalData->getNonCoulombEnergy(), 1.5);
+}
+
+TEST_F(TestPhysicalData, addBondEnergy_accumulates)
+{
+    _physicalData->setBondEnergy(0.0);
+    _physicalData->addBondEnergy(1.0);
+    _physicalData->addBondEnergy(2.0);
+    EXPECT_DOUBLE_EQ(_physicalData->getBondEnergy(), 3.0);
+}
+
+TEST_F(TestPhysicalData, addAngleEnergy_accumulates)
+{
+    _physicalData->setAngleEnergy(0.0);
+    _physicalData->addAngleEnergy(1.0);
+    _physicalData->addAngleEnergy(-0.5);
+    EXPECT_DOUBLE_EQ(_physicalData->getAngleEnergy(), 0.5);
+}
+
+TEST_F(TestPhysicalData, addDihedralEnergy_accumulates)
+{
+    _physicalData->setDihedralEnergy(0.0);
+    _physicalData->addDihedralEnergy(1.0);
+    EXPECT_DOUBLE_EQ(_physicalData->getDihedralEnergy(), 1.0);
+}
+
+TEST_F(TestPhysicalData, addImproperEnergy_accumulates)
+{
+    _physicalData->setImproperEnergy(0.0);
+    _physicalData->addImproperEnergy(1.5);
+    EXPECT_DOUBLE_EQ(_physicalData->getImproperEnergy(), 1.5);
+}
+
+TEST_F(TestPhysicalData, addRingPolymerEnergy_accumulates)
+{
+    _physicalData->setRingPolymerEnergy(0.0);
+    _physicalData->addRingPolymerEnergy(2.0);
+    _physicalData->addRingPolymerEnergy(3.0);
+    EXPECT_DOUBLE_EQ(_physicalData->getRingPolymerEnergy(), 5.0);
+}
+
+TEST_F(TestPhysicalData, addVirial_accumulates)
+{
+    const auto v0 = diagonalMatrix(linearAlgebra::Vec3D(1.0, 2.0, 3.0));
+    const auto v1 = diagonalMatrix(linearAlgebra::Vec3D(0.5, 0.5, 0.5));
+    _physicalData->setVirial(v0);
+    _physicalData->addVirial(v1);
+    EXPECT_EQ(_physicalData->getVirial(), v0 + v1);
+}

--- a/tests/src/simulationBox/testCelllist.cpp
+++ b/tests/src/simulationBox/testCelllist.cpp
@@ -206,6 +206,39 @@ TEST_F(TestCellList, checkCoulombCutoff)
     );
 }
 
+/* ---------- activate / deactivate / isActive ---------- */
+
+TEST_F(TestCellList, activateDeactivateToggles_isActive)
+{
+    _cellList->activate();
+    EXPECT_TRUE(_cellList->isActive());
+
+    _cellList->deactivate();
+    EXPECT_FALSE(_cellList->isActive());
+
+    _cellList->activate();
+    EXPECT_TRUE(_cellList->isActive());
+}
+
+/* ---------- clone() copies the configured cell counts ---------- */
+
+TEST_F(TestCellList, clone_preservesNumberOfCellsAndNeighbourCells)
+{
+    _cellList->setNumberOfCells(4);
+    _cellList->setNumberOfNeighbourCells(2);
+    _cellList->activate();
+
+    const auto cloned = _cellList->clone();
+
+    ASSERT_NE(cloned, nullptr);
+    EXPECT_EQ(cloned->getNumberOfCells(), _cellList->getNumberOfCells());
+    EXPECT_EQ(
+        cloned->getNumberOfNeighbourCells(),
+        _cellList->getNumberOfNeighbourCells()
+    );
+    EXPECT_EQ(cloned->isActive(), _cellList->isActive());
+}
+
 /**
  * @brief testing updateCellList and setup method
  *


### PR DESCRIPTION
Adds focused unit tests for previously-thin areas:

- **PhysicalData**: `addCoulombEnergy`, `addNonCoulombEnergy`, `addBondEnergy`, `addAngleEnergy`, `addDihedralEnergy`, `addImproperEnergy`, `addRingPolymerEnergy`, `addVirial` — each verifies the accumulator semantics over a `set` + multiple `add` calls.
- **CellList**: `activate`/`deactivate`/`isActive` toggle, and `clone` preserves the configured cell counts, neighbour-cell count, and activation state.

Linux build green; 115/115 unit tests pass.