### PR TITLE
build: enforce exhaustive enum switches

### DIFF
--- a/.cmake/testing.cmake
+++ b/.cmake/testing.cmake
@@ -18,9 +18,11 @@ endif()
 
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-# Suppress double promotion warnings for googletest library
+# Suppress project warning policy for googletest library
 set(_CMAKE_CXX_FLAGS_BACKUP "${CMAKE_CXX_FLAGS}")
-string(REPLACE "-Wdouble-promotion" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+foreach(flag IN ITEMS "-Wdouble-promotion" "-Wswitch-enum" "-Werror=switch-enum")
+    string(REPLACE "${flag}" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+endforeach()
 
 add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,10 @@ set(CMAKE_CXX_STANDARD 20)
 # set default flags
 set(CMAKE_CXX_FLAGS "-std=c++20 -Wall -Wextra")
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wswitch-enum -Werror=switch-enum")
+endif()
+
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-use-linker-plugin")
 endif()

--- a/src/engine/hessianEngine.cpp
+++ b/src/engine/hessianEngine.cpp
@@ -290,12 +290,13 @@ pq::SharedOptimizer HessianEngine::setupEmptyOptimizer()
             break;
         }
 
-        case NONE:
-        default:
-            throw UserInputException(
-                std::format("Unknown optimizer type {}", string(optimizerType))
-            );
+        case NONE: break;
     }
+
+    if (!optimizer)
+        throw UserInputException(
+            std::format("Unknown optimizer type {}", string(optimizerType))
+        );
 
     optimizer->setSimulationBox(getSharedSimulationBox());
     optimizer->setPhysicalData(getSharedPhysicalData());
@@ -359,13 +360,13 @@ pq::SharedLearningRate HessianEngine::setupLearningRateStrategy()
                 "implemented"
             );
 
-        case NONE:
-        default:
-            throw UserInputException(
-                "In order to run the optimizer, you need to specify a "
-                "learning rate strategy."
-            );
+        case NONE: break;
     }
+
+    throw UserInputException(
+        "In order to run the optimizer, you need to specify a "
+        "learning rate strategy."
+    );
 }
 
 void HessianEngine::setupConvergence(pq::SharedOptimizer &optimizer)

--- a/src/engine/hessianEngine.cpp
+++ b/src/engine/hessianEngine.cpp
@@ -290,6 +290,7 @@ pq::SharedOptimizer HessianEngine::setupEmptyOptimizer()
             break;
         }
 
+        case NONE:
         default:
             throw UserInputException(
                 std::format("Unknown optimizer type {}", string(optimizerType))
@@ -358,6 +359,7 @@ pq::SharedLearningRate HessianEngine::setupLearningRateStrategy()
                 "implemented"
             );
 
+        case NONE:
         default:
             throw UserInputException(
                 "In order to run the optimizer, you need to specify a "

--- a/src/input/guffDatReader.cpp
+++ b/src/input/guffDatReader.cpp
@@ -381,7 +381,6 @@ void GuffDatReader::addNonCoulombPair(
         }
         case LJ_9_12:
         case NONE:
-        default:
         {
             throw UserInputException(std::format(
                 "Invalid nonCoulombic type {} given",

--- a/src/input/guffDatReader.cpp
+++ b/src/input/guffDatReader.cpp
@@ -379,6 +379,8 @@ void GuffDatReader::addNonCoulombPair(
             );
             break;
         }
+        case LJ_9_12:
+        case NONE:
         default:
         {
             throw UserInputException(std::format(

--- a/src/input/parameterFileReader/nonCoulombicsSection.cpp
+++ b/src/input/parameterFileReader/nonCoulombicsSection.cpp
@@ -118,7 +118,6 @@ void NonCoulombicsSection::processSection(
         case LJ_9_12:
         case GUFF:
         case NONE:
-        default:
             throw ParameterFileException(std::format(
                 "Wrong type of nonCoulombic in parameter file nonCoulombic "
                 "section at line {}  - has to be lj, buckingham or morse!",

--- a/src/input/parameterFileReader/nonCoulombicsSection.cpp
+++ b/src/input/parameterFileReader/nonCoulombicsSection.cpp
@@ -115,6 +115,9 @@ void NonCoulombicsSection::processSection(
 
         case MORSE: processMorse(lineElements, engine); break;
 
+        case LJ_9_12:
+        case GUFF:
+        case NONE:
         default:
             throw ParameterFileException(std::format(
                 "Wrong type of nonCoulombic in parameter file nonCoulombic "

--- a/src/opt/convergence/convergence.cpp
+++ b/src/opt/convergence/convergence.cpp
@@ -84,8 +84,6 @@ bool Convergence::checkConvergence() const
         case ABSOLUTE: isEnergyConverged = _isAbsEnergyConv; break;
 
         case RELATIVE: isEnergyConverged = _isRelEnergyConv; break;
-
-        default: break;
     }
 
     return isEnergyConverged && _isAbsMaxForceConv && _isAbsRMSForceConv;

--- a/src/settings/convergenceSettings.cpp
+++ b/src/settings/convergenceSettings.cpp
@@ -43,9 +43,9 @@ std::string settings::string(const ConvStrategy strategy)
         case LOOSE: return "LOOSE";
         case ABSOLUTE: return "ABSOLUTE";
         case RELATIVE: return "RELATIVE";
-
-        default: return "none";
     }
+
+    return "none";
 }
 
 /**

--- a/src/settings/hessianSettings.cpp
+++ b/src/settings/hessianSettings.cpp
@@ -37,10 +37,10 @@ std::string settings::string(const HessianBuilderType builder)
         case FINITE_DIFFERENCE_FORCES_FORWARD: return "FORWARD";
         case FINITE_DIFFERENCE_FORCES_FIVE_POINT: return "FIVE-POINT";
         case ANALYTIC: return "ANALYTIC";
-        case NONE: return "NONE";
-
-        default: return "NONE";
+        case NONE: break;
     }
+
+    return "NONE";
 }
 
 void HessianSettings::setHessianFile(const std::string_view &filename)

--- a/src/settings/manostatSettings.cpp
+++ b/src/settings/manostatSettings.cpp
@@ -38,8 +38,8 @@ std::string settings::string(const ManostatType &manostatType)
         case ManostatType::BERENDSEN: return "berendsen";
 
         case ManostatType::STOCHASTIC_RESCALING: return "stochastic_rescaling";
-        case ManostatType::NONE: return "none";
 
+        case ManostatType::NONE:
         default: return "none";
     }
 }
@@ -59,8 +59,8 @@ std::string settings::string(const Isotropy &isotropy)
         case SEMI_ISOTROPIC: return "semi_isotropic";
         case ANISOTROPIC: return "anisotropic";
         case FULL_ANISOTROPIC: return "full_anisotropic";
-        case NONE: return "isotropic";
 
+        case NONE:
         default: return "isotropic";
     }
 }

--- a/src/settings/manostatSettings.cpp
+++ b/src/settings/manostatSettings.cpp
@@ -38,6 +38,7 @@ std::string settings::string(const ManostatType &manostatType)
         case ManostatType::BERENDSEN: return "berendsen";
 
         case ManostatType::STOCHASTIC_RESCALING: return "stochastic_rescaling";
+        case ManostatType::NONE: return "none";
 
         default: return "none";
     }
@@ -58,6 +59,7 @@ std::string settings::string(const Isotropy &isotropy)
         case SEMI_ISOTROPIC: return "semi_isotropic";
         case ANISOTROPIC: return "anisotropic";
         case FULL_ANISOTROPIC: return "full_anisotropic";
+        case NONE: return "isotropic";
 
         default: return "isotropic";
     }

--- a/src/settings/manostatSettings.cpp
+++ b/src/settings/manostatSettings.cpp
@@ -39,9 +39,10 @@ std::string settings::string(const ManostatType &manostatType)
 
         case ManostatType::STOCHASTIC_RESCALING: return "stochastic_rescaling";
 
-        case ManostatType::NONE:
-        default: return "none";
+        case ManostatType::NONE: break;
     }
+
+    return "none";
 }
 
 /**
@@ -60,9 +61,10 @@ std::string settings::string(const Isotropy &isotropy)
         case ANISOTROPIC: return "anisotropic";
         case FULL_ANISOTROPIC: return "full_anisotropic";
 
-        case NONE:
-        default: return "isotropic";
+        case NONE: break;
     }
+
+    return "isotropic";
 }
 
 /***************************

--- a/src/settings/optimizerSettings.cpp
+++ b/src/settings/optimizerSettings.cpp
@@ -41,8 +41,8 @@ std::string settings::string(const OptimizerType method)
 
         case STEEPEST_DESCENT: return "STEEPEST-DESCENT";
         case ADAM: return "ADAM";
-        case NONE: return "none";
 
+        case NONE:
         default: return "none";
     }
 }
@@ -63,8 +63,8 @@ std::string settings::string(const LREnum method)
         case CONSTANT_DECAY: return "CONSTANT-DECAY";
         case EXPONENTIAL_DECAY: return "EXPONENTIAL-DECAY";
         case LINESEARCH_WOLFE: return "LINESEARCH-WOLFE";
-        case NONE: return "none";
 
+        case NONE:
         default: return "none";
     }
 }

--- a/src/settings/optimizerSettings.cpp
+++ b/src/settings/optimizerSettings.cpp
@@ -42,9 +42,10 @@ std::string settings::string(const OptimizerType method)
         case STEEPEST_DESCENT: return "STEEPEST-DESCENT";
         case ADAM: return "ADAM";
 
-        case NONE:
-        default: return "none";
+        case NONE: break;
     }
+
+    return "none";
 }
 
 /**
@@ -64,9 +65,10 @@ std::string settings::string(const LREnum method)
         case EXPONENTIAL_DECAY: return "EXPONENTIAL-DECAY";
         case LINESEARCH_WOLFE: return "LINESEARCH-WOLFE";
 
-        case NONE:
-        default: return "none";
+        case NONE: break;
     }
+
+    return "none";
 }
 
 /***************************

--- a/src/settings/optimizerSettings.cpp
+++ b/src/settings/optimizerSettings.cpp
@@ -41,6 +41,7 @@ std::string settings::string(const OptimizerType method)
 
         case STEEPEST_DESCENT: return "STEEPEST-DESCENT";
         case ADAM: return "ADAM";
+        case NONE: return "none";
 
         default: return "none";
     }
@@ -62,6 +63,7 @@ std::string settings::string(const LREnum method)
         case CONSTANT_DECAY: return "CONSTANT-DECAY";
         case EXPONENTIAL_DECAY: return "EXPONENTIAL-DECAY";
         case LINESEARCH_WOLFE: return "LINESEARCH-WOLFE";
+        case NONE: return "none";
 
         default: return "none";
     }

--- a/src/settings/potentialSettings.cpp
+++ b/src/settings/potentialSettings.cpp
@@ -47,9 +47,10 @@ std::string settings::string(const NonCoulombType nonCoulombType)
         case MORSE: return "morse";
         case GUFF: return "guff";
 
-        case NONE:
-        default: return "none";
+        case NONE: break;
     }
+
+    return "none";
 }
 
 /**
@@ -66,10 +67,10 @@ std::string settings::string(const CoulombLongRangeType coulombLongRangeType)
 
         case REACTION_FIELD: return "reaction-field";
         case WOLF: return "wolf";
-        case SHIFTED: return "shifted";
-
-        default: return "shifted";
+        case SHIFTED: break;
     }
+
+    return "shifted";
 }
 
 /********************

--- a/src/settings/potentialSettings.cpp
+++ b/src/settings/potentialSettings.cpp
@@ -46,8 +46,8 @@ std::string settings::string(const NonCoulombType nonCoulombType)
         case BUCKINGHAM: return "buck";
         case MORSE: return "morse";
         case GUFF: return "guff";
-        case NONE: return "none";
 
+        case NONE:
         default: return "none";
     }
 }

--- a/src/settings/potentialSettings.cpp
+++ b/src/settings/potentialSettings.cpp
@@ -46,6 +46,7 @@ std::string settings::string(const NonCoulombType nonCoulombType)
         case BUCKINGHAM: return "buck";
         case MORSE: return "morse";
         case GUFF: return "guff";
+        case NONE: return "none";
 
         default: return "none";
     }

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -56,6 +56,7 @@ std::string settings::string(const QMMethod method)
         case TURBOMOLE: return "TURBOMOLE";
         case MACE: return "MACE";
         case FENNOL: return "FeNNol";
+        case NONE: return "none";
 
         default: return "none";
     }
@@ -144,6 +145,7 @@ std::string settings::string(const SlakosType slakos)
         case THREEOB: return "3ob";
         case MATSCI: return "matsci";
         case CUSTOM: return "custom";
+        case NONE: return "none";
 
         default: return "none";
     }

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -56,8 +56,8 @@ std::string settings::string(const QMMethod method)
         case TURBOMOLE: return "TURBOMOLE";
         case MACE: return "MACE";
         case FENNOL: return "FeNNol";
-        case NONE: return "none";
 
+        case NONE:
         default: return "none";
     }
 }
@@ -145,8 +145,8 @@ std::string settings::string(const SlakosType slakos)
         case THREEOB: return "3ob";
         case MATSCI: return "matsci";
         case CUSTOM: return "custom";
-        case NONE: return "none";
 
+        case NONE:
         default: return "none";
     }
 }

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -57,9 +57,10 @@ std::string settings::string(const QMMethod method)
         case MACE: return "MACE";
         case FENNOL: return "FeNNol";
 
-        case NONE:
-        default: return "none";
+        case NONE: break;
     }
+
+    return "none";
 }
 
 /**
@@ -86,9 +87,9 @@ std::string settings::string(const MaceModel model)
         case MEDIUMMPA0: return "medium-mpa-0";
         case MEDIUMOMAT0: return "medium-omat-0";
         case CUSTOM: return "custom";
-
-        default: return "none";
     }
+
+    return "none";
 }
 
 /**
@@ -106,9 +107,9 @@ std::string settings::string(const MaceModelType model)
         case MACE_MP: return "mace_mp";
         case MACE_OFF: return "mace_off";
         case MACE_ANICC: return "mace_anicc";
-
-        default: return "none";
     }
+
+    return "none";
 }
 
 /**
@@ -125,9 +126,9 @@ std::string settings::string(const MaceMode mode)
 
         case ACCURATE: return "accurate";
         case FAST: return "fast";
-
-        default: return "unknown mode";
     }
+
+    return "unknown mode";
 }
 
 /**
@@ -146,9 +147,10 @@ std::string settings::string(const SlakosType slakos)
         case MATSCI: return "matsci";
         case CUSTOM: return "custom";
 
-        case NONE:
-        default: return "none";
+        case NONE: break;
     }
+
+    return "none";
 }
 
 /**
@@ -185,9 +187,9 @@ std::string settings::string(const XtbMethod method)
         case GFN1: return "GFN1-xTB";
         case GFN2: return "GFN2-xTB";
         case IPEA1: return "IPEA1-xTB";
-
-        default: return "none";
     }
+
+    return "none";
 }
 
 /**

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -109,8 +109,8 @@ void Settings::setJobtype(const JobType jobtype)
         case QM_MD: deactivateRingPolymerMD(); break;
         case RING_POLYMER_QM_MD: activateRingPolymerMD(); break;
         case QMMM_MD: deactivateRingPolymerMD(); break;
+        case NONE: deactivateRingPolymerMD(); break;
 
-        // case NONE: fallthrough
         default: deactivateRingPolymerMD(); break;
     }
 }

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -46,10 +46,10 @@ std::string settings::string(const JobType jobtype)
         case RING_POLYMER_QM_MD: return "RING_POLYMER_QM_MD";
         case MM_OPT: return "MM_OPT";
         case MM_HESSIAN: return "MM_HESSIAN";
-        case NONE: return "NONE";
-
-        default: return "NONE";
+        case NONE: break;
     }
+
+    return "NONE";
 }
 
 /***************************
@@ -110,8 +110,6 @@ void Settings::setJobtype(const JobType jobtype)
         case RING_POLYMER_QM_MD: activateRingPolymerMD(); break;
         case QMMM_MD: deactivateRingPolymerMD(); break;
         case NONE: deactivateRingPolymerMD(); break;
-
-        default: deactivateRingPolymerMD(); break;
     }
 }
 

--- a/src/settings/thermostatSettings.cpp
+++ b/src/settings/thermostatSettings.cpp
@@ -43,6 +43,7 @@ std::string settings::string(const ThermostatType &thermostatType)
         case VELOCITY_RESCALING: return "velocity_rescaling";
         case LANGEVIN: return "langevin";
         case NOSE_HOOVER: return "nh-chain";
+        case NONE: return "none";
 
         default: return "none";
     }

--- a/src/settings/thermostatSettings.cpp
+++ b/src/settings/thermostatSettings.cpp
@@ -43,8 +43,8 @@ std::string settings::string(const ThermostatType &thermostatType)
         case VELOCITY_RESCALING: return "velocity_rescaling";
         case LANGEVIN: return "langevin";
         case NOSE_HOOVER: return "nh-chain";
-        case NONE: return "none";
 
+        case NONE:
         default: return "none";
     }
 }

--- a/src/settings/thermostatSettings.cpp
+++ b/src/settings/thermostatSettings.cpp
@@ -44,9 +44,10 @@ std::string settings::string(const ThermostatType &thermostatType)
         case LANGEVIN: return "langevin";
         case NOSE_HOOVER: return "nh-chain";
 
-        case NONE:
-        default: return "none";
+        case NONE: break;
     }
+
+    return "none";
 }
 
 /**

--- a/src/setup/manostatSetup.cpp
+++ b/src/setup/manostatSetup.cpp
@@ -148,8 +148,7 @@ void ManostatSetup::setupBerendsenManostat()
             break;
 
         case NONE: // fall through
-        case ISOTROPIC: // fall through
-        default:
+        case ISOTROPIC:
             _engine.makeManostat(BerendsenManostat(pTarget, tau, compress));
 
             // clang-format on
@@ -190,8 +189,7 @@ void ManostatSetup::setupStochasticRescalingManostat()
             break;
 
         case NONE: // fall through
-        case ISOTROPIC: // fall through
-        default:
+        case ISOTROPIC:
             _engine.makeManostat(pq::StochasticManostat(pTarget, tau, compress));
 
             // clang-format on
@@ -233,8 +231,7 @@ void ManostatSetup::writeManostatSelection() const
             logOutput.writeSetupInfo("Stochastic rescaling manostat selected");
             break;
 
-        case NONE:
-        default: logOutput.writeSetupInfo("No manostat selected");
+        case NONE: logOutput.writeSetupInfo("No manostat selected");
     }
 
     logOutput.writeEmptyLine();
@@ -312,8 +309,7 @@ void ManostatSetup::writeIsotropy() const
             logOutput.writeSetupInfo("Isotropy: full anisotropic");
             break;
 
-        case NONE:
-        default: logOutput.writeSetupInfo("Isotropy: isotropic");
+        case NONE: logOutput.writeSetupInfo("Isotropy: isotropic");
     }
 
     logOutput.writeEmptyLine();

--- a/src/setup/manostatSetup.cpp
+++ b/src/setup/manostatSetup.cpp
@@ -147,6 +147,7 @@ void ManostatSetup::setupBerendsenManostat()
             _engine.makeManostat(FullAnisotropicBerendsenManostat(pTarget, tau, compress));
             break;
 
+        case NONE: // fall through
         case ISOTROPIC: // fall through
         default:
             _engine.makeManostat(BerendsenManostat(pTarget, tau, compress));
@@ -188,6 +189,7 @@ void ManostatSetup::setupStochasticRescalingManostat()
             _engine.makeManostat(pq::FullAnisoStochasticManostat(pTarget, tau, compress));
             break;
 
+        case NONE: // fall through
         case ISOTROPIC: // fall through
         default:
             _engine.makeManostat(pq::StochasticManostat(pTarget, tau, compress));
@@ -231,6 +233,7 @@ void ManostatSetup::writeManostatSelection() const
             logOutput.writeSetupInfo("Stochastic rescaling manostat selected");
             break;
 
+        case NONE:
         default: logOutput.writeSetupInfo("No manostat selected");
     }
 
@@ -309,6 +312,7 @@ void ManostatSetup::writeIsotropy() const
             logOutput.writeSetupInfo("Isotropy: full anisotropic");
             break;
 
+        case NONE:
         default: logOutput.writeSetupInfo("Isotropy: isotropic");
     }
 

--- a/src/setup/optimizerSetup.cpp
+++ b/src/setup/optimizerSetup.cpp
@@ -130,12 +130,13 @@ pq::SharedOptimizer OptimizerSetup::setupEmptyOptimizer()
             break;
         }
 
-        case NONE:
-        default:
-            throw UserInputException(
-                std::format("Unknown optimizer type {}", string(optimizerType))
-            );
+        case NONE: break;
     }
+
+    if (!optimizer)
+        throw UserInputException(
+            std::format("Unknown optimizer type {}", string(optimizerType))
+        );
 
     optimizer->setSimulationBox(_optEngine.getSharedSimulationBox());
     optimizer->setPhysicalData(_optEngine.getSharedPhysicalData());
@@ -207,15 +208,13 @@ pq::SharedLearningRate OptimizerSetup::setupLearningRateStrategy()
             );
         }
 
-        case NONE:
-        default:
-        {
-            throw UserInputException(
-                std::format("In order to run the optimizer, you need to "
-                            "specify a learning rate strategy.")
-            );
-        }
+        case NONE: break;
     }
+
+    throw UserInputException(
+        "In order to run the optimizer, you need to specify a learning rate "
+        "strategy."
+    );
 }
 
 /**

--- a/src/setup/optimizerSetup.cpp
+++ b/src/setup/optimizerSetup.cpp
@@ -130,6 +130,7 @@ pq::SharedOptimizer OptimizerSetup::setupEmptyOptimizer()
             break;
         }
 
+        case NONE:
         default:
             throw UserInputException(
                 std::format("Unknown optimizer type {}", string(optimizerType))
@@ -206,6 +207,7 @@ pq::SharedLearningRate OptimizerSetup::setupLearningRateStrategy()
             );
         }
 
+        case NONE:
         default:
         {
             throw UserInputException(

--- a/src/setup/potentialSetup.cpp
+++ b/src/setup/potentialSetup.cpp
@@ -114,16 +114,16 @@ void PotentialSetup::setupCoulomb()
             potential.makeCoulombPotential(
                 CoulombReactionField(coulRCut, rfEpsilon)
             );
-            break;
+            return;
 
         case WOLF:
             potential.makeCoulombPotential(CoulombWolf(coulRCut, wolfParam));
-            break;
+            return;
 
-        case SHIFTED:
-        default:
-            potential.makeCoulombPotential(CoulombShiftedPotential(coulRCut));
+        case SHIFTED: break;
     }
+
+    potential.makeCoulombPotential(CoulombShiftedPotential(coulRCut));
 }
 
 /**

--- a/src/setup/thermostatSetup.cpp
+++ b/src/setup/thermostatSetup.cpp
@@ -104,6 +104,7 @@ void ThermostatSetup::setup()
 
         case NOSE_HOOVER: setupNoseHooverThermostat(); break;
 
+        case NONE:
         default: _engine.makeThermostat(Thermostat());
     }
 

--- a/src/setup/thermostatSetup.cpp
+++ b/src/setup/thermostatSetup.cpp
@@ -104,8 +104,7 @@ void ThermostatSetup::setup()
 
         case NOSE_HOOVER: setupNoseHooverThermostat(); break;
 
-        case NONE:
-        default: _engine.makeThermostat(Thermostat());
+        case NONE: _engine.makeThermostat(Thermostat());
     }
 
     setupTemperatureRamp();

--- a/tests/src/input/inputFileParsing/testGeneralParser.cpp
+++ b/tests/src/input/inputFileParsing/testGeneralParser.cpp
@@ -103,6 +103,7 @@ TEST_F(TestInputFileReader, JobType)
     Settings::setIsRingPolymerMDActivated(true);
     Settings::setJobtype(JobType::NONE);
     EXPECT_FALSE(Settings::isRingPolymerMDActivated());
+    EXPECT_EQ(string(JobType::NONE), "NONE");
 }
 
 /**

--- a/tests/src/input/inputFileParsing/testGeneralParser.cpp
+++ b/tests/src/input/inputFileParsing/testGeneralParser.cpp
@@ -99,6 +99,10 @@ TEST_F(TestInputFileReader, JobType)
     );
 
     EXPECT_NO_THROW(parser.parseJobType(lineElements, 0));
+
+    Settings::setIsRingPolymerMDActivated(true);
+    Settings::setJobtype(JobType::NONE);
+    EXPECT_FALSE(Settings::isRingPolymerMDActivated());
 }
 
 /**

--- a/tests/src/settings/testConvergenceSettings.cpp
+++ b/tests/src/settings/testConvergenceSettings.cpp
@@ -25,6 +25,20 @@
 #include "convergenceSettings.hpp"
 #include "gtest/gtest.h"
 
+TEST(ConvSettingsTest, StrategyToString)
+{
+    using enum settings::ConvStrategy;
+
+    EXPECT_EQ(settings::string(RIGOROUS), "RIGOROUS");
+    EXPECT_EQ(settings::string(LOOSE), "LOOSE");
+    EXPECT_EQ(settings::string(ABSOLUTE), "ABSOLUTE");
+    EXPECT_EQ(settings::string(RELATIVE), "RELATIVE");
+    EXPECT_EQ(
+        settings::string(static_cast<settings::ConvStrategy>(-1)),
+        "none"
+    );
+}
+
 TEST(ConvSettingsTest, EnergyConvSettersAndOptionalGetters)
 {
     settings::ConvSettings::setEnergyConv(1.0e-6);

--- a/tests/src/settings/testHessianSettings.cpp
+++ b/tests/src/settings/testHessianSettings.cpp
@@ -51,6 +51,7 @@ TEST(TestHessianSettings, setBuilder)
 
     HessianSettings::setBuilder("unknown");
     EXPECT_EQ(HessianSettings::getBuilder(), HessianBuilderType::NONE);
+    EXPECT_EQ(string(HessianBuilderType::NONE), "NONE");
 }
 
 TEST(TestHessianSettings, setFilesAndDisplacement)

--- a/tests/src/settings/testManostatSettings.cpp
+++ b/tests/src/settings/testManostatSettings.cpp
@@ -131,4 +131,5 @@ TEST(ManostatSettingsTest, StringRoundTripForIsotropy)
         settings::string(settings::Isotropy::FULL_ANISOTROPIC),
         "full_anisotropic"
     );
+    EXPECT_EQ(settings::string(settings::Isotropy::NONE), "isotropic");
 }

--- a/tests/src/settings/testQMSettings.cpp
+++ b/tests/src/settings/testQMSettings.cpp
@@ -281,6 +281,7 @@ TEST(QMSettingsTest, ReturnMaceModelTypeTest)
     EXPECT_EQ(string(MaceModelType::MACE_MP), "mace_mp");
     EXPECT_EQ(string(MaceModelType::MACE_OFF), "mace_off");
     EXPECT_EQ(string(MaceModelType::MACE_ANICC), "mace_anicc");
+    EXPECT_EQ(string(static_cast<MaceModelType>(-1)), "none");
 }
 
 TEST(QMSettingsTest, ReturnMaceModelTest)
@@ -297,6 +298,14 @@ TEST(QMSettingsTest, ReturnMaceModelTest)
     EXPECT_EQ(string(MaceModel::MEDIUMMPA0), "medium-mpa-0");
     EXPECT_EQ(string(MaceModel::MEDIUMOMAT0), "medium-omat-0");
     EXPECT_EQ(string(MaceModel::CUSTOM), "custom");
+    EXPECT_EQ(string(static_cast<MaceModel>(-1)), "none");
+}
+
+TEST(QMSettingsTest, ReturnMaceModeTest)
+{
+    EXPECT_EQ(string(MaceMode::ACCURATE), "accurate");
+    EXPECT_EQ(string(MaceMode::FAST), "fast");
+    EXPECT_EQ(string(static_cast<MaceMode>(-1)), "unknown mode");
 }
 
 TEST(QMSettingsTest, ReturnXtbMethodTest)
@@ -304,6 +313,7 @@ TEST(QMSettingsTest, ReturnXtbMethodTest)
     EXPECT_EQ(string(XtbMethod::GFN1), "GFN1-xTB");
     EXPECT_EQ(string(XtbMethod::GFN2), "GFN2-xTB");
     EXPECT_EQ(string(XtbMethod::IPEA1), "IPEA1-xTB");
+    EXPECT_EQ(string(static_cast<XtbMethod>(-1)), "none");
 }
 
 TEST(QMSettingsTest, SetFennolModelPath)

--- a/tests/src/setup/testManostatSetup.cpp
+++ b/tests/src/setup/testManostatSetup.cpp
@@ -81,6 +81,23 @@ TEST_F(TestSetup, setupManostatBerendsen)
     EXPECT_EQ(berendsen.getCompressibility(), 4.0);
 }
 
+TEST_F(TestSetup, setupManostatNoneIsotropyDefaultsToIsotropic)
+{
+    ManostatSettings::setManostatType(ManostatType::BERENDSEN);
+    ManostatSettings::setIsotropy(Isotropy::NONE);
+    ManostatSettings::setPressureSet(true);
+    ManostatSettings::setTargetPressure(300.0);
+    ManostatSettings::setTauManostat(0.2);
+    ManostatSettings::setCompressibility(4.0);
+
+    ManostatSetup manostatSetup(*_mdEngine);
+    EXPECT_NO_THROW(manostatSetup.setup());
+
+    const auto &manostat = _mdEngine->getManostat();
+    const auto berendsen = dynamic_cast<const BerendsenManostat &>(manostat);
+    EXPECT_EQ(berendsen.getIsotropy(), Isotropy::ISOTROPIC);
+}
+
 TEST_F(TestSetup, setupManostatSemiIsotropicBerendsen)
 {
     ManostatSettings::setManostatType("berendsen");

--- a/tests/src/setup/testOptimizerSetup.cpp
+++ b/tests/src/setup/testOptimizerSetup.cpp
@@ -135,6 +135,8 @@ TEST_F(TestSetup, setupLearningRateStrategyNoneThrows)
 {
     resetOptimizerSettings();
     OptimizerSettings::setLearningRateStrategy(LREnum::NONE);
+    EXPECT_EQ(string(LREnum::NONE), "none");
+
     OptimizerSetup s(dynamic_cast<engine::OptEngine &>(*_engine));
     EXPECT_THROW(s.setupLearningRateStrategy(), UserInputException);
 }


### PR DESCRIPTION
Adds a GNU compile-time error for unhandled enum values and makes the existing sentinel cases explicit without changing their behavior.

Closes #291