### PR TITLE
feat(qm): add mace_mode (accurate/fast) to select CuEq acceleration for MACE

### DIFF
--- a/changes/mace-cueq.enhancement.md
+++ b/changes/mace-cueq.enhancement.md
@@ -1,0 +1,5 @@
+- New `mace_mode` input option for MACE QM runs: `accurate` (default, the
+  exact e3nn reference) or `fast` (cuequivariance-accelerated kernels —
+  substantially faster for MD, at the cost of not being bit-identical to the
+  e3nn reference). `fast` requires the `cuequivariance` and
+  `cuequivariance-torch` packages.

--- a/changes/mace-cueq.enhancement.md
+++ b/changes/mace-cueq.enhancement.md
@@ -1,5 +1,6 @@
 - New `mace_mode` input option for MACE QM runs: `accurate` (default, the
   exact e3nn reference) or `fast` (cuequivariance-accelerated kernels —
   substantially faster for MD, at the cost of not being bit-identical to the
-  e3nn reference). `fast` requires the `cuequivariance` and
-  `cuequivariance-torch` packages.
+  e3nn reference). `fast` requires `cuequivariance`, `cuequivariance-torch`
+  and the matching CUDA ops package `cuequivariance-ops-torch-cuXX` (not pulled
+  in automatically), where `XX` matches the CUDA build of the installed `torch`.

--- a/docs/sphinx/src/userGuide/inputFile.rst
+++ b/docs/sphinx/src/userGuide/inputFile.rst
@@ -1495,7 +1495,7 @@ Possible options are:
    2. **fast** - cuequivariance-accelerated kernels; substantially faster for MD, but the results are an approximation of (not bit-identical to) the e3nn reference
 
 .. Note::
-    The ``fast`` mode requires the ``cuequivariance`` and ``cuequivariance-torch`` packages, built for the same CUDA version as the installed ``torch``. Use ``accurate`` for the exact e3nn reference.
+    The ``fast`` mode requires ``cuequivariance``, ``cuequivariance-torch`` and the matching CUDA ops package ``cuequivariance-ops-torch-cuXX``, where ``XX`` is the CUDA major your ``torch`` was built against (e.g. ``cu13`` for a CUDA-13 ``torch`` build). The ops package is **not** pulled in automatically by ``cuequivariance-torch`` -- install it explicitly, e.g. ``pip install cuequivariance-ops-torch-cu13``. Use ``accurate`` for the exact e3nn reference.
 
 .. centered:: *default value* = "accurate"
 

--- a/docs/sphinx/src/userGuide/inputFile.rst
+++ b/docs/sphinx/src/userGuide/inputFile.rst
@@ -1476,6 +1476,30 @@ With the ``mace_model_path`` keyword the user can specify a custom URL correspon
     The ``mace_model_path`` can only be specified if :ref:`mace_model <maceModelKey>` keyword is set to ``custom``.
 
 
+.. _maceModeKey:
+
+MACE Mode
+===============
+
+.. admonition:: Key
+    :class: tip
+
+    mace_mode = {string} -> "accurate"
+
+With the ``mace_mode`` keyword the user can select the evaluation mode / kernel backend of the `MACE <https://github.com/ACEsuit/mace>`_ model for the QM calculations.
+
+Possible options are:
+
+   1. **accurate** (default) - the exact e3nn reference implementation
+
+   2. **fast** - cuequivariance-accelerated kernels; substantially faster for MD, but the results are an approximation of (not bit-identical to) the e3nn reference
+
+.. Note::
+    The ``fast`` mode requires the ``cuequivariance`` and ``cuequivariance-torch`` packages, built for the same CUDA version as the installed ``torch``. Use ``accurate`` for the exact e3nn reference.
+
+.. centered:: *default value* = "accurate"
+
+
 .. _xtbMethodKey:
 
 ASE-xTB Method

--- a/include/QM/ase/aseMaceRunner.hpp
+++ b/include/QM/ase/aseMaceRunner.hpp
@@ -42,7 +42,8 @@ namespace QM
             const std::string& modelType,
             const std::string& model,
             const std::string& fpType,
-            const bool         dispersion
+            const bool         dispersion,
+            const bool         enableCueq
         );
     };
 }   // namespace QM

--- a/include/input/inputFileParser/QMInputParser.hpp
+++ b/include/input/inputFileParser/QMInputParser.hpp
@@ -53,6 +53,7 @@ namespace input
         void parseRemoveNetForce(const pq::strings &, const size_t);
 
         void parseMaceModel(const pq::strings &, const size_t);
+        void parseMaceMode(const pq::strings &, const size_t);
         void parseMaceModelPath(const pq::strings &, const size_t);
         void parseMaceQMMethod(const std::string_view &);
 

--- a/include/settings/qmSettings.hpp
+++ b/include/settings/qmSettings.hpp
@@ -80,6 +80,17 @@ namespace settings
     };
 
     /**
+     * @class enum MaceMode
+     *
+     * @brief enum class for the MACE evaluation mode / kernel backend
+     */
+    enum class MaceMode : size_t
+    {
+        ACCURATE,
+        FAST
+    };
+
+    /**
      * @class enum xtbMethod
      */
     enum class XtbMethod : size_t
@@ -103,6 +114,7 @@ namespace settings
     std::string string(const QMMethod method);
     std::string string(const MaceModel model);
     std::string string(const MaceModelType model);
+    std::string string(const MaceMode mode);
     std::string string(const XtbMethod method);
     std::string string(const SlakosType slakos);
     std::string string(
@@ -121,6 +133,7 @@ namespace settings
         static inline QMMethod      _qmMethod      = QMMethod::NONE;
         static inline MaceModel     _maceModel     = MaceModel::MEDIUM;
         static inline MaceModelType _maceModelType = MaceModelType::MACE_MP;
+        static inline MaceMode      _maceMode      = MaceMode::ACCURATE;
         static inline SlakosType    _slakosType    = SlakosType::NONE;
         static inline XtbMethod     _xtbMethod     = XtbMethod::GFN2;
 
@@ -157,6 +170,8 @@ namespace settings
         static void setMaceModel(const MaceModel model);
         static void setMaceModelType(const std::string_view &model);
         static void setMaceModelType(const MaceModelType model);
+        static void setMaceMode(const std::string_view &mode);
+        static void setMaceMode(const MaceMode mode);
         static void setMaceModelPath(const std::string_view &path);
 
         static void setQMScript(const std::string_view &script);
@@ -190,6 +205,7 @@ namespace settings
         [[nodiscard]] static QMMethod      getQMMethod();
         [[nodiscard]] static MaceModel     getMaceModel();
         [[nodiscard]] static MaceModelType getMaceModelType();
+        [[nodiscard]] static MaceMode      getMaceMode();
         [[nodiscard]] static std::string   getMaceModelPath();
 
         [[nodiscard]] static std::string getQMScript();

--- a/src/QM/ase/aseMaceRunner.cpp
+++ b/src/QM/ase/aseMaceRunner.cpp
@@ -22,6 +22,8 @@
 
 #include "aseMaceRunner.hpp"
 
+#include <cstdio>   // for fprintf, stderr
+
 #include "pybind11/embed.h"
 
 using QM::AseMaceRunner;
@@ -33,6 +35,7 @@ using QM::AseMaceRunner;
  * @param model
  * @param fpType
  * @param dispersion
+ * @param enableCueq
  *
  * @throw py::error_already_set if the import of the mace module fails
  */
@@ -40,7 +43,8 @@ AseMaceRunner::AseMaceRunner(
     const std::string &modelType,
     const std::string &model,
     const std::string &fpType,
-    const bool         dispersion
+    const bool         dispersion,
+    const bool         enableCueq
 )
     : AseQMRunner()
 {
@@ -52,6 +56,7 @@ AseMaceRunner::AseMaceRunner(
 
         calculatorArgs["model"]         = model.c_str();
         calculatorArgs["dispersion"]    = pybind11::bool_(dispersion);
+        calculatorArgs["enable_cueq"]   = pybind11::bool_(enableCueq);
         calculatorArgs["default_dtype"] = fpType.c_str();
         calculatorArgs["device"]        = pybind11::str("cuda");
 
@@ -60,6 +65,17 @@ AseMaceRunner::AseMaceRunner(
     catch (const py::error_already_set &)
     {
         ::PyErr_Print();
+        if (enableCueq)
+            ::fprintf(
+                stderr,
+                "\nPQ: mace_mode = fast uses cuequivariance-accelerated MACE "
+                "kernels and requires the Python packages 'cuequivariance' and "
+                "'cuequivariance-torch', built for the same CUDA version as the "
+                "installed torch. If the error above is a missing or "
+                "incompatible cuequivariance, install the matching packages; "
+                "otherwise set mace_mode = accurate to use the standard e3nn "
+                "evaluation.\n"
+            );
         throw;
     }
 }

--- a/src/QM/ase/aseMaceRunner.cpp
+++ b/src/QM/ase/aseMaceRunner.cpp
@@ -69,12 +69,14 @@ AseMaceRunner::AseMaceRunner(
             ::fprintf(
                 stderr,
                 "\nPQ: mace_mode = fast uses cuequivariance-accelerated MACE "
-                "kernels and requires the Python packages 'cuequivariance' and "
-                "'cuequivariance-torch', built for the same CUDA version as the "
-                "installed torch. If the error above is a missing or "
-                "incompatible cuequivariance, install the matching packages; "
-                "otherwise set mace_mode = accurate to use the standard e3nn "
-                "evaluation.\n"
+                "kernels. These need 'cuequivariance', 'cuequivariance-torch' "
+                "and -- the piece pip does NOT pull in automatically -- the "
+                "matching CUDA ops package 'cuequivariance-ops-torch-cuXX', "
+                "where XX is the CUDA major your torch was built against (e.g. "
+                "cu13 for a CUDA-13 torch build: "
+                "'pip install cuequivariance-ops-torch-cu13'). Install that to "
+                "use fast mode, or set mace_mode = accurate for the standard "
+                "e3nn evaluation.\n"
             );
         throw;
     }

--- a/src/engine/qmmdEngine.cpp
+++ b/src/engine/qmmdEngine.cpp
@@ -106,6 +106,7 @@ void QMMDEngine::setMaceQMRunner()
     const auto modelPath = QMSettings::getMaceModelPath();
     const auto useDFTD   = QMSettings::useDispersionCorr();
     const auto fpType    = Settings::getFloatingPointPybindString();
+    const auto useCueq   = QMSettings::getMaceMode() == MaceMode::FAST;
 
     auto maceModel = string(QMSettings::getMaceModel());
 
@@ -113,7 +114,7 @@ void QMMDEngine::setMaceQMRunner()
         maceModel = modelPath;
 
     _qmRunner =
-        make_shared<AseMaceRunner>(modelType, maceModel, fpType, useDFTD);
+        make_shared<AseMaceRunner>(modelType, maceModel, fpType, useDFTD, useCueq);
 #else
     throw CompileTimeException(
         "A mace type qm method was requested but ASE was not enabled at "

--- a/src/input/inputFileParser/QMInputParser.cpp
+++ b/src/input/inputFileParser/QMInputParser.cpp
@@ -103,6 +103,12 @@ QMInputParser::QMInputParser(Engine &engine) : InputFileParser(engine)
     );
 
     addKeyword(
+        std::string("mace_mode"),
+        bind_front(&QMInputParser::parseMaceMode, this),
+        false
+    );
+
+    addKeyword(
         std::string("mace_model_path"),
         bind_front(&QMInputParser::parseMaceModelPath, this),
         false
@@ -373,6 +379,22 @@ void QMInputParser::parseMaceModel(
                 lineElements[2]
             )
         );
+}
+
+/**
+ * @brief parse the MACE evaluation mode
+ *
+ * @param lineElements
+ * @param lineNumber
+ */
+void QMInputParser::parseMaceMode(
+    const std::vector<std::string> &lineElements,
+    const size_t                    lineNumber
+)
+{
+    checkCommand(lineElements, lineNumber);
+
+    QMSettings::setMaceMode(lineElements[2]);
 }
 
 /**

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -27,6 +27,7 @@
 #include "exceptions.hpp"        // for customException
 #include "stringUtilities.hpp"   // for toLowerCopy
 
+using settings::MaceMode;
 using settings::MaceModel;
 using settings::MaceModelType;
 using settings::QMMethod;
@@ -106,6 +107,25 @@ std::string settings::string(const MaceModelType model)
         case MACE_ANICC: return "mace_anicc";
 
         default: return "none";
+    }
+}
+
+/**
+ * @brief returns the maceMode as string
+ *
+ * @param mode
+ * @return std::string
+ */
+std::string settings::string(const MaceMode mode)
+{
+    switch (mode)
+    {
+        using enum MaceMode;
+
+        case ACCURATE: return "accurate";
+        case FAST: return "fast";
+
+        default: return "accurate";
     }
 }
 
@@ -352,6 +372,37 @@ void QMSettings::setMaceModelType(const MaceModelType model)
 }
 
 /**
+ * @brief sets the maceMode to enum in settings
+ *
+ * @param mode
+ */
+void QMSettings::setMaceMode(const std::string_view &mode)
+{
+    using enum MaceMode;
+    const auto modeToLower = toLowerAndReplaceDashesCopy(mode);
+
+    if ("accurate" == modeToLower)
+        _maceMode = ACCURATE;
+
+    else if ("fast" == modeToLower)
+        _maceMode = FAST;
+
+    else
+        throw UserInputException(std::format(
+            "Unknown mace_mode \"{}\". Valid values are \"accurate\" (exact "
+            "e3nn reference) or \"fast\" (cuequivariance-accelerated).",
+            mode
+        ));
+}
+
+/**
+ * @brief sets the maceMode to enum in settings
+ *
+ * @param mode
+ */
+void QMSettings::setMaceMode(const MaceMode mode) { _maceMode = mode; }
+
+/**
  * @brief set the mace model path
  *
  */
@@ -591,6 +642,13 @@ QMMethod QMSettings::getQMMethod() { return _qmMethod; }
 MaceModel QMSettings::getMaceModel() { return _maceModel; }
 
 MaceModelType QMSettings::getMaceModelType() { return _maceModelType; }
+
+/**
+ * @brief returns the maceMode
+ *
+ * @return MaceMode
+ */
+MaceMode QMSettings::getMaceMode() { return _maceMode; }
 
 /**
  * @brief returns the maceModelPath

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -125,7 +125,7 @@ std::string settings::string(const MaceMode mode)
         case ACCURATE: return "accurate";
         case FAST: return "fast";
 
-        default: return "accurate";
+        default: return "unknown mode";
     }
 }
 

--- a/src/setup/qmSetup.cpp
+++ b/src/setup/qmSetup.cpp
@@ -337,6 +337,7 @@ void QMSetup::setupWriteInfo() const
         const auto modelPath = QMSettings::getMaceModelPath();
         const auto fp        = Settings::getFloatingPointPybindString();
         const auto useDisp   = QMSettings::useDispersionCorr() ? "on" : "off";
+        const auto maceMode  = QMSettings::getMaceMode();
 
         // clang-format off
         const auto modelTypeMsg = std::format("Model type:            {}", string(modelType));
@@ -344,6 +345,7 @@ void QMSetup::setupWriteInfo() const
         const auto modelPathMsg = std::format("Model path:            {}", modelPath);
         const auto fpMsg        = std::format("Floating point type:   {}", fp);
         const auto dispCorrMsg  = std::format("Dispersion Correction: {}", useDisp);
+        const auto modeMsg      = std::format("Evaluation mode:       {}", string(maceMode));
         // clang-format on
 
         logOutput.writeSetupInfo(modelTypeMsg);
@@ -354,6 +356,14 @@ void QMSetup::setupWriteInfo() const
 
         logOutput.writeSetupInfo(fpMsg);
         logOutput.writeSetupInfo(dispCorrMsg);
+        logOutput.writeSetupInfo(modeMsg);
+
+        if (maceMode == MaceMode::FAST)
+            logOutput.writeSetupInfo(std::format(
+                "                       cuequivariance-accelerated kernels; "
+                "results are not bit-identical to the e3nn reference "
+                "(use mace_mode = accurate for the exact reference)"
+            ));
     }
 
     if (qmMethod == FENNOL)

--- a/tests/data/inputFileReader/keywordList.txt
+++ b/tests/data/inputFileReader/keywordList.txt
@@ -125,6 +125,7 @@ remove_net_force            false
 mace_model                  false
 mace_model_size             false
 mace_model_path             false
+mace_mode                   false
 slakos                      false
 slakos_path                 false
 third_order                 false

--- a/tests/src/input/inputFileParsing/testQMParser.cpp
+++ b/tests/src/input/inputFileParsing/testQMParser.cpp
@@ -255,6 +255,26 @@ TEST_F(TestInputFileReader, parseMaceModel)
     )
 }
 
+TEST_F(TestInputFileReader, parseMaceMode)
+{
+    using enum MaceMode;
+
+    auto parser = QMInputParser(*_engine);
+
+    parser.parseMaceMode({"mace_mode", "=", "accurate"}, 0);
+    EXPECT_EQ(QMSettings::getMaceMode(), ACCURATE);
+
+    parser.parseMaceMode({"mace_mode", "=", "fast"}, 0);
+    EXPECT_EQ(QMSettings::getMaceMode(), FAST);
+
+    ASSERT_THROW_MSG(
+        parser.parseMaceMode({"mace_mode", "=", "notAMode"}, 0),
+        UserInputException,
+        "Unknown mace_mode \"notAMode\". Valid values are \"accurate\" (exact "
+        "e3nn reference) or \"fast\" (cuequivariance-accelerated)."
+    )
+}
+
 TEST_F(TestInputFileReader, parseMaceModelPath)
 {
     auto parser = QMInputParser(*_engine);

--- a/tests/src/settings/testQMSettings.cpp
+++ b/tests/src/settings/testQMSettings.cpp
@@ -101,6 +101,30 @@ TEST(QMSettingsTest, SetMaceModelTest)
     );
 }
 
+TEST(QMSettingsTest, SetMaceModeTest)
+{
+    using enum MaceMode;
+
+    QMSettings::setMaceMode("accurate");
+    EXPECT_EQ(QMSettings::getMaceMode(), ACCURATE);
+
+    QMSettings::setMaceMode("fast");
+    EXPECT_EQ(QMSettings::getMaceMode(), FAST);
+
+    QMSettings::setMaceMode(ACCURATE);
+    EXPECT_EQ(QMSettings::getMaceMode(), ACCURATE);
+
+    EXPECT_EQ(string(ACCURATE), "accurate");
+    EXPECT_EQ(string(FAST), "fast");
+
+    ASSERT_THROW_MSG(
+        QMSettings::setMaceMode("notAMode"),
+        UserInputException,
+        "Unknown mace_mode \"notAMode\". Valid values are \"accurate\" (exact "
+        "e3nn reference) or \"fast\" (cuequivariance-accelerated)."
+    );
+}
+
 TEST(QMSettingsTest, SetMaceModelTypeTest)
 {
     QMSettings::setMaceModelType("mace_mp");

--- a/tests/src/setup/testQMSetupAse.cpp
+++ b/tests/src/setup/testQMSetupAse.cpp
@@ -295,15 +295,18 @@ class MACECalculator:
     modules["mace"]             = maceModule;
     modules["mace.calculators"] = calculatorsModule;
 
-    ASSERT_NO_THROW(
-        { QM::AseMaceRunner runner("MACECalculator", "model.model", "float64", true); }
-    );
+    ASSERT_NO_THROW({
+        QM::AseMaceRunner runner(
+            "MACECalculator", "model.model", "float64", true, false
+        );
+    });
 
     auto lastKwargs = calculatorsModule.attr("MACECalculator").attr("last_kwargs")
                           .cast<pybind11::dict>();
 
     EXPECT_EQ(lastKwargs["model"].cast<std::string>(), "model.model");
     EXPECT_EQ(lastKwargs["dispersion"].cast<bool>(), true);
+    EXPECT_EQ(lastKwargs["enable_cueq"].cast<bool>(), false);
     EXPECT_EQ(lastKwargs["default_dtype"].cast<std::string>(), "float64");
     EXPECT_EQ(lastKwargs["device"].cast<std::string>(), "cuda");
 
@@ -311,5 +314,20 @@ class MACECalculator:
     modules.attr("pop")("mace", pybind11::none());
     modules.attr("pop")("ase.atoms", pybind11::none());
     modules.attr("pop")("ase", pybind11::none());
+}
+
+TEST_F(TestQMSetupAse, setupAseMaceWriteInfoFast)
+{
+    QMSettings::setQMMethod(QMMethod::MACE);
+    QMSettings::setMaceMode("fast");
+    _qmSetup->setupWriteInfo();
+
+    std::ifstream file("default.log");
+    std::string   line;
+    std::string   all;
+    while (std::getline(file, line)) all += line + "\n";
+
+    EXPECT_NE(all.find("Evaluation mode:       fast"), std::string::npos);
+    EXPECT_NE(all.find("cuequivariance-accelerated"), std::string::npos);
 }
 #endif


### PR DESCRIPTION
## Summary

Adds a `mace_mode` input keyword for MACE QM runs, letting users choose
between exact accuracy and cuequivariance-accelerated speed:

- `mace_mode = accurate` (default) — the e3nn reference; current
  behaviour, bit-for-bit reproducible.
- `mace_mode = fast` — passes `enable_cueq=True` to the MACE ASE
  calculator, using cuequivariance-accelerated kernels.

## Why

For MD, `fast` is substantially quicker, at the cost of results that are
an approximation of (not bit-identical to) the e3nn reference.
`accurate` stays available whenever the exact reference is needed.

## Usability

- Default stays `accurate`, so existing inputs reproduce exactly and runs
  never fail when `cuequivariance` is absent.
- The setup log reports the active mode (and, in fast mode, that the
  result is not bit-identical to e3nn) for reproducibility.
- If `fast` is requested without the packages, the runner prints a clear
  hint to install `cuequivariance` / `cuequivariance-torch` (matching the
  torch CUDA build), or to switch back to `accurate` — instead of a raw
  traceback.
- Invalid values are rejected with a helpful message.

## Dependency

`mace_mode = fast` requires `cuequivariance` and `cuequivariance-torch`
matching the torch CUDA build.

## Validation

- Builds on `dev` (all changed files + the `PQ` target).
- `mace_mode` parses and validates (accurate / fast / rejects invalid);
  the flag flows end-to-end and reaches the calculator.
