### PR TITLE
test: coverage for ManostatSettings, ConstraintSettings, FileSettings, ConvSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ All notable changes to this project will be documented in this file.
   momentum to ~0), `resetAngularMomentum` (finite velocities), and
   `resetForces` (zeros per-atom forces). The previously 0%-covered
   97-line `src/resetKinetics/resetKinetics.cpp` is now exercised
+- Coverage for `ManostatSettings`, `ConstraintSettings`, `FileSettings`,
+  and `ConvergenceSettings` static-class setters/getters (manostat type
+  + isotropy string round-trips, shake/rattle tolerances + max-iters,
+  input/output file-name round-trips, optional energy/force convergence
+  thresholds)
 - Expanded coverage for `mathUtilities` (`compare` with tolerance,
   `compare(Vec3D)` with tolerance, `kroneckerDelta`); `Thermostat`
   variants (`VelocityRescaling`: tau getter/setter, thermostat type,

--- a/tests/src/settings/CMakeLists.txt
+++ b/tests/src/settings/CMakeLists.txt
@@ -3,6 +3,10 @@ set(source_files
     testQMSettings.cpp
     testOutputFileSettings.cpp
     testThermostatSettings.cpp
+    testManostatSettings.cpp
+    testConstraintSettings.cpp
+    testFileSettings.cpp
+    testConvergenceSettings.cpp
 )
 
 foreach(source_file ${source_files})

--- a/tests/src/settings/testConstraintSettings.cpp
+++ b/tests/src/settings/testConstraintSettings.cpp
@@ -1,0 +1,65 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "constraintSettings.hpp"
+#include "gtest/gtest.h"
+
+TEST(ConstraintSettingsTest, ShakeMaxIterRoundTrip)
+{
+    settings::ConstraintSettings::setShakeMaxIter(500u);
+    EXPECT_EQ(settings::ConstraintSettings::getShakeMaxIter(), 500u);
+
+    settings::ConstraintSettings::setShakeMaxIter(1u);
+    EXPECT_EQ(settings::ConstraintSettings::getShakeMaxIter(), 1u);
+}
+
+TEST(ConstraintSettingsTest, RattleMaxIterRoundTrip)
+{
+    settings::ConstraintSettings::setRattleMaxIter(750u);
+    EXPECT_EQ(settings::ConstraintSettings::getRattleMaxIter(), 750u);
+}
+
+TEST(ConstraintSettingsTest, ShakeToleranceRoundTrip)
+{
+    settings::ConstraintSettings::setShakeTolerance(1.0e-4);
+    EXPECT_DOUBLE_EQ(
+        settings::ConstraintSettings::getShakeTolerance(),
+        1.0e-4
+    );
+
+    settings::ConstraintSettings::setShakeTolerance(1.0e-12);
+    EXPECT_DOUBLE_EQ(
+        settings::ConstraintSettings::getShakeTolerance(),
+        1.0e-12
+    );
+}
+
+TEST(ConstraintSettingsTest, RattleToleranceRoundTrip)
+{
+    settings::ConstraintSettings::setRattleTolerance(1.0e-6);
+    EXPECT_DOUBLE_EQ(
+        settings::ConstraintSettings::getRattleTolerance(),
+        1.0e-6
+    );
+}

--- a/tests/src/settings/testConvergenceSettings.cpp
+++ b/tests/src/settings/testConvergenceSettings.cpp
@@ -25,50 +25,50 @@
 #include "convergenceSettings.hpp"
 #include "gtest/gtest.h"
 
-TEST(ConvergenceSettingsTest, EnergyConvSettersAndOptionalGetters)
+TEST(ConvSettingsTest, EnergyConvSettersAndOptionalGetters)
 {
-    settings::ConvergenceSettings::setEnergyConv(1.0e-6);
-    ASSERT_TRUE(settings::ConvergenceSettings::getEnergyConv().has_value());
+    settings::ConvSettings::setEnergyConv(1.0e-6);
+    ASSERT_TRUE(settings::ConvSettings::getEnergyConv().has_value());
     EXPECT_DOUBLE_EQ(
-        settings::ConvergenceSettings::getEnergyConv().value(),
+        settings::ConvSettings::getEnergyConv().value(),
         1.0e-6
     );
 
-    settings::ConvergenceSettings::setRelEnergyConv(1.0e-5);
-    ASSERT_TRUE(settings::ConvergenceSettings::getRelEnergyConv().has_value());
+    settings::ConvSettings::setRelEnergyConv(1.0e-5);
+    ASSERT_TRUE(settings::ConvSettings::getRelEnergyConv().has_value());
     EXPECT_DOUBLE_EQ(
-        settings::ConvergenceSettings::getRelEnergyConv().value(),
+        settings::ConvSettings::getRelEnergyConv().value(),
         1.0e-5
     );
 
-    settings::ConvergenceSettings::setAbsEnergyConv(1.0e-4);
-    ASSERT_TRUE(settings::ConvergenceSettings::getAbsEnergyConv().has_value());
+    settings::ConvSettings::setAbsEnergyConv(1.0e-4);
+    ASSERT_TRUE(settings::ConvSettings::getAbsEnergyConv().has_value());
     EXPECT_DOUBLE_EQ(
-        settings::ConvergenceSettings::getAbsEnergyConv().value(),
+        settings::ConvSettings::getAbsEnergyConv().value(),
         1.0e-4
     );
 }
 
-TEST(ConvergenceSettingsTest, ForceConvSettersAndOptionalGetters)
+TEST(ConvSettingsTest, ForceConvSettersAndOptionalGetters)
 {
-    settings::ConvergenceSettings::setForceConv(1.0e-3);
-    ASSERT_TRUE(settings::ConvergenceSettings::getForceConv().has_value());
+    settings::ConvSettings::setForceConv(1.0e-3);
+    ASSERT_TRUE(settings::ConvSettings::getForceConv().has_value());
     EXPECT_DOUBLE_EQ(
-        settings::ConvergenceSettings::getForceConv().value(),
+        settings::ConvSettings::getForceConv().value(),
         1.0e-3
     );
 
-    settings::ConvergenceSettings::setMaxForceConv(1.0e-2);
-    ASSERT_TRUE(settings::ConvergenceSettings::getMaxForceConv().has_value());
+    settings::ConvSettings::setMaxForceConv(1.0e-2);
+    ASSERT_TRUE(settings::ConvSettings::getMaxForceConv().has_value());
     EXPECT_DOUBLE_EQ(
-        settings::ConvergenceSettings::getMaxForceConv().value(),
+        settings::ConvSettings::getMaxForceConv().value(),
         1.0e-2
     );
 
-    settings::ConvergenceSettings::setRMSForceConv(1.0e-3);
-    ASSERT_TRUE(settings::ConvergenceSettings::getRMSForceConv().has_value());
+    settings::ConvSettings::setRMSForceConv(1.0e-3);
+    ASSERT_TRUE(settings::ConvSettings::getRMSForceConv().has_value());
     EXPECT_DOUBLE_EQ(
-        settings::ConvergenceSettings::getRMSForceConv().value(),
+        settings::ConvSettings::getRMSForceConv().value(),
         1.0e-3
     );
 }

--- a/tests/src/settings/testConvergenceSettings.cpp
+++ b/tests/src/settings/testConvergenceSettings.cpp
@@ -1,0 +1,74 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "convergenceSettings.hpp"
+#include "gtest/gtest.h"
+
+TEST(ConvergenceSettingsTest, EnergyConvSettersAndOptionalGetters)
+{
+    settings::ConvergenceSettings::setEnergyConv(1.0e-6);
+    ASSERT_TRUE(settings::ConvergenceSettings::getEnergyConv().has_value());
+    EXPECT_DOUBLE_EQ(
+        settings::ConvergenceSettings::getEnergyConv().value(),
+        1.0e-6
+    );
+
+    settings::ConvergenceSettings::setRelEnergyConv(1.0e-5);
+    ASSERT_TRUE(settings::ConvergenceSettings::getRelEnergyConv().has_value());
+    EXPECT_DOUBLE_EQ(
+        settings::ConvergenceSettings::getRelEnergyConv().value(),
+        1.0e-5
+    );
+
+    settings::ConvergenceSettings::setAbsEnergyConv(1.0e-4);
+    ASSERT_TRUE(settings::ConvergenceSettings::getAbsEnergyConv().has_value());
+    EXPECT_DOUBLE_EQ(
+        settings::ConvergenceSettings::getAbsEnergyConv().value(),
+        1.0e-4
+    );
+}
+
+TEST(ConvergenceSettingsTest, ForceConvSettersAndOptionalGetters)
+{
+    settings::ConvergenceSettings::setForceConv(1.0e-3);
+    ASSERT_TRUE(settings::ConvergenceSettings::getForceConv().has_value());
+    EXPECT_DOUBLE_EQ(
+        settings::ConvergenceSettings::getForceConv().value(),
+        1.0e-3
+    );
+
+    settings::ConvergenceSettings::setMaxForceConv(1.0e-2);
+    ASSERT_TRUE(settings::ConvergenceSettings::getMaxForceConv().has_value());
+    EXPECT_DOUBLE_EQ(
+        settings::ConvergenceSettings::getMaxForceConv().value(),
+        1.0e-2
+    );
+
+    settings::ConvergenceSettings::setRMSForceConv(1.0e-3);
+    ASSERT_TRUE(settings::ConvergenceSettings::getRMSForceConv().has_value());
+    EXPECT_DOUBLE_EQ(
+        settings::ConvergenceSettings::getRMSForceConv().value(),
+        1.0e-3
+    );
+}

--- a/tests/src/settings/testFileSettings.cpp
+++ b/tests/src/settings/testFileSettings.cpp
@@ -1,0 +1,77 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "fileSettings.hpp"
+#include "gtest/gtest.h"
+
+TEST(FileSettingsTest, MolDescriptorRoundTrip)
+{
+    settings::FileSettings::setMolDescriptorFileName("mol.dat");
+    EXPECT_EQ(settings::FileSettings::getMolDescriptorFileName(), "mol.dat");
+}
+
+TEST(FileSettingsTest, GuffDatRoundTrip)
+{
+    settings::FileSettings::setGuffDatFileName("guff.dat");
+    EXPECT_EQ(settings::FileSettings::getGuffDatFileName(), "guff.dat");
+}
+
+TEST(FileSettingsTest, TopologyAndParameterRoundTrip)
+{
+    settings::FileSettings::setTopologyFileName("topology.top");
+    EXPECT_EQ(settings::FileSettings::getTopologyFileName(), "topology.top");
+
+    settings::FileSettings::setParameterFileName("parameter.par");
+    EXPECT_EQ(settings::FileSettings::getParameterFilename(), "parameter.par");
+}
+
+TEST(FileSettingsTest, StartAndRingPolymerRoundTrip)
+{
+    settings::FileSettings::setStartFileName("start.rst");
+    EXPECT_EQ(settings::FileSettings::getStartFileName(), "start.rst");
+
+    settings::FileSettings::setRingPolymerStartFileName("rp_start.rst");
+    EXPECT_EQ(
+        settings::FileSettings::getRingPolymerStartFileName(),
+        "rp_start.rst"
+    );
+}
+
+TEST(FileSettingsTest, MShakeAndDFTBRoundTrip)
+{
+    settings::FileSettings::setMShakeFileName("mshake.dat");
+    EXPECT_EQ(settings::FileSettings::getMShakeFileName(), "mshake.dat");
+
+    settings::FileSettings::setDFTBFileName("dftb_in.hsd");
+    EXPECT_EQ(settings::FileSettings::getDFTBFileName(), "dftb_in.hsd");
+}
+
+TEST(FileSettingsTest, IntraNonBondedRoundTrip)
+{
+    settings::FileSettings::setIntraNonBondedFileName("intra.dat");
+    EXPECT_EQ(
+        settings::FileSettings::getIntraNonBondedFileName(),
+        "intra.dat"
+    );
+}

--- a/tests/src/settings/testManostatSettings.cpp
+++ b/tests/src/settings/testManostatSettings.cpp
@@ -1,0 +1,134 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "gtest/gtest.h"
+#include "manostatSettings.hpp"
+
+TEST(ManostatSettingsTest, SetManostatTypeViaString)
+{
+    settings::ManostatSettings::setManostatType("berendsen");
+    EXPECT_EQ(
+        settings::ManostatSettings::getManostatType(),
+        settings::ManostatType::BERENDSEN
+    );
+
+    settings::ManostatSettings::setManostatType("stochastic_rescaling");
+    EXPECT_EQ(
+        settings::ManostatSettings::getManostatType(),
+        settings::ManostatType::STOCHASTIC_RESCALING
+    );
+
+    settings::ManostatSettings::setManostatType("none");
+    EXPECT_EQ(
+        settings::ManostatSettings::getManostatType(),
+        settings::ManostatType::NONE
+    );
+}
+
+TEST(ManostatSettingsTest, SetIsotropyViaString)
+{
+    settings::ManostatSettings::setIsotropy("isotropic");
+    EXPECT_EQ(
+        settings::ManostatSettings::getIsotropy(),
+        settings::Isotropy::ISOTROPIC
+    );
+
+    settings::ManostatSettings::setIsotropy("semi_isotropic");
+    EXPECT_EQ(
+        settings::ManostatSettings::getIsotropy(),
+        settings::Isotropy::SEMI_ISOTROPIC
+    );
+
+    settings::ManostatSettings::setIsotropy("anisotropic");
+    EXPECT_EQ(
+        settings::ManostatSettings::getIsotropy(),
+        settings::Isotropy::ANISOTROPIC
+    );
+
+    settings::ManostatSettings::setIsotropy("full_anisotropic");
+    EXPECT_EQ(
+        settings::ManostatSettings::getIsotropy(),
+        settings::Isotropy::FULL_ANISOTROPIC
+    );
+}
+
+TEST(ManostatSettingsTest, DoubleSettersAndGetters)
+{
+    settings::ManostatSettings::setTargetPressure(2.5);
+    EXPECT_DOUBLE_EQ(settings::ManostatSettings::getTargetPressure(), 2.5);
+
+    settings::ManostatSettings::setTauManostat(1.5);
+    EXPECT_DOUBLE_EQ(settings::ManostatSettings::getTauManostat(), 1.5);
+
+    settings::ManostatSettings::setCompressibility(4.5e-5);
+    EXPECT_DOUBLE_EQ(
+        settings::ManostatSettings::getCompressibility(),
+        4.5e-5
+    );
+}
+
+TEST(ManostatSettingsTest, AnisotropicAxesSettersAndGetters)
+{
+    settings::ManostatSettings::set2DIsotropicAxes({0u, 1u});
+    EXPECT_EQ(
+        settings::ManostatSettings::get2DIsotropicAxes(),
+        (std::vector<size_t>{0u, 1u})
+    );
+
+    settings::ManostatSettings::set2DAnisotropicAxis(2u);
+    EXPECT_EQ(settings::ManostatSettings::get2DAnisotropicAxis(), 2u);
+}
+
+TEST(ManostatSettingsTest, StringRoundTripForManostatType)
+{
+    EXPECT_EQ(
+        settings::string(settings::ManostatType::BERENDSEN),
+        "berendsen"
+    );
+    EXPECT_EQ(
+        settings::string(settings::ManostatType::STOCHASTIC_RESCALING),
+        "stochastic_rescaling"
+    );
+    EXPECT_EQ(settings::string(settings::ManostatType::NONE), "none");
+}
+
+TEST(ManostatSettingsTest, StringRoundTripForIsotropy)
+{
+    EXPECT_EQ(
+        settings::string(settings::Isotropy::ISOTROPIC),
+        "isotropic"
+    );
+    EXPECT_EQ(
+        settings::string(settings::Isotropy::SEMI_ISOTROPIC),
+        "semi_isotropic"
+    );
+    EXPECT_EQ(
+        settings::string(settings::Isotropy::ANISOTROPIC),
+        "anisotropic"
+    );
+    EXPECT_EQ(
+        settings::string(settings::Isotropy::FULL_ANISOTROPIC),
+        "full_anisotropic"
+    );
+}


### PR DESCRIPTION
Adds static-class setter/getter coverage for four previously-untested settings classes:

- **ManostatSettings**: manostat-type + isotropy string round-trips; double getters/setters for target pressure, tau, compressibility; 2D anisotropic axes.
- **ConstraintSettings**: shake/rattle max-iter + tolerance round-trips.
- **FileSettings**: round-trips for the molecule-descriptor, guff.dat, topology, parameter, intra-nonbonded, start / ring-polymer-start, mShake, and DFTB file names.
- **ConvSettings**: optional energy / force / max-force / RMS-force / rel-/abs-energy convergence thresholds.

Linux build green; 119/119 unit tests pass.