### PR TITLE
fix: repair math review regressions

### DIFF
--- a/changes/math-review-concrete.bugfix.md
+++ b/changes/math-review-concrete.bugfix.md
@@ -1,0 +1,1 @@
+- Fix concrete math and force-kernel regressions found during the critical math review: count non-adjacent atom-type duplicates correctly, export brute-force and cell-list force kernels, keep Langevin sigma in sync with friction changes, and reject aliased periodic cell-list neighbor layouts.

--- a/src/potential/potentialBruteForce.cpp
+++ b/src/potential/potentialBruteForce.cpp
@@ -45,7 +45,7 @@ PotentialBruteForce::~PotentialBruteForce() = default;
  * @param simBox
  * @param physicalData
  */
-inline void PotentialBruteForce::
+void PotentialBruteForce::
     calculateForces(SimulationBox &simBox, PhysicalData &physicalData, CellList &)
 {
     startTimingsSection("InterNonBonded");

--- a/src/potential/potentialCellList.cpp
+++ b/src/potential/potentialCellList.cpp
@@ -55,7 +55,7 @@ PotentialCellList::~PotentialCellList() = default;
  * @param physicalData
  * @param cellList
  */
-inline void PotentialCellList::calculateForces(
+void PotentialCellList::calculateForces(
     SimulationBox &simBox,
     PhysicalData  &physicalData,
     CellList      &cellList

--- a/src/simulationBox/celllist.cpp
+++ b/src/simulationBox/celllist.cpp
@@ -142,6 +142,15 @@ void CellList::addNeighbouringCells(const double coulombCutoff)
 {
     _nNeighbourCells = Vec3Dul(ceil(coulombCutoff / _cellSize));
 
+    const auto requiredCells = _nNeighbourCells * 2 + 1;
+
+    for (size_t i = 0; i < 3; ++i)
+        if (_nCells[i] < requiredCells[i])
+            throw CellListException(
+                "Number of cells per dimension must be at least "
+                "2 * neighbour cells + 1."
+            );
+
     auto addCell = [this](auto &cell) { addNeighbouringCellPointers(cell); };
 
     std::ranges::for_each(_cells, addCell);

--- a/src/simulationBox/molecule.cpp
+++ b/src/simulationBox/molecule.cpp
@@ -64,9 +64,10 @@ size_t Molecule::getNumberOfAtomTypes()
 
     std::ranges::transform(_atoms, fill, getExternalAtomType);
 
-    const auto nUnique = std::ranges::size(std::ranges::unique(extAtomTypes));
+    std::ranges::sort(extAtomTypes);
+    const auto uniqueAtomTypes = std::ranges::unique(extAtomTypes);
 
-    return getNumberOfAtoms() - nUnique;
+    return std::ranges::distance(extAtomTypes.begin(), uniqueAtomTypes.begin());
 }
 
 /**

--- a/src/simulationBox/moleculeType.cpp
+++ b/src/simulationBox/moleculeType.cpp
@@ -51,9 +51,12 @@ MoleculeType::MoleculeType(const std::string_view &name) : _name(name){};
  */
 size_t MoleculeType::MoleculeType::getNumberOfAtomTypes()
 {
-    const auto nUnique = std::ranges::size(std::ranges::unique(_atomTypes));
+    auto atomTypes = _atomTypes;
 
-    return _externalAtomTypes.size() - nUnique;
+    std::ranges::sort(atomTypes);
+    const auto uniqueAtomTypes = std::ranges::unique(atomTypes);
+
+    return std::ranges::distance(atomTypes.begin(), uniqueAtomTypes.begin());
 }
 
 /**************************

--- a/src/thermostat/langevinThermostat.cpp
+++ b/src/thermostat/langevinThermostat.cpp
@@ -184,6 +184,7 @@ void LangevinThermostat::setTargetTemperature(const double targetTemperature)
 void LangevinThermostat::setFriction(const double friction)
 {
     _friction = friction;
+    calculateSigma(friction, _targetTemperature);
 }
 
 /**

--- a/tests/src/setup/testCelllistSetup.cpp
+++ b/tests/src/setup/testCelllistSetup.cpp
@@ -24,6 +24,7 @@
 #include "celllistSetup.hpp"   // for CellListSetup, setupCellList, setup
 #include "engine.hpp"          // for Engine
 #include "potential.hpp"       // for PotentialBruteForce, PotentialCellList
+#include "potentialSettings.hpp"   // for PotentialSettings
 #include "testSetup.hpp"       // for TestSetup
 
 #include "gtest/gtest.h"   // for Message, TestPartResult
@@ -43,6 +44,9 @@ TEST_F(TestSetup, setupCellList)
 
     EXPECT_EQ(typeid((_engine->getPotential())), typeid(potential::PotentialBruteForce));
 
+    settings::PotentialSettings::setCoulombRadiusCutOff(4.0);
+    _engine->getSimulationBox().setBoxDimensions({15.0, 15.0, 15.0});
+    _engine->getCellList().setNumberOfCells(3);
     _engine->getCellList().activate();
     cellListSetup.setup();
 

--- a/tests/src/setup/testOutputFilesSetup.cpp
+++ b/tests/src/setup/testOutputFilesSetup.cpp
@@ -50,8 +50,8 @@ namespace
             ".log",     ".info",    ".rst",     ".en",     ".xyz",
             ".timings", ".force",   ".instant_en", ".vel",  ".chrg",
             ".mom",     ".vir",     ".stress",  ".box",    ".rpmd.rst",
-            ".rpmd.xyz",".rpmd.vel",".rpmd.frc",".rpmd.chrg",".rpmd.en",
-            ".opt",     ".ref"
+            ".rpmd.xyz",".rpmd.vel",".rpmd.frc",".rpmd.force",".rpmd.chrg",
+            ".rpmd.en", ".opt",     ".ref"
         };
         for (const auto &s : suffixes)
             ::remove((std::string(_PREFIX) + s).c_str());

--- a/tests/src/simulationBox/testCelllist.cpp
+++ b/tests/src/simulationBox/testCelllist.cpp
@@ -189,6 +189,21 @@ TEST_F(TestCellList, addNeighbouringCells)
     );
 }
 
+TEST_F(TestCellList, addNeighbouringCellsRejectsAliasedPeriodicOffsets)
+{
+    _cellList->setNumberOfCells(2);
+    _cellList->determineCellSize(_simulationBox->getBoxDimensions());
+    _cellList->resizeCells();
+    _cellList->determineCellBoundaries(_simulationBox->getBoxDimensions());
+
+    EXPECT_THROW_MSG(
+        _cellList->addNeighbouringCells(4.0),
+        customException::CellListException,
+        "Number of cells per dimension must be at least "
+        "2 * neighbour cells + 1."
+    );
+}
+
 /**
  * @brief testing checkCoulombCutoff method
  *
@@ -247,7 +262,10 @@ TEST_F(TestCellList, clone_preservesNumberOfCellsAndNeighbourCells)
  */
 TEST_F(TestCellList, updateCellList)
 {
-    settings::PotentialSettings::setCoulombRadiusCutOff(22.0);
+    settings::PotentialSettings::setCoulombRadiusCutOff(4.0);
+    _cellList->setNumberOfCells(11);
+    _cellList->resizeCells();
+
     EXPECT_NO_THROW(_cellList->updateCellList(*_simulationBox));
     _cellList->activate();
 

--- a/tests/src/simulationBox/testMolecule.cpp
+++ b/tests/src/simulationBox/testMolecule.cpp
@@ -23,6 +23,7 @@
 #include "testMolecule.hpp"
 
 #include "gtest/gtest.h"         // for Message, TestPartResult
+#include "moleculeType.hpp"      // for MoleculeType
 #include "orthorhombicBox.hpp"   // for OrthorhombicBox
 #include "staticMatrix.hpp"      // for diagonalMatrix
 
@@ -72,4 +73,35 @@ TEST_F(TestMolecule, setAtomForceToZero)
 TEST_F(TestMolecule, getNumberOfAtomTypes)
 {
     EXPECT_EQ(_molecule->getNumberOfAtomTypes(), 2);
+}
+
+TEST_F(TestMolecule, getNumberOfAtomTypesCountsNonAdjacentDuplicates)
+{
+    auto molecule = simulationBox::Molecule();
+    molecule.setNumberOfAtoms(3);
+
+    const auto atom1 = std::make_shared<simulationBox::Atom>();
+    const auto atom2 = std::make_shared<simulationBox::Atom>();
+    const auto atom3 = std::make_shared<simulationBox::Atom>();
+
+    atom1->setExternalAtomType(1);
+    atom2->setExternalAtomType(2);
+    atom3->setExternalAtomType(1);
+
+    molecule.addAtom(atom1);
+    molecule.addAtom(atom2);
+    molecule.addAtom(atom3);
+
+    EXPECT_EQ(molecule.getNumberOfAtomTypes(), 2);
+}
+
+TEST_F(TestMolecule, moleculeTypeCountsNonAdjacentDuplicates)
+{
+    auto moleculeType = simulationBox::MoleculeType();
+
+    moleculeType.addAtomType(1);
+    moleculeType.addAtomType(2);
+    moleculeType.addAtomType(1);
+
+    EXPECT_EQ(moleculeType.getNumberOfAtomTypes(), 2);
 }

--- a/tests/src/thermostat/testThermostat.cpp
+++ b/tests/src/thermostat/testThermostat.cpp
@@ -257,6 +257,19 @@ TEST_F(TestThermostat, langevin_setTargetTemperatureRecomputesSigma)
     EXPECT_GT(sigmaAt600, sigmaAt300);
 }
 
+TEST_F(TestThermostat, langevin_setFrictionRecomputesSigma)
+{
+    auto langevin = thermostat::LangevinThermostat(300.0, 0.1);
+    settings::TimingsSettings::setTimeStep(0.1);
+    const auto sigmaAtFrictionPointOne = langevin.getSigma();
+
+    langevin.setFriction(0.5);
+    const auto sigmaAtFrictionPointFive = langevin.getSigma();
+
+    EXPECT_NE(sigmaAtFrictionPointOne, sigmaAtFrictionPointFive);
+    EXPECT_GT(sigmaAtFrictionPointFive, sigmaAtFrictionPointOne);
+}
+
 TEST_F(TestThermostat, langevin_thermostatType)
 {
     auto langevin = thermostat::LangevinThermostat(300.0, 0.1);


### PR DESCRIPTION
## Summary
- count molecule and molecule-type atom types after sorting, so non-adjacent duplicate types are not over-counted
- export the brute-force and cell-list `calculateForces` definitions by removing invalid out-of-line `inline` specifiers
- recompute Langevin `sigma` when friction changes, matching the existing target-temperature setter behavior
- reject periodic cell-list layouts where neighbor offsets alias the same cells, and update setup fixtures to use valid geometry
- fix RPMD output-file test cleanup so repeated full-suite runs do not collide on `ofsTest.rpmd.force`

## Root cause
- `std::ranges::unique` only compacts consecutive equal elements, so unsorted atom-type vectors produced wrong type counts for patterns like `1, 2, 1`.
- The force-kernel definitions lived in `.cpp` files but were marked `inline`, so consumers could fail to link the symbols.
- Langevin `setFriction()` updated `_friction` without updating the noise amplitude derived from friction and temperature.
- The half-neighbor cell-list stencil assumes enough cells per dimension to prevent periodic offset aliasing.

## Validation
- `cmake --build build-stochastic-rescale-ci --parallel 4`
- `ctest --test-dir build-stochastic-rescale-ci --output-on-failure --parallel 4` - 141/141 passed

## References
- `std::ranges::unique` removes duplicates from consecutive equivalent groups only: https://en.cppreference.com/w/cpp/algorithm/ranges/unique
- LAMMPS developer docs describe half neighbor-list stencils over nearby bins: https://docs.lammps.org/Developer_par_neigh.html

No reproducer ZIP is committed here; the repo now carries the actual fixes plus focused regression tests.
