### PR TITLE
fix: export potential force kernels

### DIFF
--- a/changes/potential-force-linkage.bugfix.md
+++ b/changes/potential-force-linkage.bugfix.md
@@ -1,0 +1,1 @@
+- Export brute-force and cell-list force-kernel definitions so the potential equivalence test can link and run.

--- a/src/potential/potentialBruteForce.cpp
+++ b/src/potential/potentialBruteForce.cpp
@@ -45,7 +45,7 @@ PotentialBruteForce::~PotentialBruteForce() = default;
  * @param simBox
  * @param physicalData
  */
-inline void PotentialBruteForce::
+void PotentialBruteForce::
     calculateForces(SimulationBox &simBox, PhysicalData &physicalData, CellList &)
 {
     startTimingsSection("InterNonBonded");

--- a/src/potential/potentialCellList.cpp
+++ b/src/potential/potentialCellList.cpp
@@ -55,7 +55,7 @@ PotentialCellList::~PotentialCellList() = default;
  * @param physicalData
  * @param cellList
  */
-inline void PotentialCellList::calculateForces(
+void PotentialCellList::calculateForces(
     SimulationBox &simBox,
     PhysicalData  &physicalData,
     CellList      &cellList


### PR DESCRIPTION
## Summary
- Remove `inline` from the out-of-line `PotentialBruteForce::calculateForces` definition.
- Remove `inline` from the out-of-line `PotentialCellList::calculateForces` definition.
- This lets the existing brute-force/cell-list equivalence test link and run against the exported symbols.

## Root cause
These definitions live in `.cpp` files. Marking them `inline` there can leave no externally usable definition for other translation units that call through the public declarations.

## Validation
- `cmake --build build-stochastic-rescale-ci --target testBruteForceCellListEquivalence --parallel 4`
- `build-stochastic-rescale-ci/tests/src/potential/testBruteForceCellListEquivalence`

## Reference
- https://en.cppreference.com/w/cpp/language/inline
