### PR TITLE
fix: refresh Langevin sigma on friction changes

### DIFF
--- a/changes/langevin-friction-sigma.bugfix.md
+++ b/changes/langevin-friction-sigma.bugfix.md
@@ -1,0 +1,1 @@
+- Recompute the Langevin noise amplitude when friction changes so thermostat setters keep dependent state consistent.

--- a/src/thermostat/langevinThermostat.cpp
+++ b/src/thermostat/langevinThermostat.cpp
@@ -184,6 +184,7 @@ void LangevinThermostat::setTargetTemperature(const double targetTemperature)
 void LangevinThermostat::setFriction(const double friction)
 {
     _friction = friction;
+    calculateSigma(friction, _targetTemperature);
 }
 
 /**

--- a/tests/src/thermostat/testThermostat.cpp
+++ b/tests/src/thermostat/testThermostat.cpp
@@ -257,6 +257,19 @@ TEST_F(TestThermostat, langevin_setTargetTemperatureRecomputesSigma)
     EXPECT_GT(sigmaAt600, sigmaAt300);
 }
 
+TEST_F(TestThermostat, langevin_setFrictionRecomputesSigma)
+{
+    auto langevin = thermostat::LangevinThermostat(300.0, 0.1);
+    settings::TimingsSettings::setTimeStep(0.1);
+    const auto sigmaAtFrictionPointOne = langevin.getSigma();
+
+    langevin.setFriction(0.5);
+    const auto sigmaAtFrictionPointFive = langevin.getSigma();
+
+    EXPECT_NE(sigmaAtFrictionPointOne, sigmaAtFrictionPointFive);
+    EXPECT_GT(sigmaAtFrictionPointFive, sigmaAtFrictionPointOne);
+}
+
 TEST_F(TestThermostat, langevin_thermostatType)
 {
     auto langevin = thermostat::LangevinThermostat(300.0, 0.1);


### PR DESCRIPTION
## Summary
- Recompute `LangevinThermostat::_sigma` inside `setFriction()`.
- Add a regression test matching the existing target-temperature sigma recomputation test.

## Root cause
The Langevin noise amplitude is derived from friction and target temperature. `setTargetTemperature()` already refreshed `_sigma`, but `setFriction()` left the dependent state stale.

## Validation
- `cmake --build build-stochastic-rescale-ci --target testThermostat --parallel 4`
- `build-stochastic-rescale-ci/tests/src/thermostat/testThermostat`

## Reference
- Langevin dynamics random/noise term depends on friction and temperature: https://en.wikipedia.org/wiki/Langevin_dynamics
