### PR TITLE
doc: update PQ reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ and LTO, see the Installation Guide.
 
 If you use PQ in your research, please cite:
 
-- Gamper, J., Gallmetzer, J. M., Weiss, A. K. H., & Hofer, T. S. (2025). PQ: An Open-Source Platform for Advanced Molecular Dynamics Simulations. Zenodo. <https://doi.org/10.5281/zenodo.14185071>
+- Gamper, J., Gallmetzer, J. M., Penz, A., Weiss, A. K. H., & Hofer, T. S. PQ: An Open-Source Platform for Advanced Molecular Dynamics Simulations. Zenodo. <https://doi.org/10.5281/zenodo.14185071>
 
-- Gamper, J., Gallmetzer, J. M., Weiss, A. K. H., & Hofer, T. S. (2024). PQAnalysis (1.2.1). Zenodo. <https://doi.org/10.5281/zenodo.11322103>
+- Gamper, J., Gallmetzer, J. M., Weiss, A. K. H., & Hofer, T. S. PQAnalysis. Zenodo. <https://doi.org/10.5281/zenodo.11322103>

--- a/include/output/references/referenceFiles/pq.ref
+++ b/include/output/references/referenceFiles/pq.ref
@@ -1,5 +1,5 @@
 PQ Software
-    Gamper, J., Gallmetzer, J. M., Weiss, A. K. H.,
-    Hofer, T. S. (2024). PQ: An Open-Source Platform
+    Gamper, J., Gallmetzer, J. M., Penz, A., Weiss, A. K. H.,
+    Hofer, T. S. PQ: An Open-Source Platform
     for Advanced Molecular Dynamics Simulations. Zenodo.
     https://doi.org/10.5281/zenodo.14185071

--- a/include/output/references/referenceFiles/pq.ref.bib
+++ b/include/output/references/referenceFiles/pq.ref.bib
@@ -2,13 +2,10 @@
 % PQ Software %
 %%%%%%%%%%%%%%%
 
-@software{gamper_2024_14185072,
-  author       = {Gamper, Jakob and Gallmetzer, Josef Maria and Weiss, Alexander K. H. and Hofer, Thomas S.},
+@software{gamper_pq,
+  author       = {Gamper, Jakob and Gallmetzer, Josef Maria and Penz, Armin and Weiss, Alexander K. H. and Hofer, Thomas S.},
   title        = {PQ: An Open-Source Platform for Advanced Molecular Dynamics Simulations},
-  month        = nov,
-  year         = 2024,
   publisher    = {Zenodo},
-  version      = {0.5.0},
-  doi          = {10.5281/zenodo.14185072},
-  url          = {https://doi.org/10.5281/zenodo.14185072},
+  doi          = {10.5281/zenodo.14185071},
+  url          = {https://doi.org/10.5281/zenodo.14185071},
 }


### PR DESCRIPTION
Updated PQ references for citation to be version invariant, links now lead automatically to the newest version of PQ and PQAnalysis and I shamelessly added myself to the refs, according to the new Zenodo version.