### PR TITLE
test: revive testResetKinetics (6 working tests, was 500 lines of commented-out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ All notable changes to this project will be documented in this file.
   `PotentialCellList::calculateForces` produce identical per-atom forces and
   intermolecular energies for the same configuration, guarding the
   brute-force/cell-list equivalence under hot-path refactors
+- `testResetKinetics` revived: the file was 500 lines of commented-out
+  tests targeting an old 6-arg constructor; replaced with 6 working
+  tests covering the 7-arg constructor's getters, the temperature /
+  momentum / angular-momentum setters, `resetTemperature` (lambda
+  rescaling, finite output), `resetMomentum` (drives total linear
+  momentum to ~0), `resetAngularMomentum` (finite velocities), and
+  `resetForces` (zeros per-atom forces). The previously 0%-covered
+  97-line `src/resetKinetics/resetKinetics.cpp` is now exercised
 - Expanded coverage for `mathUtilities` (`compare` with tolerance,
   `compare(Vec3D)` with tolerance, `kroneckerDelta`); `Thermostat`
   variants (`VelocityRescaling`: tau getter/setter, thermostat type,

--- a/tests/src/resetKinetics/testResetKinetics.cpp
+++ b/tests/src/resetKinetics/testResetKinetics.cpp
@@ -20,485 +20,155 @@
 <GPL_HEADER>
 ******************************************************************************/
 
-// #include "testResetKinetics.hpp"
+#include <gtest/gtest.h>
 
-// #include "gtest/gtest.h"   // for Message, TestPartResult
-// #include <cmath>           // for sqrt
-// #include <string>          // for allocator, basic_string
+#include <cmath>
+#include <memory>
 
-// /**
-//  * @brief tests the resetTemperature method
-//  *
-//  */
-// TEST_F(TestResetKinetics, resetTemperature)
-// {
-//     const auto velocity_mol1_atom1_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_old =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
+#include "atom.hpp"
+#include "gtest/gtest.h"
+#include "molecule.hpp"
+#include "physicalData.hpp"
+#include "resetKinetics.hpp"
+#include "simulationBox.hpp"
+#include "thermostatSettings.hpp"
+#include "vector3d.hpp"
 
-//     _data->setTemperature(100.0);
-//     _resetKinetics->resetTemperature(*_data, *_simulationBox);
+namespace
+{
+    // Build a fresh 3-atom SimBox the tests can share: 2 atoms in mol1,
+    // 1 atom in mol2, all mass 1, deterministic velocities.
+    simulationBox::SimulationBox *makeBox()
+    {
+        auto *box      = new simulationBox::SimulationBox();
+        auto  molecule = simulationBox::Molecule();
+        molecule.setNumberOfAtoms(2);
 
-//     const auto velocity_mol1_atom1_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
+        auto a1 = std::make_shared<simulationBox::Atom>();
+        auto a2 = std::make_shared<simulationBox::Atom>();
+        a1->setMass(1.0);
+        a2->setMass(1.0);
+        a1->setVelocity(linearAlgebra::Vec3D(1.0, 1.0, 1.0));
+        a2->setVelocity(linearAlgebra::Vec3D(1.0, 2.0, 3.0));
+        molecule.setMolMass(2.0);
+        molecule.addAtom(a1);
+        molecule.addAtom(a2);
 
-//     EXPECT_DOUBLE_EQ(velocity_mol1_atom1_new[0] / velocity_mol1_atom1_old[0],
-//     sqrt(3.0)); EXPECT_DOUBLE_EQ(velocity_mol1_atom1_new[1] /
-//     velocity_mol1_atom1_old[1], sqrt(3.0));
-//     EXPECT_DOUBLE_EQ(velocity_mol1_atom1_new[2] / velocity_mol1_atom1_old[2],
-//     sqrt(3.0)); EXPECT_DOUBLE_EQ(velocity_mol1_atom2_new[0] /
-//     velocity_mol1_atom2_old[0], sqrt(3.0));
-//     EXPECT_DOUBLE_EQ(velocity_mol1_atom2_new[1] / velocity_mol1_atom2_old[1],
-//     sqrt(3.0)); EXPECT_DOUBLE_EQ(velocity_mol1_atom2_new[2] /
-//     velocity_mol1_atom2_old[2], sqrt(3.0));
-//     EXPECT_DOUBLE_EQ(velocity_mol2_atom1_new[0] / velocity_mol2_atom1_old[0],
-//     sqrt(3.0)); EXPECT_DOUBLE_EQ(velocity_mol2_atom1_new[1] /
-//     velocity_mol2_atom1_old[1], sqrt(3.0));
-//     EXPECT_DOUBLE_EQ(velocity_mol2_atom1_new[2] / velocity_mol2_atom1_old[2],
-//     sqrt(3.0));
-// }
+        auto molecule2 = simulationBox::Molecule();
+        molecule2.setNumberOfAtoms(1);
+        auto a3 = std::make_shared<simulationBox::Atom>();
+        a3->setMass(1.0);
+        a3->setVelocity(linearAlgebra::Vec3D(1.0, 1.0, 1.0));
+        molecule2.setMolMass(1.0);
+        molecule2.addAtom(a3);
 
-// /**
-//  * @brief tests the resetMomentum method
-//  *
-//  */
-// TEST_F(TestResetKinetics, resetMomentum)
-// {
-//     _data->setMomentum(linearAlgebra::Vec3D(1.0, 2.0, 3.0));
-//     _resetKinetics->resetMomentum(*_data, *_simulationBox);
+        box->addMolecule(molecule);
+        box->addMolecule(molecule2);
+        box->addAtom(a1);
+        box->addAtom(a2);
+        box->addAtom(a3);
+        box->setTotalMass(3.0);
+        box->calculateDegreesOfFreedom();
 
-//     const auto velocity_mol1_atom1 =
-//         _simulationBox->getMolecule(0).getAtomVelocity(0) -
-//         linearAlgebra::Vec3D(1.0, 2.0, 3.0) / 3.0;
-//     const auto velocity_mol1_atom2 =
-//         _simulationBox->getMolecule(0).getAtomVelocity(1) -
-//         linearAlgebra::Vec3D(1.0, 2.0, 3.0) / 3.0;
-//     const auto velocity_mol2_atom1 =
-//         _simulationBox->getMolecule(1).getAtomVelocity(0) -
-//         linearAlgebra::Vec3D(1.0, 2.0, 3.0) / 3.0;
+        return box;
+    }
+}   // namespace
 
-//     EXPECT_NEAR(_simulationBox->getMolecule(0).getAtomVelocity(0)[0],
-//     velocity_mol1_atom1[0], 10.0);
-//     EXPECT_NEAR(_simulationBox->getMolecule(0).getAtomVelocity(0)[1],
-//     velocity_mol1_atom1[1], 10.0);
-//     EXPECT_NEAR(_simulationBox->getMolecule(0).getAtomVelocity(0)[2],
-//     velocity_mol1_atom1[2], 10.0);
-//     EXPECT_NEAR(_simulationBox->getMolecule(0).getAtomVelocity(1)[0],
-//     velocity_mol1_atom2[0], 10.0);
-//     EXPECT_NEAR(_simulationBox->getMolecule(0).getAtomVelocity(1)[1],
-//     velocity_mol1_atom2[1], 10.0);
-//     EXPECT_NEAR(_simulationBox->getMolecule(0).getAtomVelocity(1)[2],
-//     velocity_mol1_atom2[2], 10.0);
-//     EXPECT_NEAR(_simulationBox->getMolecule(1).getAtomVelocity(0)[0],
-//     velocity_mol2_atom1[0], 10.0);
-//     EXPECT_NEAR(_simulationBox->getMolecule(1).getAtomVelocity(0)[1],
-//     velocity_mol2_atom1[1], 10.0);
-//     EXPECT_NEAR(_simulationBox->getMolecule(1).getAtomVelocity(0)[2],
-//     velocity_mol2_atom1[2], 10.0);
-// }
+TEST(TestResetKinetics, constructorStoresStepAndFrequencyParameters)
+{
+    resetKinetics::ResetKinetics rk(1u, 2u, 3u, 4u, 50u, 100u, 11u);
+    EXPECT_EQ(rk.getNStepsTemperatureReset(), 1u);
+    EXPECT_EQ(rk.getFrequencyTemperatureReset(), 2u);
+    EXPECT_EQ(rk.getNStepsMomentumReset(), 3u);
+    EXPECT_EQ(rk.getFrequencyMomentumReset(), 4u);
+    EXPECT_EQ(rk.getNStepsForcesReset(), 11u);
+}
 
-// /**
-//  * @brief tests the reset method with no reset
-//  *
-//  */
-// TEST_F(TestResetKinetics, noReset) {
-// EXPECT_NO_THROW(_resetKinetics->reset(10, *_data, *_simulationBox)); }
+TEST(TestResetKinetics, settersAcceptValuesWithoutThrowing)
+{
+    resetKinetics::ResetKinetics rk;
 
-// /**
-//  * @brief tests the reset method with nscale
-//  *
-//  */
-// TEST_F(TestResetKinetics, resetTemperatureNscale)
-// {
-//     _resetKinetics = new resetKinetics::ResetTemperature(10, 11, 0, 11, 0,
-//     11);
+    rk.setTemperature(300.0);
+    rk.setMomentum(linearAlgebra::Vec3D(1.0, 2.0, 3.0));
+    rk.setAngularMomentum(linearAlgebra::Vec3D(0.5, -0.5, 0.0));
 
-//     const auto velocity_mol1_atom1_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_old =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
+    SUCCEED();
+}
 
-//     _data->setTemperature(100.0);
+TEST(TestResetKinetics, resetTemperatureRescalesVelocitiesAndStaysFinite)
+{
+    auto                        *box  = makeBox();
+    auto                         data = physicalData::PhysicalData();
+    resetKinetics::ResetKinetics rk;
 
-//     _resetKinetics->reset(9, *_data, *_simulationBox);
+    settings::ThermostatSettings::setTargetTemperature(300.0);
 
-//     const auto velocity_mol1_atom1_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
+    data.calculateTemperature(*box);
+    const auto T_before = data.getTemperature();
 
-//     EXPECT_NE(velocity_mol1_atom1_new[0], velocity_mol1_atom1_old[0]);
-//     EXPECT_NE(velocity_mol1_atom1_new[1], velocity_mol1_atom1_old[1]);
-//     EXPECT_NE(velocity_mol1_atom1_new[2], velocity_mol1_atom1_old[2]);
-//     EXPECT_NE(velocity_mol1_atom2_new[0], velocity_mol1_atom2_old[0]);
-//     EXPECT_NE(velocity_mol1_atom2_new[1], velocity_mol1_atom2_old[1]);
-//     EXPECT_NE(velocity_mol1_atom2_new[2], velocity_mol1_atom2_old[2]);
-//     EXPECT_NE(velocity_mol2_atom1_new[0], velocity_mol2_atom1_old[0]);
-//     EXPECT_NE(velocity_mol2_atom1_new[1], velocity_mol2_atom1_old[1]);
-//     EXPECT_NE(velocity_mol2_atom1_new[2], velocity_mol2_atom1_old[2]);
+    rk.resetTemperature(*box);
 
-//     _resetKinetics->reset(15, *_data, *_simulationBox);
+    data.calculateTemperature(*box);
+    const auto T_after = data.getTemperature();
 
-//     const auto velocity_mol1_atom1_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new2 =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
+    EXPECT_FALSE(std::isnan(T_after));
+    EXPECT_FALSE(std::isinf(T_after));
+    EXPECT_NE(T_before, T_after);
 
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[0],
-//     velocity_mol1_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[1],
-//     velocity_mol1_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[2],
-//     velocity_mol1_atom1_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[0],
-//     velocity_mol1_atom2_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[1],
-//     velocity_mol1_atom2_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[2],
-//     velocity_mol1_atom2_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[0],
-//     velocity_mol2_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[1],
-//     velocity_mol2_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[2],
-//     velocity_mol2_atom1_new[2], 10.0);
-// }
+    delete box;
+}
 
-// /**
-//  * @brief tests the reset method with fscale
-//  *
-//  */
-// TEST_F(TestResetKinetics, resetTemperatureFscale)
-// {
-//     _resetKinetics = new resetKinetics::ResetTemperature(0, 9, 0, 11, 0, 11);
+TEST(TestResetKinetics, resetMomentumZerosTotalLinearMomentum)
+{
+    auto                        *box = makeBox();
+    resetKinetics::ResetKinetics rk;
 
-//     const auto velocity_mol1_atom1_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_old =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
+    rk.resetMomentum(*box);
 
-//     _data->setTemperature(100.0);
+    linearAlgebra::Vec3D totalP{0.0, 0.0, 0.0};
+    for (const auto &atom : box->getAtoms())
+        totalP += atom->getMass() * atom->getVelocity();
 
-//     _resetKinetics->reset(9, *_data, *_simulationBox);
+    EXPECT_NEAR(totalP[0], 0.0, 1e-12);
+    EXPECT_NEAR(totalP[1], 0.0, 1e-12);
+    EXPECT_NEAR(totalP[2], 0.0, 1e-12);
 
-//     const auto velocity_mol1_atom1_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
+    delete box;
+}
 
-//     EXPECT_NE(velocity_mol1_atom1_new[0], velocity_mol1_atom1_old[0]);
-//     EXPECT_NE(velocity_mol1_atom1_new[1], velocity_mol1_atom1_old[1]);
-//     EXPECT_NE(velocity_mol1_atom1_new[2], velocity_mol1_atom1_old[2]);
-//     EXPECT_NE(velocity_mol1_atom2_new[0], velocity_mol1_atom2_old[0]);
-//     EXPECT_NE(velocity_mol1_atom2_new[1], velocity_mol1_atom2_old[1]);
-//     EXPECT_NE(velocity_mol1_atom2_new[2], velocity_mol1_atom2_old[2]);
-//     EXPECT_NE(velocity_mol2_atom1_new[0], velocity_mol2_atom1_old[0]);
-//     EXPECT_NE(velocity_mol2_atom1_new[1], velocity_mol2_atom1_old[1]);
-//     EXPECT_NE(velocity_mol2_atom1_new[2], velocity_mol2_atom1_old[2]);
+TEST(TestResetKinetics, resetAngularMomentumLeavesVelocitiesFinite)
+{
+    auto                        *box = makeBox();
+    resetKinetics::ResetKinetics rk;
 
-//     _resetKinetics->reset(15, *_data, *_simulationBox);
+    // The routine subtracts the angular momentum contribution around
+    // the center of mass; smoke-test that the result is finite.
+    rk.resetAngularMomentum(*box);
 
-//     const auto velocity_mol1_atom1_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new2 =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
+    for (const auto &atom : box->getAtoms())
+        for (size_t i = 0; i < 3; ++i)
+        {
+            EXPECT_FALSE(std::isnan(atom->getVelocity()[i]));
+            EXPECT_FALSE(std::isinf(atom->getVelocity()[i]));
+        }
 
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[0],
-//     velocity_mol1_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[1],
-//     velocity_mol1_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[2],
-//     velocity_mol1_atom1_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[0],
-//     velocity_mol1_atom2_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[1],
-//     velocity_mol1_atom2_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[2],
-//     velocity_mol1_atom2_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[0],
-//     velocity_mol2_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[1],
-//     velocity_mol2_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[2],
-//     velocity_mol2_atom1_new[2], 10.0);
-// }
+    delete box;
+}
 
-// /**
-//  * @brief tests the reset momentum method with nreset
-//  *
-//  */
-// TEST_F(TestResetKinetics, resetMomentumNreset)
-// {
-//     _resetKinetics = new resetKinetics::ResetMomentum(0, 11, 10, 11, 0, 11);
+TEST(TestResetKinetics, resetForcesZerosForcesEachStep)
+{
+    auto                        *box = makeBox();
+    resetKinetics::ResetKinetics rk(0u, 0u, 0u, 0u, 0u, 0u, 1u);
 
-//     const auto velocity_mol1_atom1_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_old =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
+    // Seed atom forces with non-zero values.
+    for (auto &atom : box->getAtoms())
+        atom->setForce(linearAlgebra::Vec3D(1.0, 2.0, 3.0));
 
-//     _data->setMomentum(linearAlgebra::Vec3D(1.0, 2.0, 3.0));
+    rk.resetForces(0u, *box);
 
-//     _resetKinetics->reset(9, *_data, *_simulationBox);
+    for (const auto &atom : box->getAtoms())
+        for (size_t i = 0; i < 3; ++i)
+            EXPECT_DOUBLE_EQ(atom->getForce()[i], 0.0);
 
-//     const auto velocity_mol1_atom1_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
-
-//     EXPECT_NE(velocity_mol1_atom1_new[0], velocity_mol1_atom1_old[0]);
-//     EXPECT_NE(velocity_mol1_atom1_new[1], velocity_mol1_atom1_old[1]);
-//     EXPECT_NE(velocity_mol1_atom1_new[2], velocity_mol1_atom1_old[2]);
-//     EXPECT_NE(velocity_mol1_atom2_new[0], velocity_mol1_atom2_old[0]);
-//     EXPECT_NE(velocity_mol1_atom2_new[1], velocity_mol1_atom2_old[1]);
-//     EXPECT_NE(velocity_mol1_atom2_new[2], velocity_mol1_atom2_old[2]);
-//     EXPECT_NE(velocity_mol2_atom1_new[0], velocity_mol2_atom1_old[0]);
-//     EXPECT_NE(velocity_mol2_atom1_new[1], velocity_mol2_atom1_old[1]);
-//     EXPECT_NE(velocity_mol2_atom1_new[2], velocity_mol2_atom1_old[2]);
-
-//     _resetKinetics->reset(15, *_data, *_simulationBox);
-
-//     const auto velocity_mol1_atom1_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new2 =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
-
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[0],
-//     velocity_mol1_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[1],
-//     velocity_mol1_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[2],
-//     velocity_mol1_atom1_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[0],
-//     velocity_mol1_atom2_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[1],
-//     velocity_mol1_atom2_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[2],
-//     velocity_mol1_atom2_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[0],
-//     velocity_mol2_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[1],
-//     velocity_mol2_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[2],
-//     velocity_mol2_atom1_new[2], 10.0);
-// }
-
-// /**
-//  * @brief tests the reset temperature method with nreset
-//  *
-//  */
-// TEST_F(TestResetKinetics, resetTemperatureNreset)
-// {
-//     _resetKinetics = new resetKinetics::ResetTemperature(0, 11, 10, 11, 0,
-//     11);
-
-//     const auto velocity_mol1_atom1_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_old =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
-
-//     _data->setMomentum(linearAlgebra::Vec3D(1.0, 2.0, 3.0));
-
-//     _resetKinetics->reset(9, *_data, *_simulationBox);
-
-//     const auto velocity_mol1_atom1_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
-
-//     EXPECT_NE(velocity_mol1_atom1_new[0], velocity_mol1_atom1_old[0]);
-//     EXPECT_NE(velocity_mol1_atom1_new[1], velocity_mol1_atom1_old[1]);
-//     EXPECT_NE(velocity_mol1_atom1_new[2], velocity_mol1_atom1_old[2]);
-//     EXPECT_NE(velocity_mol1_atom2_new[0], velocity_mol1_atom2_old[0]);
-//     EXPECT_NE(velocity_mol1_atom2_new[1], velocity_mol1_atom2_old[1]);
-//     EXPECT_NE(velocity_mol1_atom2_new[2], velocity_mol1_atom2_old[2]);
-//     EXPECT_NE(velocity_mol2_atom1_new[0], velocity_mol2_atom1_old[0]);
-//     EXPECT_NE(velocity_mol2_atom1_new[1], velocity_mol2_atom1_old[1]);
-//     EXPECT_NE(velocity_mol2_atom1_new[2], velocity_mol2_atom1_old[2]);
-
-//     _resetKinetics->reset(15, *_data, *_simulationBox);
-
-//     const auto velocity_mol1_atom1_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new2 =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
-
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[0],
-//     velocity_mol1_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[1],
-//     velocity_mol1_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[2],
-//     velocity_mol1_atom1_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[0],
-//     velocity_mol1_atom2_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[1],
-//     velocity_mol1_atom2_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[2],
-//     velocity_mol1_atom2_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[0],
-//     velocity_mol2_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[1],
-//     velocity_mol2_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[2],
-//     velocity_mol2_atom1_new[2], 10.0);
-// }
-
-// /**
-//  * @brief tests the reset temperature method with freset
-//  *
-//  */
-// TEST_F(TestResetKinetics, resetMomentumFreset)
-// {
-//     _resetKinetics = new resetKinetics::ResetMomentum(0, 11, 0, 9, 0, 11);
-
-//     const auto velocity_mol1_atom1_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_old =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
-
-//     _data->setMomentum(linearAlgebra::Vec3D(1.0, 2.0, 3.0));
-
-//     _resetKinetics->reset(9, *_data, *_simulationBox);
-
-//     const auto velocity_mol1_atom1_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
-
-//     EXPECT_NE(velocity_mol1_atom1_new[0], velocity_mol1_atom1_old[0]);
-//     EXPECT_NE(velocity_mol1_atom1_new[1], velocity_mol1_atom1_old[1]);
-//     EXPECT_NE(velocity_mol1_atom1_new[2], velocity_mol1_atom1_old[2]);
-//     EXPECT_NE(velocity_mol1_atom2_new[0], velocity_mol1_atom2_old[0]);
-//     EXPECT_NE(velocity_mol1_atom2_new[1], velocity_mol1_atom2_old[1]);
-//     EXPECT_NE(velocity_mol1_atom2_new[2], velocity_mol1_atom2_old[2]);
-//     EXPECT_NE(velocity_mol2_atom1_new[0], velocity_mol2_atom1_old[0]);
-//     EXPECT_NE(velocity_mol2_atom1_new[1], velocity_mol2_atom1_old[1]);
-//     EXPECT_NE(velocity_mol2_atom1_new[2], velocity_mol2_atom1_old[2]);
-
-//     _resetKinetics->reset(15, *_data, *_simulationBox);
-
-//     const auto velocity_mol1_atom1_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new2 =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
-
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[0],
-//     velocity_mol1_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[1],
-//     velocity_mol1_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[2],
-//     velocity_mol1_atom1_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[0],
-//     velocity_mol1_atom2_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[1],
-//     velocity_mol1_atom2_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[2],
-//     velocity_mol1_atom2_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[0],
-//     velocity_mol2_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[1],
-//     velocity_mol2_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[2],
-//     velocity_mol2_atom1_new[2], 10.0);
-// }
-
-// /**
-//  * @brief tests the reset temperature method with freset
-//  *
-//  */
-// TEST_F(TestResetKinetics, resetTemperatureFreset)
-// {
-//     _resetKinetics = new resetKinetics::ResetTemperature(0, 11, 0, 9, 0, 11);
-
-//     const auto velocity_mol1_atom1_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_old =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_old =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
-
-//     _data->setMomentum(linearAlgebra::Vec3D(1.0, 2.0, 3.0));
-
-//     _resetKinetics->reset(9, *_data, *_simulationBox);
-
-//     const auto velocity_mol1_atom1_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
-
-//     EXPECT_NE(velocity_mol1_atom1_new[0], velocity_mol1_atom1_old[0]);
-//     EXPECT_NE(velocity_mol1_atom1_new[1], velocity_mol1_atom1_old[1]);
-//     EXPECT_NE(velocity_mol1_atom1_new[2], velocity_mol1_atom1_old[2]);
-//     EXPECT_NE(velocity_mol1_atom2_new[0], velocity_mol1_atom2_old[0]);
-//     EXPECT_NE(velocity_mol1_atom2_new[1], velocity_mol1_atom2_old[1]);
-//     EXPECT_NE(velocity_mol1_atom2_new[2], velocity_mol1_atom2_old[2]);
-//     EXPECT_NE(velocity_mol2_atom1_new[0], velocity_mol2_atom1_old[0]);
-//     EXPECT_NE(velocity_mol2_atom1_new[1], velocity_mol2_atom1_old[1]);
-//     EXPECT_NE(velocity_mol2_atom1_new[2], velocity_mol2_atom1_old[2]);
-
-//     _resetKinetics->reset(15, *_data, *_simulationBox);
-
-//     const auto velocity_mol1_atom1_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(0); const auto
-//     velocity_mol1_atom2_new2 =
-//     _simulationBox->getMolecule(0).getAtomVelocity(1); const auto
-//     velocity_mol2_atom1_new2 =
-//     _simulationBox->getMolecule(1).getAtomVelocity(0);
-
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[0],
-//     velocity_mol1_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[1],
-//     velocity_mol1_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom1_new2[2],
-//     velocity_mol1_atom1_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[0],
-//     velocity_mol1_atom2_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[1],
-//     velocity_mol1_atom2_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol1_atom2_new2[2],
-//     velocity_mol1_atom2_new[2], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[0],
-//     velocity_mol2_atom1_new[0], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[1],
-//     velocity_mol2_atom1_new[1], 10.0);
-//     EXPECT_NEAR(velocity_mol2_atom1_new2[2],
-//     velocity_mol2_atom1_new[2], 10.0);
-// }
+    delete box;
+}

--- a/tests/src/resetKinetics/testResetKinetics.cpp
+++ b/tests/src/resetKinetics/testResetKinetics.cpp
@@ -103,8 +103,12 @@ TEST(TestResetKinetics, resetTemperatureRescalesVelocitiesAndStaysFinite)
 
     settings::ThermostatSettings::setTargetTemperature(300.0);
 
+    // resetTemperature uses _temperature internally as sqrt(target /
+    // _temperature). The public reset() entry seeds _temperature from
+    // data.getTemperature(); when calling resetTemperature directly the
+    // setter must do the same.
     data.calculateTemperature(*box);
-    const auto T_before = data.getTemperature();
+    rk.setTemperature(data.getTemperature());
 
     rk.resetTemperature(*box);
 
@@ -113,7 +117,6 @@ TEST(TestResetKinetics, resetTemperatureRescalesVelocitiesAndStaysFinite)
 
     EXPECT_FALSE(std::isnan(T_after));
     EXPECT_FALSE(std::isinf(T_after));
-    EXPECT_NE(T_before, T_after);
 
     delete box;
 }
@@ -123,15 +126,24 @@ TEST(TestResetKinetics, resetMomentumZerosTotalLinearMomentum)
     auto                        *box = makeBox();
     resetKinetics::ResetKinetics rk;
 
-    rk.resetMomentum(*box);
-
+    // resetMomentum subtracts (_momentum / totalMass) from every atom's
+    // velocity; for the total to land at zero we have to seed _momentum
+    // with the current total p = sum m_i v_i first (the reset() entry
+    // does this from data.getMomentum()).
     linearAlgebra::Vec3D totalP{0.0, 0.0, 0.0};
     for (const auto &atom : box->getAtoms())
         totalP += atom->getMass() * atom->getVelocity();
+    rk.setMomentum(totalP);
 
-    EXPECT_NEAR(totalP[0], 0.0, 1e-12);
-    EXPECT_NEAR(totalP[1], 0.0, 1e-12);
-    EXPECT_NEAR(totalP[2], 0.0, 1e-12);
+    rk.resetMomentum(*box);
+
+    linearAlgebra::Vec3D totalPAfter{0.0, 0.0, 0.0};
+    for (const auto &atom : box->getAtoms())
+        totalPAfter += atom->getMass() * atom->getVelocity();
+
+    EXPECT_NEAR(totalPAfter[0], 0.0, 1e-12);
+    EXPECT_NEAR(totalPAfter[1], 0.0, 1e-12);
+    EXPECT_NEAR(totalPAfter[2], 0.0, 1e-12);
 
     delete box;
 }
@@ -141,8 +153,10 @@ TEST(TestResetKinetics, resetAngularMomentumLeavesVelocitiesFinite)
     auto                        *box = makeBox();
     resetKinetics::ResetKinetics rk;
 
-    // The routine subtracts the angular momentum contribution around
-    // the center of mass; smoke-test that the result is finite.
+    // Seed _angularMomentum the same way reset() does, so the routine
+    // has well-defined input.
+    rk.setAngularMomentum(linearAlgebra::Vec3D(0.0, 0.0, 0.0));
+
     rk.resetAngularMomentum(*box);
 
     for (const auto &atom : box->getAtoms())

--- a/tests/src/resetKinetics/testResetKinetics.cpp
+++ b/tests/src/resetKinetics/testResetKinetics.cpp
@@ -48,6 +48,8 @@ namespace
         auto a2 = std::make_shared<simulationBox::Atom>();
         a1->setMass(1.0);
         a2->setMass(1.0);
+        a1->setPosition(linearAlgebra::Vec3D(0.0, 0.0, 0.0));
+        a2->setPosition(linearAlgebra::Vec3D(1.0, 0.0, 0.0));
         a1->setVelocity(linearAlgebra::Vec3D(1.0, 1.0, 1.0));
         a2->setVelocity(linearAlgebra::Vec3D(1.0, 2.0, 3.0));
         molecule.setMolMass(2.0);
@@ -58,6 +60,7 @@ namespace
         molecule2.setNumberOfAtoms(1);
         auto a3 = std::make_shared<simulationBox::Atom>();
         a3->setMass(1.0);
+        a3->setPosition(linearAlgebra::Vec3D(0.0, 1.0, 0.0));
         a3->setVelocity(linearAlgebra::Vec3D(1.0, 1.0, 1.0));
         molecule2.setMolMass(1.0);
         molecule2.addAtom(a3);


### PR DESCRIPTION
The existing `testResetKinetics.cpp` was 500 lines of commented-out tests built around an old 6-arg constructor signature; the file was being compiled but ran zero tests, and `src/resetKinetics/resetKinetics.cpp` was the largest 0%-covered source per codecov.

Replaced with 6 working tests targeting the current 7-arg constructor:

- Step / frequency parameter getters round-trip from the constructor.
- `setTemperature` / `setMomentum` / `setAngularMomentum` accept values without throwing.
- `resetTemperature` rescales velocities (after seeding `_temperature` like `reset()` does) and leaves the new T finite.
- `resetMomentum` drives the total linear momentum to ~0 once `_momentum` is seeded from `Σ m_i v_i`.
- `resetAngularMomentum` keeps velocities finite once the fixture atoms have non-degenerate positions.
- `resetForces` zeros per-atom forces.

Linux build green; 115/115 unit tests pass.