### PR TITLE
fix: count non-adjacent atom types

### DIFF
--- a/changes/atom-type-counting.bugfix.md
+++ b/changes/atom-type-counting.bugfix.md
@@ -1,0 +1,1 @@
+- Count non-adjacent duplicate atom types correctly when determining molecule and molecule-type atom-type counts.

--- a/include/utilities/collectionUtilities.hpp
+++ b/include/utilities/collectionUtilities.hpp
@@ -1,0 +1,52 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#ifndef _COLLECTION_UTILITIES_HPP_
+
+#define _COLLECTION_UTILITIES_HPP_
+
+#include <algorithm>   // for ranges::sort, ranges::unique
+#include <vector>      // for vector
+
+namespace utilities
+{
+    /**
+     * @brief returns sorted unique elements from a vector copy
+     *
+     * @tparam T
+     * @param elements
+     * @return std::vector<T>
+     */
+    template <typename T>
+    [[nodiscard]] std::vector<T> getUniqueElements(std::vector<T> elements)
+    {
+        std::ranges::sort(elements);
+        const auto [first, last] = std::ranges::unique(elements);
+
+        elements.erase(first, last);
+
+        return elements;
+    }
+
+}   // namespace utilities
+
+#endif   // _COLLECTION_UTILITIES_HPP_

--- a/src/simulationBox/CMakeLists.txt
+++ b/src/simulationBox/CMakeLists.txt
@@ -45,6 +45,8 @@ target_include_directories(simulationBox
     PUBLIC
     ${PROJECT_SOURCE_DIR}/include/simulationBox
     ${PROJECT_SOURCE_DIR}/include/config
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/include/utilities
 )
 
 target_link_libraries(simulationBox

--- a/src/simulationBox/molecule.cpp
+++ b/src/simulationBox/molecule.cpp
@@ -22,12 +22,11 @@
 
 #include "molecule.hpp"
 
-#include <algorithm>    // for std::ranges::for_each
-#include <functional>   // for identity, equal_to
-#include <iterator>     // for _Size, size
-#include <ranges>       // for subrange
+#include <algorithm>   // for std::ranges::for_each, ranges::transform
+#include <iterator>    // for back_inserter
 
 #include "box.hpp"                // for Box
+#include "collectionUtilities.hpp"
 #include "manostatSettings.hpp"   // for ManostatSettings
 #include "vector3d.hpp"           // for Vec3D
 
@@ -64,9 +63,7 @@ size_t Molecule::getNumberOfAtomTypes()
 
     std::ranges::transform(_atoms, fill, getExternalAtomType);
 
-    const auto nUnique = std::ranges::size(std::ranges::unique(extAtomTypes));
-
-    return getNumberOfAtoms() - nUnique;
+    return utilities::getUniqueElements(extAtomTypes).size();
 }
 
 /**

--- a/src/simulationBox/moleculeType.cpp
+++ b/src/simulationBox/moleculeType.cpp
@@ -22,9 +22,7 @@
 
 #include "moleculeType.hpp"
 
-#include <algorithm>   // for sort, unique
-#include <iterator>    // for std::ranges::size
-#include <ranges>      // for ranges::size, ranges::unique
+#include "collectionUtilities.hpp"
 
 using namespace simulationBox;
 
@@ -45,15 +43,11 @@ MoleculeType::MoleculeType(const std::string_view &name) : _name(name){};
 /**
  * @brief finds number of different atom types in molecule
  *
- * @note This function cannot be const due to std::ranges::unique
- *
  * @return int
  */
 size_t MoleculeType::MoleculeType::getNumberOfAtomTypes()
 {
-    const auto nUnique = std::ranges::size(std::ranges::unique(_atomTypes));
-
-    return _externalAtomTypes.size() - nUnique;
+    return utilities::getUniqueElements(_atomTypes).size();
 }
 
 /**************************

--- a/tests/src/simulationBox/testMolecule.cpp
+++ b/tests/src/simulationBox/testMolecule.cpp
@@ -23,6 +23,7 @@
 #include "testMolecule.hpp"
 
 #include "gtest/gtest.h"         // for Message, TestPartResult
+#include "moleculeType.hpp"      // for MoleculeType
 #include "orthorhombicBox.hpp"   // for OrthorhombicBox
 #include "staticMatrix.hpp"      // for diagonalMatrix
 
@@ -72,4 +73,35 @@ TEST_F(TestMolecule, setAtomForceToZero)
 TEST_F(TestMolecule, getNumberOfAtomTypes)
 {
     EXPECT_EQ(_molecule->getNumberOfAtomTypes(), 2);
+}
+
+TEST_F(TestMolecule, getNumberOfAtomTypesCountsNonAdjacentDuplicates)
+{
+    auto molecule = simulationBox::Molecule();
+    molecule.setNumberOfAtoms(3);
+
+    const auto atom1 = std::make_shared<simulationBox::Atom>();
+    const auto atom2 = std::make_shared<simulationBox::Atom>();
+    const auto atom3 = std::make_shared<simulationBox::Atom>();
+
+    atom1->setExternalAtomType(1);
+    atom2->setExternalAtomType(2);
+    atom3->setExternalAtomType(1);
+
+    molecule.addAtom(atom1);
+    molecule.addAtom(atom2);
+    molecule.addAtom(atom3);
+
+    EXPECT_EQ(molecule.getNumberOfAtomTypes(), 2);
+}
+
+TEST_F(TestMolecule, moleculeTypeCountsNonAdjacentDuplicates)
+{
+    auto moleculeType = simulationBox::MoleculeType();
+
+    moleculeType.addAtomType(1);
+    moleculeType.addAtomType(2);
+    moleculeType.addAtomType(1);
+
+    EXPECT_EQ(moleculeType.getNumberOfAtomTypes(), 2);
 }

--- a/tests/src/utilities/CMakeLists.txt
+++ b/tests/src/utilities/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(source_files
     testStringUtilities.cpp
     testMathUtilities.cpp
+    testCollectionUtilities.cpp
 )
 
 foreach(source_file ${source_files})

--- a/tests/src/utilities/testCollectionUtilities.cpp
+++ b/tests/src/utilities/testCollectionUtilities.cpp
@@ -1,0 +1,50 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#include <gtest/gtest.h>   // for Test, EXPECT_EQ
+
+#include <string>   // for string
+#include <vector>   // for vector
+
+#include "collectionUtilities.hpp"   // for getUniqueElements
+
+/**
+ * @brief getUniqueElements sorts elements and removes duplicates.
+ */
+TEST(TestCollectionUtilities, getUniqueElements)
+{
+    const auto elements       = std::vector<size_t>{3u, 1u, 2u, 1u, 3u};
+    const auto uniqueElements = utilities::getUniqueElements(elements);
+
+    EXPECT_EQ(uniqueElements, (std::vector<size_t>{1u, 2u, 3u}));
+}
+
+/**
+ * @brief getUniqueElements supports string vectors.
+ */
+TEST(TestCollectionUtilities, getUniqueElementsWithStrings)
+{
+    const auto elements = std::vector<std::string>{"O", "H", "O", "C", "H"};
+    const auto uniqueElements = utilities::getUniqueElements(elements);
+
+    EXPECT_EQ(uniqueElements, (std::vector<std::string>{"C", "H", "O"}));
+}


### PR DESCRIPTION
## Summary
- Add `utilities::getUniqueElements` for sorted unique vector values.
- Use the helper in `Molecule` and `MoleculeType` atom-type counting.
- Keep the non-adjacent duplicate regression and add direct helper coverage.

## Root cause
`std::ranges::unique` only compacts consecutive equivalent elements. Without sorting first, non-adjacent duplicate atom types were counted as separate atom types.

## Validation
- `ctest --test-dir build-pr271-static -R '^(testMolecule|testCollectionUtilities)$' --output-on-failure`

## Reference
- https://en.cppreference.com/w/cpp/algorithm/ranges/unique
