### PR TITLE
refactor: rename keyword mace_model_size to mace_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 - Add FeNNol neural network potential as ASE QM runner
 - Add keywords "mshake-iter" and "mshake-tolerance"
 
+### Refactor
+
+- Rename keyword "mace_model_size" to "mace_model" and add deprecation warning
+
 ### Build
 
 - Faster builds: link-time optimization (`-flto`) is now opt-in via
@@ -110,6 +114,8 @@ All notable changes to this project will be documented in this file.
 - `utilities::isZero<T>(a)` helper added to `mathUtilities.hpp`,
   centralizing the exact-zero check (`a == T(0)`). Callers that need a
   tolerance can still use `compare(a, T(0), tol)`
+- Add option to queue warnings before the .log output file has been created 
+  and flush them to the file at the end of the setup
 
 ### Tests
 

--- a/docs/sphinx/src/userGuide/inputFile.rst
+++ b/docs/sphinx/src/userGuide/inputFile.rst
@@ -1418,17 +1418,17 @@ This can increase momentum conservation when using a QM program with limited num
 
 .. centered:: *default value* = false
 
-.. _maceModelSizeKey:
+.. _maceModelKey:
 
-MACE Model Size
-===============
+MACE Model
+==========
 
 .. admonition:: Key
     :class: tip
 
-    mace_model_size = {string} -> "medium"
+    mace_model = {string} -> "medium"
 
-With the ``mace_model_size`` keyword the user can specify the size of the `MACE <https://github.com/ACEsuit/mace>`_ model for the QM calculations.
+With the ``mace_model`` keyword the user can specify the `MACE <https://github.com/ACEsuit/mace>`_ model for the QM calculations.
 
 Possible options are:
 
@@ -1457,7 +1457,7 @@ Possible options are:
    12. **custom** - custom MACE model (to be set *via* the :ref:`mace_model_path <maceModelPathKey>` keyword)
 
 .. Note::
-    The :ref:`qm_prog <qmprogamKey>` option ``mace-off`` is only compatible with the first three model sizes: "small", "medium" and "large"
+    The :ref:`qm_prog <qmprogamKey>` option ``mace-off`` is only compatible with the first three models: "small", "medium" and "large"
 
 
 .. _maceModelPathKey:
@@ -1473,7 +1473,7 @@ MACE Model Path
 With the ``mace_model_path`` keyword the user can specify a custom URL corresponding to a `MACE <https://github.com/ACEsuit/mace-foundations?tab=readme-ov-file>`__ model for the QM calculations.
 
 .. Note::
-    The ``mace_model_path`` can only be specified if :ref:`mace_model_size <maceModelSizeKey>` keyword is set to ``custom``.
+    The ``mace_model_path`` can only be specified if :ref:`mace_model <maceModelKey>` keyword is set to ``custom``.
 
 
 .. _xtbMethodKey:

--- a/examples/acof1_mace/README.md
+++ b/examples/acof1_mace/README.md
@@ -22,6 +22,6 @@ The input file `run-01.in` contains the following settings:
 - `manostat = stochastic_rescaling`: Stochastic rescaling manostat (Bussi).
 - `isotropy = full_anisotropic`: Full anisotropic pressure coupling.
 - `qm_prog = mace_mp`: MACE-MP-0 model for the "QM" calculation.
-- `mace_model_size = large`: Large model size.
+- `mace_model = large`: Large MACE model.
 - `dispersion = true`: Dispersion correction on.
 - `floating_point_type = float`: Single precision.

--- a/examples/acof1_mace/run-01.in
+++ b/examples/acof1_mace/run-01.in
@@ -26,7 +26,7 @@
 
 # Mace Calculation Setup Keywords
       qm_prog = mace_mp;
-      mace_model_size = large;
+      mace_model = large;
       dispersion = true;
       floating_point_type = float;
 

--- a/examples/h2o_mace/README.md
+++ b/examples/h2o_mace/README.md
@@ -18,5 +18,5 @@ The input file `run-01.in` contains the following settings:
 
 - `jobtype = qm-md`: QM-MD simulation.
 - `qm_prog = mace_mp`: MACE-MP-0 model for the "QM" calculation.
-- `mace_model_size = medium`: Large model size.
+- `mace_model = medium`: Medium MACE model.
 - `floating_point_type = float`: Single precision.

--- a/examples/h2o_mace/run-01.in
+++ b/examples/h2o_mace/run-01.in
@@ -12,7 +12,7 @@
 
 # Mace Calculation Setup Keywords
       qm_prog = mace_mp;
-      mace_model_size = medium;
+      mace_model = medium;
       floating_point_type = float;
 
 # Files

--- a/examples/mof-5_mace/run-01.in
+++ b/examples/mof-5_mace/run-01.in
@@ -19,7 +19,7 @@
       qm_prog             = mace-mp;
       dispersion          = on;
       floating_point_type = float;
-      mace_model_size     = custom;
+      mace_model          = custom;
       mace_model_path     = https://github.com/ACEsuit/mace-foundations/releases/download/mace_matpes_0/MACE-matpes-pbe-omat-ft.model;
 
 

--- a/include/input/inputFileParser/QMInputParser.hpp
+++ b/include/input/inputFileParser/QMInputParser.hpp
@@ -52,7 +52,7 @@ namespace input
         void parseDispersion(const pq::strings &, const size_t);
         void parseRemoveNetForce(const pq::strings &, const size_t);
 
-        void parseMaceModelSize(const pq::strings &, const size_t);
+        void parseMaceModel(const pq::strings &, const size_t);
         void parseMaceModelPath(const pq::strings &, const size_t);
         void parseMaceQMMethod(const std::string_view &);
 

--- a/include/output/logOutput.hpp
+++ b/include/output/logOutput.hpp
@@ -24,7 +24,10 @@
 
 #define _LOG_OUTPUT_HPP_
 
+#include <string>
+
 #include "output.hpp"
+#include "typeAliases.hpp"
 
 namespace output
 {
@@ -55,6 +58,12 @@ namespace output
         void writeSetupWarning(const std::string &setupWarning);
         void writeSetupCompleted();
         void writeRead(const std::string &message, const std::string &file);
+
+        void queueWarning(const std::string &warning);
+        void flushQueuedWarnings();
+
+       private:
+        pq::strings _pendingWarnings;
     };
 
 }   // namespace output

--- a/include/settings/qmSettings.hpp
+++ b/include/settings/qmSettings.hpp
@@ -50,10 +50,10 @@ namespace settings
     };
 
     /**
-     * @class enum MaceModelSize
+     * @class enum MaceModel
      *
      */
-    enum class MaceModelSize : size_t
+    enum class MaceModel : size_t
     {
         SMALL,
         MEDIUM,
@@ -101,7 +101,7 @@ namespace settings
     };
 
     std::string string(const QMMethod method);
-    std::string string(const MaceModelSize model);
+    std::string string(const MaceModel model);
     std::string string(const MaceModelType model);
     std::string string(const XtbMethod method);
     std::string string(const SlakosType slakos);
@@ -119,7 +119,7 @@ namespace settings
     {
        private:
         static inline QMMethod      _qmMethod      = QMMethod::NONE;
-        static inline MaceModelSize _maceModelSize = MaceModelSize::MEDIUM;
+        static inline MaceModel     _maceModel     = MaceModel::MEDIUM;
         static inline MaceModelType _maceModelType = MaceModelType::MACE_MP;
         static inline SlakosType    _slakosType    = SlakosType::NONE;
         static inline XtbMethod     _xtbMethod     = XtbMethod::GFN2;
@@ -153,8 +153,8 @@ namespace settings
         static void setQMMethod(const std::string_view &method);
         static void setQMMethod(const QMMethod method);
 
-        static void setMaceModelSize(const std::string_view &model);
-        static void setMaceModelSize(const MaceModelSize model);
+        static void setMaceModel(const std::string_view &model);
+        static void setMaceModel(const MaceModel model);
         static void setMaceModelType(const std::string_view &model);
         static void setMaceModelType(const MaceModelType model);
         static void setMaceModelPath(const std::string_view &path);
@@ -188,7 +188,7 @@ namespace settings
          ***************************/
 
         [[nodiscard]] static QMMethod      getQMMethod();
-        [[nodiscard]] static MaceModelSize getMaceModelSize();
+        [[nodiscard]] static MaceModel     getMaceModel();
         [[nodiscard]] static MaceModelType getMaceModelType();
         [[nodiscard]] static std::string   getMaceModelPath();
 

--- a/src/engine/qmmdEngine.cpp
+++ b/src/engine/qmmdEngine.cpp
@@ -107,7 +107,7 @@ void QMMDEngine::setMaceQMRunner()
     const auto useDFTD   = QMSettings::useDispersionCorr();
     const auto fpType    = Settings::getFloatingPointPybindString();
 
-    auto maceModel = string(QMSettings::getMaceModelSize());
+    auto maceModel = string(QMSettings::getMaceModel());
 
     if (!modelPath.empty())
         maceModel = modelPath;

--- a/src/input/inputFileParser/QMInputParser.cpp
+++ b/src/input/inputFileParser/QMInputParser.cpp
@@ -28,6 +28,7 @@
 #include <sstream>         // for stringstream
 #include <unordered_map>   // for unordered_map
 
+#include "engine.hpp"             // for Engine
 #include "exceptions.hpp"         // for InputFileException, customException
 #include "hubbardDerivMap.hpp"    // for hubbardDerivMap3ob
 #include "qmSettings.hpp"         // for Settings
@@ -91,7 +92,13 @@ QMInputParser::QMInputParser(Engine &engine) : InputFileParser(engine)
 
     addKeyword(
         std::string("mace_model_size"),
-        bind_front(&QMInputParser::parseMaceModelSize, this),
+        bind_front(&QMInputParser::parseMaceModel, this),
+        false
+    );
+
+    addKeyword(
+        std::string("mace_model"),
+        bind_front(&QMInputParser::parseMaceModel, this),
         false
     );
 
@@ -291,63 +298,75 @@ void QMInputParser::parseRemoveNetForce(
 }
 
 /**
- * @brief parse the size of the Mace model
+ * @brief parse the Mace model
  *
  * @param lineElements
  * @param lineNumber
  *
- * @throws InputFileException if the size is not recognized
+ * @throws InputFileException if the model is not recognized
  */
-void QMInputParser::parseMaceModelSize(
+void QMInputParser::parseMaceModel(
     const std::vector<std::string> &lineElements,
     const size_t                    lineNumber
 )
 {
-    using enum MaceModelSize;
+    using enum MaceModel;
     checkCommand(lineElements, lineNumber);
+
+    auto      &logOutput = _engine.getLogOutput();
+    auto      &stdOut    = _engine.getStdoutOutput();
+    const auto modelSizeWarning =
+        "The keyword \"mace_model_size\" is deprecated and has been renamed to "
+        "\"mace_model\". It will be removed in a future release.";
+
+    if (lineElements[0] == "mace_model_size")
+    {
+        logOutput.queueWarning(modelSizeWarning);
+        stdOut.writeSetupWarning(modelSizeWarning);
+    }
 
     const auto size = toLowerAndReplaceDashesCopy(lineElements[2]);
 
     if ("small" == size)
-        QMSettings::setMaceModelSize(SMALL);
+        QMSettings::setMaceModel(SMALL);
 
     else if ("medium" == size)
-        QMSettings::setMaceModelSize(MEDIUM);
+        QMSettings::setMaceModel(MEDIUM);
 
     else if ("large" == size)
-        QMSettings::setMaceModelSize(LARGE);
+        QMSettings::setMaceModel(LARGE);
 
     else if ("small_0b" == size)
-        QMSettings::setMaceModelSize(SMALL0B);
+        QMSettings::setMaceModel(SMALL0B);
 
     else if ("medium_0b" == size)
-        QMSettings::setMaceModelSize(MEDIUM0B);
+        QMSettings::setMaceModel(MEDIUM0B);
 
     else if ("small_0b2" == size)
-        QMSettings::setMaceModelSize(SMALL0B2);
+        QMSettings::setMaceModel(SMALL0B2);
 
     else if ("medium_0b2" == size)
-        QMSettings::setMaceModelSize(MEDIUM0B2);
+        QMSettings::setMaceModel(MEDIUM0B2);
 
     else if ("large_0b2" == size)
-        QMSettings::setMaceModelSize(LARGE0B2);
+        QMSettings::setMaceModel(LARGE0B2);
 
     else if ("medium_0b3" == size)
-        QMSettings::setMaceModelSize(MEDIUM0B3);
+        QMSettings::setMaceModel(MEDIUM0B3);
 
     else if ("medium_mpa_0" == size)
-        QMSettings::setMaceModelSize(MEDIUMMPA0);
+        QMSettings::setMaceModel(MEDIUMMPA0);
 
     else if ("medium_omat_0" == size)
-        QMSettings::setMaceModelSize(MEDIUMOMAT0);
+        QMSettings::setMaceModel(MEDIUMOMAT0);
 
     else if ("custom" == size)
-        QMSettings::setMaceModelSize(CUSTOM);
+        QMSettings::setMaceModel(CUSTOM);
 
     else
         throw InputFileException(
             std::format(
-                "Invalid mace_model_size \"{}\" in input file.\n"
+                "Invalid mace_model \"{}\" in input file.\n"
                 "Possible values are: small, medium, large, small-0b,\n"
                 "medium-0b, small-0b2, medium-0b2, large-0b2, medium-0b3,\n"
                 "medium-mpa-0, medium-omat-0, custom",

--- a/src/output/logOutput.cpp
+++ b/src/output/logOutput.cpp
@@ -150,3 +150,28 @@ void LogOutput::writeRead(const std::string &message, const std::string &file)
 {
     _fp << readMessage(message, file) << '\n' << std::flush;
 }
+
+/**
+ * @brief add a warning message that will be printed after the output file has
+ * been created
+ *
+ */
+void LogOutput::queueWarning(const std::string &warning)
+{
+    _pendingWarnings.push_back(warning);
+}
+
+/**
+ * @brief flush pending warning messages to the output file
+ *
+ */
+void LogOutput::flushQueuedWarnings()
+{
+    for (const auto &message : _pendingWarnings)
+    {
+        writeSetupWarning(message);
+        writeEmptyLine();
+    }
+
+    _pendingWarnings.clear();
+}

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -27,7 +27,7 @@
 #include "exceptions.hpp"        // for customException
 #include "stringUtilities.hpp"   // for toLowerCopy
 
-using settings::MaceModelSize;
+using settings::MaceModel;
 using settings::MaceModelType;
 using settings::QMMethod;
 using settings::QMSettings;
@@ -66,11 +66,11 @@ std::string settings::string(const QMMethod method)
  * @param model
  * @return std::string
  */
-std::string settings::string(const MaceModelSize model)
+std::string settings::string(const MaceModel model)
 {
     switch (model)
     {
-        using enum MaceModelSize;
+        using enum MaceModel;
 
         case SMALL: return "small";
         case MEDIUM: return "medium";
@@ -261,47 +261,47 @@ void QMSettings::setQMMethod(const QMMethod method) { _qmMethod = method; }
  *
  * @param model
  */
-void QMSettings::setMaceModelSize(const std::string_view &model)
+void QMSettings::setMaceModel(const std::string_view &model)
 {
-    using enum MaceModelSize;
+    using enum MaceModel;
     const auto modelToLowerAndReplaceDashes =
         toLowerAndReplaceDashesCopy(model);
 
     if ("small" == modelToLowerAndReplaceDashes)
-        _maceModelSize = SMALL;
+        _maceModel = SMALL;
 
     else if ("medium" == modelToLowerAndReplaceDashes)
-        _maceModelSize = MEDIUM;
+        _maceModel = MEDIUM;
 
     else if ("large" == modelToLowerAndReplaceDashes)
-        _maceModelSize = LARGE;
+        _maceModel = LARGE;
 
     else if ("small_0b" == modelToLowerAndReplaceDashes)
-        _maceModelSize = SMALL0B;
+        _maceModel = SMALL0B;
 
     else if ("medium_0b" == modelToLowerAndReplaceDashes)
-        _maceModelSize = MEDIUM0B;
+        _maceModel = MEDIUM0B;
 
     else if ("small_0b2" == modelToLowerAndReplaceDashes)
-        _maceModelSize = SMALL0B2;
+        _maceModel = SMALL0B2;
 
     else if ("medium_0b2" == modelToLowerAndReplaceDashes)
-        _maceModelSize = MEDIUM0B2;
+        _maceModel = MEDIUM0B2;
 
     else if ("large_0b2" == modelToLowerAndReplaceDashes)
-        _maceModelSize = LARGE0B2;
+        _maceModel = LARGE0B2;
 
     else if ("medium_0b3" == modelToLowerAndReplaceDashes)
-        _maceModelSize = MEDIUM0B3;
+        _maceModel = MEDIUM0B3;
 
     else if ("medium_mpa_0" == modelToLowerAndReplaceDashes)
-        _maceModelSize = MEDIUMMPA0;
+        _maceModel = MEDIUMMPA0;
 
     else if ("medium_omat_0" == modelToLowerAndReplaceDashes)
-        _maceModelSize = MEDIUMOMAT0;
+        _maceModel = MEDIUMOMAT0;
 
     else if ("custom" == modelToLowerAndReplaceDashes)
-        _maceModelSize = CUSTOM;
+        _maceModel = CUSTOM;
 
     else
         throw UserInputException(
@@ -314,10 +314,7 @@ void QMSettings::setMaceModelSize(const std::string_view &model)
  *
  * @param model
  */
-void QMSettings::setMaceModelSize(const MaceModelSize model)
-{
-    _maceModelSize = model;
-}
+void QMSettings::setMaceModel(const MaceModel model) { _maceModel = model; }
 
 /**
  * @brief sets the maceModelType to enum in settings
@@ -447,7 +444,8 @@ void QMSettings::setSlakosType(const std::string_view &slakos)
     }
 
     else
-        throw UserInputException(std::format("Slakos {} not recognized", slakos)
+        throw UserInputException(
+            std::format("Slakos {} not recognized", slakos)
         );
 }
 
@@ -478,10 +476,12 @@ void QMSettings::setSlakosPath(const std::string_view &path)
 
     else
     {
-        throw UserInputException(std::format(
-            "Slakos path cannot be set for slakos type: {}",
-            string(_slakosType)
-        ));
+        throw UserInputException(
+            std::format(
+                "Slakos path cannot be set for slakos type: {}",
+                string(_slakosType)
+            )
+        );
     }
 }
 
@@ -586,9 +586,9 @@ QMMethod QMSettings::getQMMethod() { return _qmMethod; }
 /**
  * @brief returns the maceModel
  *
- * @return MaceModelSize
+ * @return MaceModel
  */
-MaceModelSize QMSettings::getMaceModelSize() { return _maceModelSize; }
+MaceModel QMSettings::getMaceModel() { return _maceModel; }
 
 MaceModelType QMSettings::getMaceModelType() { return _maceModelType; }
 

--- a/src/setup/qmSetup.cpp
+++ b/src/setup/qmSetup.cpp
@@ -151,19 +151,20 @@ void QMSetup::setupQMMethodMace()
 
     if (QMSettings::getMaceModelType() != MaceModelType::MACE_MP)
     {
-        const auto modelSize = QMSettings::getMaceModelSize();
-        if (modelSize != MaceModelSize::SMALL &&
-            modelSize != MaceModelSize::MEDIUM &&
-            modelSize != MaceModelSize::LARGE)
-            throw InputFileException(std::format(
-                "The '{}' model size is only compatible with the '{}' "
-                "model type.",
-                string(modelSize),
-                string(MaceModelType::MACE_MP)
-            ));
+        const auto modelSize = QMSettings::getMaceModel();
+        if (modelSize != MaceModel::SMALL && modelSize != MaceModel::MEDIUM &&
+            modelSize != MaceModel::LARGE)
+            throw InputFileException(
+                std::format(
+                    "The '{}' model size is only compatible with the '{}' "
+                    "model type.",
+                    string(modelSize),
+                    string(MaceModelType::MACE_MP)
+                )
+            );
     }
 
-    if (QMSettings::getMaceModelSize() == MaceModelSize::CUSTOM &&
+    if (QMSettings::getMaceModel() == MaceModel::CUSTOM &&
         QMSettings::getMaceModelPath().empty())
         throw InputFileException(
             "You have requested a custom MACE model but haven't provided a "
@@ -171,7 +172,7 @@ void QMSetup::setupQMMethodMace()
             "This setup is invalid."
         );
 
-    if (QMSettings::getMaceModelSize() != MaceModelSize::CUSTOM &&
+    if (QMSettings::getMaceModel() != MaceModel::CUSTOM &&
         !QMSettings::getMaceModelPath().empty())
         throw InputFileException(
             "You have set a custom MACE model path without requesting a custom "
@@ -332,7 +333,7 @@ void QMSetup::setupWriteInfo() const
     if (qmMethod == MACE)
     {
         const auto modelType = QMSettings::getMaceModelType();
-        const auto modelSize = QMSettings::getMaceModelSize();
+        const auto modelSize = QMSettings::getMaceModel();
         const auto modelPath = QMSettings::getMaceModelPath();
         const auto fp        = Settings::getFloatingPointPybindString();
         const auto useDisp   = QMSettings::useDispersionCorr() ? "on" : "off";
@@ -348,7 +349,7 @@ void QMSetup::setupWriteInfo() const
         logOutput.writeSetupInfo(modelTypeMsg);
         logOutput.writeSetupInfo(modelSizeMsg);
 
-        if (modelSize == MaceModelSize::CUSTOM)
+        if (modelSize == MaceModel::CUSTOM)
             logOutput.writeSetupInfo(modelPathMsg);
 
         logOutput.writeSetupInfo(fpMsg);

--- a/src/setup/setup.cpp
+++ b/src/setup/setup.cpp
@@ -210,4 +210,6 @@ void setup::setupEngine(Engine &engine)
 
     if (Settings::isOptJobType())
         setupOptimizer(engine);
+
+    engine.getLogOutput().flushQueuedWarnings();
 }

--- a/tests/data/inputFileReader/keywordList.txt
+++ b/tests/data/inputFileReader/keywordList.txt
@@ -122,6 +122,7 @@ qm_script_full_path         false
 qm_loop_time_limit          false
 dispersion                  false
 remove_net_force            false
+mace_model                  false
 mace_model_size             false
 mace_model_path             false
 slakos                      false

--- a/tests/src/input/inputFileParsing/testQMParser.cpp
+++ b/tests/src/input/inputFileParsing/testQMParser.cpp
@@ -204,51 +204,51 @@ TEST_F(TestInputFileReader, parseMaceQMMethod)
     )
 }
 
-TEST_F(TestInputFileReader, parseMaceModelSize)
+TEST_F(TestInputFileReader, parseMaceModel)
 {
-    using enum MaceModelSize;
+    using enum MaceModel;
 
     auto parser = QMInputParser(*_engine);
-    parser.parseMaceModelSize({"mace_model_size", "=", "small"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), SMALL);
+    parser.parseMaceModel({"mace_model", "=", "small"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), SMALL);
 
-    parser.parseMaceModelSize({"mace_model_size", "=", "medium"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MEDIUM);
+    parser.parseMaceModel({"mace_model", "=", "medium"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), MEDIUM);
 
-    parser.parseMaceModelSize({"mace_model_size", "=", "large"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), LARGE);
+    parser.parseMaceModel({"mace_model", "=", "large"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), LARGE);
 
-    parser.parseMaceModelSize({"mace_model_size", "=", "small_0b"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), SMALL0B);
+    parser.parseMaceModel({"mace_model", "=", "small_0b"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), SMALL0B);
 
-    parser.parseMaceModelSize({"mace_model_size", "=", "medium_0b"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MEDIUM0B);
+    parser.parseMaceModel({"mace_model", "=", "medium_0b"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), MEDIUM0B);
 
-    parser.parseMaceModelSize({"mace_model_size", "=", "small_0b2"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), SMALL0B2);
+    parser.parseMaceModel({"mace_model", "=", "small_0b2"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), SMALL0B2);
 
-    parser.parseMaceModelSize({"mace_model_size", "=", "medium_0b2"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MEDIUM0B2);
+    parser.parseMaceModel({"mace_model", "=", "medium_0b2"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), MEDIUM0B2);
 
-    parser.parseMaceModelSize({"mace_model_size", "=", "large_0b2"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), LARGE0B2);
+    parser.parseMaceModel({"mace_model", "=", "large_0b2"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), LARGE0B2);
 
-    parser.parseMaceModelSize({"mace_model_size", "=", "medium_0b3"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MEDIUM0B3);
+    parser.parseMaceModel({"mace_model", "=", "medium_0b3"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), MEDIUM0B3);
 
-    parser.parseMaceModelSize({"mace_model_size", "=", "medium_mpa_0"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MEDIUMMPA0);
+    parser.parseMaceModel({"mace_model", "=", "medium_mpa_0"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), MEDIUMMPA0);
 
-    parser.parseMaceModelSize({"mace_model_size", "=", "medium_omat_0"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MEDIUMOMAT0);
+    parser.parseMaceModel({"mace_model", "=", "medium_omat_0"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), MEDIUMOMAT0);
 
-    parser.parseMaceModelSize({"mace_model_size", "=", "custom"}, 0);
-    EXPECT_EQ(QMSettings::getMaceModelSize(), CUSTOM);
+    parser.parseMaceModel({"mace_model", "=", "custom"}, 0);
+    EXPECT_EQ(QMSettings::getMaceModel(), CUSTOM);
 
     ASSERT_THROW_MSG(
-        parser.parseMaceModelSize({"mace_model_size", "=", "notASize"}, 0),
+        parser.parseMaceModel({"mace_model", "=", "notASize"}, 0),
         InputFileException,
-        "Invalid mace_model_size \"notASize\" in input file.\n"
+        "Invalid mace_model \"notASize\" in input file.\n"
         "Possible values are: small, medium, large, small-0b,\n"
         "medium-0b, small-0b2, medium-0b2, large-0b2, medium-0b3,\n"
         "medium-mpa-0, medium-omat-0, custom"

--- a/tests/src/output/testLogOutput.cpp
+++ b/tests/src/output/testLogOutput.cpp
@@ -231,8 +231,32 @@ TEST_F(TestLogOutput, TestwriteSetupWarning)
     std::ifstream file("default.log");
     std::string   line;
     getline(file, line);
-    EXPECT_EQ(
-        line,
-        std::format("WARNING: This is a warning message.")
-    );
+    EXPECT_EQ(line, std::format("WARNING: This is a warning message."));
+}
+
+/**
+ * @brief tests adding warnings to the queue and then flushing them to the log
+ * file
+ *
+ */
+TEST_F(TestLogOutput, TestAddAndFlushQueuedWarnings)
+{
+    _logOutput->queueWarning("This keyword is deprecated and will be removed.");
+    _logOutput->queueWarning("Combining these two methods is discouraged.");
+
+    _logOutput->setFilename("default.log");
+    _logOutput->flushQueuedWarnings();
+    _logOutput->close();
+    std::ifstream file("default.log");
+    std::string   line;
+    // clang-format off
+    getline(file, line);
+    EXPECT_EQ(line, std::format("WARNING: This keyword is deprecated and will be removed."));
+    getline(file, line);
+    EXPECT_EQ(line, std::format(""));
+    getline(file, line);
+    EXPECT_EQ(line, std::format("WARNING: Combining these two methods is discouraged."));
+    getline(file, line);
+    EXPECT_EQ(line, std::format(""));
+    // clang-format on
 }

--- a/tests/src/settings/testQMSettings.cpp
+++ b/tests/src/settings/testQMSettings.cpp
@@ -56,48 +56,48 @@ TEST(QMSettingsTest, SetQMMethodTest)
     EXPECT_EQ(QMSettings::getQMMethod(), QMMethod::NONE);
 }
 
-TEST(QMSettingsTest, SetMaceModelSizeTest)
+TEST(QMSettingsTest, SetMaceModelTest)
 {
-    QMSettings::setMaceModelSize("small");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::SMALL);
+    QMSettings::setMaceModel("small");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::SMALL);
 
-    QMSettings::setMaceModelSize("medium");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::MEDIUM);
+    QMSettings::setMaceModel("medium");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::MEDIUM);
 
-    QMSettings::setMaceModelSize("large");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::LARGE);
+    QMSettings::setMaceModel("large");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::LARGE);
 
-    QMSettings::setMaceModelSize("small-0b");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::SMALL0B);
+    QMSettings::setMaceModel("small-0b");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::SMALL0B);
 
-    QMSettings::setMaceModelSize("medium-0b");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::MEDIUM0B);
+    QMSettings::setMaceModel("medium-0b");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::MEDIUM0B);
 
-    QMSettings::setMaceModelSize("small-0b2");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::SMALL0B2);
+    QMSettings::setMaceModel("small-0b2");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::SMALL0B2);
 
-    QMSettings::setMaceModelSize("medium-0b2");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::MEDIUM0B2);
+    QMSettings::setMaceModel("medium-0b2");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::MEDIUM0B2);
 
-    QMSettings::setMaceModelSize("large-0b2");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::LARGE0B2);
+    QMSettings::setMaceModel("large-0b2");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::LARGE0B2);
 
-    QMSettings::setMaceModelSize("medium-0b3");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::MEDIUM0B3);
+    QMSettings::setMaceModel("medium-0b3");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::MEDIUM0B3);
 
-    QMSettings::setMaceModelSize("medium-mpa-0");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::MEDIUMMPA0);
+    QMSettings::setMaceModel("medium-mpa-0");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::MEDIUMMPA0);
 
-    QMSettings::setMaceModelSize("medium-omat-0");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::MEDIUMOMAT0);
+    QMSettings::setMaceModel("medium-omat-0");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::MEDIUMOMAT0);
 
-    QMSettings::setMaceModelSize("custom");
-    EXPECT_EQ(QMSettings::getMaceModelSize(), MaceModelSize::CUSTOM);
+    QMSettings::setMaceModel("custom");
+    EXPECT_EQ(QMSettings::getMaceModel(), MaceModel::CUSTOM);
 
     ASSERT_THROW_MSG(
-        QMSettings::setMaceModelSize("notAMaceModelSize"),
+        QMSettings::setMaceModel("notAMaceModel"),
         UserInputException,
-        "Mace model size notAMaceModelSize not recognized"
+        "Mace model size notAMaceModel not recognized"
     );
 }
 
@@ -234,20 +234,20 @@ TEST(QMSettingsTest, ReturnMaceModelTypeTest)
     EXPECT_EQ(string(MaceModelType::MACE_ANICC), "mace_anicc");
 }
 
-TEST(QMSettingsTest, ReturnMaceModelSizeTest)
+TEST(QMSettingsTest, ReturnMaceModelTest)
 {
-    EXPECT_EQ(string(MaceModelSize::SMALL), "small");
-    EXPECT_EQ(string(MaceModelSize::MEDIUM), "medium");
-    EXPECT_EQ(string(MaceModelSize::LARGE), "large");
-    EXPECT_EQ(string(MaceModelSize::SMALL0B), "small-0b");
-    EXPECT_EQ(string(MaceModelSize::MEDIUM0B), "medium-0b");
-    EXPECT_EQ(string(MaceModelSize::SMALL0B2), "small-0b2");
-    EXPECT_EQ(string(MaceModelSize::MEDIUM0B2), "medium-0b2");
-    EXPECT_EQ(string(MaceModelSize::LARGE0B2), "large-0b2");
-    EXPECT_EQ(string(MaceModelSize::MEDIUM0B3), "medium-0b3");
-    EXPECT_EQ(string(MaceModelSize::MEDIUMMPA0), "medium-mpa-0");
-    EXPECT_EQ(string(MaceModelSize::MEDIUMOMAT0), "medium-omat-0");
-    EXPECT_EQ(string(MaceModelSize::CUSTOM), "custom");
+    EXPECT_EQ(string(MaceModel::SMALL), "small");
+    EXPECT_EQ(string(MaceModel::MEDIUM), "medium");
+    EXPECT_EQ(string(MaceModel::LARGE), "large");
+    EXPECT_EQ(string(MaceModel::SMALL0B), "small-0b");
+    EXPECT_EQ(string(MaceModel::MEDIUM0B), "medium-0b");
+    EXPECT_EQ(string(MaceModel::SMALL0B2), "small-0b2");
+    EXPECT_EQ(string(MaceModel::MEDIUM0B2), "medium-0b2");
+    EXPECT_EQ(string(MaceModel::LARGE0B2), "large-0b2");
+    EXPECT_EQ(string(MaceModel::MEDIUM0B3), "medium-0b3");
+    EXPECT_EQ(string(MaceModel::MEDIUMMPA0), "medium-mpa-0");
+    EXPECT_EQ(string(MaceModel::MEDIUMOMAT0), "medium-omat-0");
+    EXPECT_EQ(string(MaceModel::CUSTOM), "custom");
 }
 
 TEST(QMSettingsTest, ReturnXtbMethodTest)

--- a/tests/src/setup/testQMSetup.cpp
+++ b/tests/src/setup/testQMSetup.cpp
@@ -217,7 +217,7 @@ TEST(TestQMSetup, setupQMMethodMaceOffInvalidModelSize)
 
     QMSettings::setQMMethod(QMMethod::MACE);
     QMSettings::setMaceModelType("mace-off");
-    QMSettings::setMaceModelSize("medium-omat-0");
+    QMSettings::setMaceModel("medium-omat-0");
 
     ASSERT_THROW_MSG(
         qmSetup.setupQMMethodMace(),
@@ -234,7 +234,7 @@ TEST(TestQMSetup, setupQMMethodMaceRedundantModelPath)
 
     QMSettings::setQMMethod(QMMethod::MACE);
     QMSettings::setMaceModelType("mace-mp");
-    QMSettings::setMaceModelSize("medium-omat-0");
+    QMSettings::setMaceModel("medium-omat-0");
     QMSettings::setMaceModelPath("https://not-a-valid-url");
 
     ASSERT_THROW_MSG(
@@ -253,7 +253,7 @@ TEST(TestQMSetup, setupQMMethodMaceMissingModelPath)
 
     QMSettings::setQMMethod(QMMethod::MACE);
     QMSettings::setMaceModelType("mace-mp");
-    QMSettings::setMaceModelSize("custom");
+    QMSettings::setMaceModel("custom");
     QMSettings::setMaceModelPath("");
 
     ASSERT_THROW_MSG(


### PR DESCRIPTION
This PR solves issue #278 
Additionally, the functionality has been added to queue warnings for the `.log` output file before its creation. The queued warnings are then flushed to the file at the end of the setup.