### PR TITLE
fix: guard SLAKOS tests in ASE-off builds

### DIFF
--- a/tests/src/input/inputFileParsing/testQMParser.cpp
+++ b/tests/src/input/inputFileParsing/testQMParser.cpp
@@ -294,11 +294,27 @@ TEST_F(TestInputFileReader, parseSlakosType)
 
     auto parser = QMInputParser(*_engine);
 
+#ifdef WITH_ASE
     parser.parseSlakosType({"slakos", "=", "3ob"}, 0);
     EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::THREEOB);
 
     parser.parseSlakosType({"slakos", "=", "matsci"}, 0);
     EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::MATSCI);
+#else
+    ASSERT_THROW_MSG(
+        parser.parseSlakosType({"slakos", "=", "3ob"}, 0),
+        InputFileException,
+        "Built-in SLAKOS sets (3ob/matsci) require building PQ with "
+        "-DBUILD_WITH_ASE=On"
+    );
+
+    ASSERT_THROW_MSG(
+        parser.parseSlakosType({"slakos", "=", "matsci"}, 0),
+        InputFileException,
+        "Built-in SLAKOS sets (3ob/matsci) require building PQ with "
+        "-DBUILD_WITH_ASE=On"
+    );
+#endif
 
     parser.parseSlakosType({"slakos", "=", "custom"}, 0);
     EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::CUSTOM);
@@ -311,6 +327,7 @@ TEST_F(TestInputFileReader, parseSlakosType)
     )
 }
 
+#ifdef WITH_ASE
 TEST_F(TestInputFileReader, parseSlakosTypeThirdOrder)
 {
     using enum QMMethod;
@@ -328,6 +345,7 @@ TEST_F(TestInputFileReader, parseSlakosTypeThirdOrder)
     EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::THREEOB);
     EXPECT_FALSE(QMSettings::useThirdOrderDftb());
 }
+#endif
 
 TEST_F(TestInputFileReader, parseSlakosPath)
 {

--- a/tests/src/settings/testQMSettings.cpp
+++ b/tests/src/settings/testQMSettings.cpp
@@ -145,23 +145,25 @@ TEST(QMSettingsTest, SetMaceModelTypeTest)
 
 TEST(QMSettingsTest, SetSlakosTypeTest)
 {
+#ifdef WITH_ASE
     QMSettings::setSlakosType("3ob");
     EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::THREEOB);
 
     QMSettings::setSlakosType("matsci");
     EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::MATSCI);
 
-    QMSettings::setSlakosType("custom");
-    EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::CUSTOM);
-
-    QMSettings::setSlakosType("none");
-    EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::NONE);
-
     QMSettings::setSlakosType(SlakosType::THREEOB);
     EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::THREEOB);
 
     QMSettings::setSlakosType(SlakosType::MATSCI);
     EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::MATSCI);
+#endif
+
+    QMSettings::setSlakosType("custom");
+    EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::CUSTOM);
+
+    QMSettings::setSlakosType("none");
+    EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::NONE);
 
     QMSettings::setSlakosType(SlakosType::CUSTOM);
     EXPECT_EQ(QMSettings::getSlakosType(), SlakosType::CUSTOM);
@@ -176,6 +178,27 @@ TEST(QMSettingsTest, SetSlakosTypeTest)
     );
 }
 
+#ifndef WITH_ASE
+TEST(QMSettingsTest, SetBuiltInSlakosTypeRequiresAse)
+{
+    ASSERT_THROW_MSG(
+        QMSettings::setSlakosType("3ob"),
+        InputFileException,
+        "Built-in SLAKOS sets (3ob/matsci) require building PQ with "
+        "-DBUILD_WITH_ASE=On"
+    );
+
+    ASSERT_THROW_MSG(
+        QMSettings::setSlakosType("matsci"),
+        InputFileException,
+        "Built-in SLAKOS sets (3ob/matsci) require building PQ with "
+        "-DBUILD_WITH_ASE=On"
+    );
+
+    QMSettings::setSlakosType("none");
+}
+#endif
+
 TEST(QMSettingsTest, SetSlakosPathTest)
 {
     QMSettings::setSlakosType("none");
@@ -189,6 +212,7 @@ TEST(QMSettingsTest, SetSlakosPathTest)
     QMSettings::setSlakosPath("/path/to/slakos");
     EXPECT_EQ(QMSettings::getSlakosPath(), "/path/to/slakos");
 
+#ifdef WITH_ASE
     QMSettings::setSlakosType("3ob");
     ASSERT_THROW_MSG(
         QMSettings::setSlakosPath("/path/to/slakos"),
@@ -202,6 +226,7 @@ TEST(QMSettingsTest, SetSlakosPathTest)
         UserInputException,
         "Slakos path cannot be set for slakos type: matsci"
     );
+#endif
 }
 
 TEST(QMSettingsTest, SetXtbMethodTest)

--- a/tests/src/setup/testQMSetup.cpp
+++ b/tests/src/setup/testQMSetup.cpp
@@ -121,6 +121,7 @@ TEST(TestQMSetup, setupQMFull)
     EXPECT_NO_THROW(setup::setupQM(engine));
 }
 
+#ifdef WITH_ASE
 TEST(TestQMSetup, setupQMMethodAseDftbPlus3ob3rdOrderNotSet)
 {
     engine::QMMDEngine engine;
@@ -175,6 +176,7 @@ TEST(TestQMSetup, setupQMMethodAseDftbPlusMatsci)
     qmSetup.setupQMMethodAseDftbPlus();
     EXPECT_EQ(QMSettings::useThirdOrderDftb(), false);
 }
+#endif
 
 TEST(TestQMSetup, setupQMMethodAseDftbPlusCustom)
 {

--- a/tests/src/setup/testQMSetupAse.cpp
+++ b/tests/src/setup/testQMSetupAse.cpp
@@ -37,6 +37,7 @@
 #include "qmRunner.hpp"           // for QMRunner
 #include "throwWithMessage.hpp"   // for ASSERT_THROW_MSG
 
+#ifdef WITH_ASE
 TEST_F(TestQMSetupAse, setupAseDftbplus3OB)
 {
     QMSettings::setSlakosType("3ob");
@@ -156,6 +157,7 @@ TEST_F(TestQMSetupAse, setupAseDftbplusMatsci)
     getline(file, line);
     EXPECT_EQ(line, "         3rd order is turned:  off");
 }
+#endif
 
 TEST_F(TestQMSetupAse, setupAseDftbplusCustom)
 {


### PR DESCRIPTION
Guards built-in SLAKOS tests when ASE support is disabled and verifies the expected input error instead.

Closes #304.