### PR TITLE
refactor: centralize input keyword validation

### DIFF
--- a/include/input/inputFileReader.hpp
+++ b/include/input/inputFileReader.hpp
@@ -110,7 +110,12 @@ namespace input
          * input validation functions *
          ******************************/
 
+        void validateTimings() const;
+        void validateQM() const;
+        void validateThermostat() const;
+        void validateManostat() const;
         void validateReactionFieldCoulomb() const;
+        void validateRingPolymer() const;
     };
 
 }   // namespace input

--- a/include/settings/manostatSettings.hpp
+++ b/include/settings/manostatSettings.hpp
@@ -75,8 +75,6 @@ namespace settings
         static inline ManostatType _manostatType = ManostatType::NONE;
         static inline Isotropy     _isotropy     = Isotropy::ISOTROPIC;
 
-        static inline bool _isPressureSet = false;
-
         static inline double _targetPressure;
 
         // clang-format off
@@ -101,7 +99,6 @@ namespace settings
         static void setIsotropy(const std::string_view &isotropy);
         static void setIsotropy(const Isotropy &isotropy);
 
-        static void setPressureSet(const bool pressureSet);
         static void setTargetPressure(const double targetPressure);
         static void setTauManostat(const double tauManostat);
         static void setCompressibility(const double compressibility);
@@ -112,7 +109,6 @@ namespace settings
          * standard getter methods *
          ***************************/
 
-        [[nodiscard]] static bool isPressureSet();
         [[nodiscard]] static bool isBerendsenBased();
 
         [[nodiscard]] static ManostatType        getManostatType();

--- a/include/settings/ringPolymerSettings.hpp
+++ b/include/settings/ringPolymerSettings.hpp
@@ -37,14 +37,12 @@ namespace settings
     class RingPolymerSettings
     {
        private:
-        static inline bool   _numberOfBeadsSet = false;
-        static inline size_t _numberOfBeads    = 0;
+        static inline size_t _numberOfBeads = 0;
 
        public:
         static void setNumberOfBeads(const size_t numberOfBeads);
 
         [[nodiscard]] static size_t getNumberOfBeads();
-        [[nodiscard]] static bool   isNumberOfBeadsSet();
     };
 }   // namespace settings
 

--- a/include/settings/timingsSettings.hpp
+++ b/include/settings/timingsSettings.hpp
@@ -41,9 +41,6 @@ namespace settings
         static inline size_t _numberOfSteps;
         static inline size_t _stepCount = 0;
 
-        static inline bool _isTimeStepSet = false;
-        static inline bool _isNumberOfStepsSet = false;
-
        public:
         TimingsSettings()  = default;
         ~TimingsSettings() = default;
@@ -63,8 +60,6 @@ namespace settings
         [[nodiscard]] static double getTimeStep();
         [[nodiscard]] static size_t getStepCount();
         [[nodiscard]] static size_t getNumberOfSteps();
-        [[nodiscard]] static bool   isTimeStepSet();
-        [[nodiscard]] static bool   isNumberOfStepsSet();
     };
 }   // namespace settings
 

--- a/include/setup/manostatSetup.hpp
+++ b/include/setup/manostatSetup.hpp
@@ -46,7 +46,6 @@ namespace setup
 
         void setup();
 
-        void isPressureSet() const;
         void setupBerendsenManostat();
         void setupStochasticRescalingManostat();
 

--- a/include/setup/qmSetup.hpp
+++ b/include/setup/qmSetup.hpp
@@ -47,8 +47,6 @@ namespace setup
         void setup();
         void setupQMMethod();
         void setupQMMethodAseDftbPlus();
-        void setupQMMethodFennol();
-        void setupQMMethodMace();
         void setupQMMethodAseXtb();
         void setupQMScript() const;
         void setupCoulombRadiusCutOff() const;

--- a/include/setup/thermostatSetup.hpp
+++ b/include/setup/thermostatSetup.hpp
@@ -46,7 +46,7 @@ namespace setup
 
         void setup();
 
-        void isTargetTemperatureSet() const;
+        void setupTargetTemperature() const;
         void setupTemperatureRamp();
         void setupBerendsenThermostat();
         void setupLangevinThermostat();

--- a/src/input/inputFileParser/manostatInputParser.cpp
+++ b/src/input/inputFileParser/manostatInputParser.cpp
@@ -148,7 +148,6 @@ void ManostatInputParser::parsePressure(
     checkCommand(lineElements, lineNumber);
 
     ManostatSettings::setTargetPressure(stod(lineElements[2]));
-    ManostatSettings::setPressureSet(true);
 }
 
 /**

--- a/src/input/inputValidation.cpp
+++ b/src/input/inputValidation.cpp
@@ -20,9 +20,18 @@
 <GPL_HEADER>
 ******************************************************************************/
 
-#include "exceptions.hpp"          // for InputFileException
-#include "inputFileReader.hpp"     // for InputFileReader
-#include "potentialSettings.hpp"   // for PotentialSettings
+#include "inputFileReader.hpp"
+
+#include <format>   // for format
+
+#include "exceptions.hpp"            // for InputFileException
+#include "hessianSettings.hpp"       // for HessianSettings
+#include "manostatSettings.hpp"      // for ManostatSettings
+#include "potentialSettings.hpp"     // for PotentialSettings
+#include "qmSettings.hpp"            // for QMSettings
+#include "settings.hpp"              // for Settings
+#include "thermostatSettings.hpp"    // for ThermostatSettings
+#include "timingsSettings.hpp"       // for TimingsSettings
 
 using namespace input;
 using namespace settings;
@@ -36,7 +45,178 @@ using namespace customException;
  */
 void InputFileReader::validateInputConfiguration() const
 {
+    validateTimings();
+    validateQM();
+    validateThermostat();
+    validateManostat();
     validateReactionFieldCoulomb();
+    validateRingPolymer();
+}
+
+/**
+ * @brief validates conditionally required timing keywords
+ *
+ * @throws UserInputException if `nstep` or `timestep` is missing for a job
+ * type that requires it
+ */
+void InputFileReader::validateTimings() const
+{
+    using enum JobType;
+
+    const auto jobType = Settings::getJobtype();
+    const auto requiresNumberOfSteps =
+        Settings::isMDJobType() || Settings::isOptJobType() ||
+        (jobType == MM_HESSIAN && HessianSettings::optimizeBeforeHessian());
+
+    if (requiresNumberOfSteps && !getKeywordSet("nstep"))
+        throw UserInputException(std::format(
+            "Job type {} selected. Please set nstep in the input file.",
+            string(jobType)
+        ));
+
+    if (Settings::isMDJobType() && !getKeywordSet("timestep"))
+        throw UserInputException(std::format(
+            "Molecular Dynamics job type {} selected. Please set the "
+            "time step in the input file.",
+            string(jobType)
+        ));
+}
+
+/**
+ * @brief validates QM keyword dependencies
+ *
+ * @throws InputFileException if selected QM settings require missing or
+ * incompatible keywords
+ */
+void InputFileReader::validateQM() const
+{
+    if (!Settings::isQMActivated())
+        return;
+
+    const auto qmMethod = QMSettings::getQMMethod();
+
+    if (qmMethod == QMMethod::ASEDFTBPLUS)
+    {
+        auto useThirdOrder = QMSettings::useThirdOrderDftb();
+
+        if (QMSettings::getSlakosType() == SlakosType::THREEOB &&
+            !getKeywordSet("third_order"))
+            useThirdOrder = true;
+
+        if (!useThirdOrder && getKeywordSet("hubbard_derivs"))
+            throw InputFileException(
+                "You have set custom Hubbard derivatives but disabled 3rd "
+                "order DFTB. This setup is invalid."
+            );
+    }
+
+    if (qmMethod == QMMethod::FENNOL && !getKeywordSet("fennol_model_path"))
+        throw InputFileException(
+            "The FeNNol QM runner has been selected but the "
+            "\"fennol_model_path\" keyword has not been set. This setup is "
+            "invalid."
+        );
+
+    if (qmMethod != QMMethod::MACE)
+        return;
+
+    const auto modelType    = QMSettings::getMaceModelType();
+    const auto model        = QMSettings::getMaceModel();
+    const auto modelPathSet = getKeywordSet("mace_model_path");
+
+    if (modelType != MaceModelType::MACE_MP && model != MaceModel::SMALL &&
+        model != MaceModel::MEDIUM && model != MaceModel::LARGE)
+        throw InputFileException(std::format(
+            "The '{}' model size is only compatible with the '{}' model type.",
+            string(model),
+            string(MaceModelType::MACE_MP)
+        ));
+
+    if (model == MaceModel::CUSTOM && !modelPathSet)
+        throw InputFileException(
+            "You have requested a custom MACE model but haven't provided a "
+            "MACE model path."
+            "This setup is invalid."
+        );
+
+    if (model != MaceModel::CUSTOM && modelPathSet)
+        throw InputFileException(
+            "You have set a custom MACE model path without requesting a custom "
+            "mace model size."
+            "This setup is invalid."
+        );
+}
+
+/**
+ * @brief validates thermostat keyword dependencies
+ *
+ * @throws InputFileException if temperature keywords are missing,
+ * contradictory, or define an invalid ramp
+ */
+void InputFileReader::validateThermostat() const
+{
+    const auto thermostatType = ThermostatSettings::getThermostatType();
+
+    if (thermostatType != ThermostatType::NONE)
+    {
+        const auto targetTempDefined = getKeywordSet("temp");
+        const auto endTempDefined    = getKeywordSet("end_temp");
+
+        if (!targetTempDefined && !endTempDefined)
+            throw InputFileException(std::format(
+                "Target or end temperature not set for {} thermostat",
+                string(thermostatType)
+            ));
+
+        if (targetTempDefined && endTempDefined)
+            throw InputFileException(std::format(
+                "Both target and end temperature set for {} thermostat. They "
+                "are mutually exclusive as they are treated as synonyms",
+                string(thermostatType)
+            ));
+    }
+
+    if (!getKeywordSet("start_temp"))
+        return;
+
+    const auto totalSteps = TimingsSettings::getNumberOfSteps();
+    const auto rampSteps  = ThermostatSettings::getTemperatureRampSteps();
+
+    if (rampSteps > totalSteps)
+        throw InputFileException(std::format(
+            "Number of total simulation steps {} is smaller than the "
+            "number of temperature ramping steps {}",
+            totalSteps,
+            rampSteps
+        ));
+
+    const auto effectiveRampSteps = rampSteps == 0 ? totalSteps : rampSteps;
+    const auto frequency =
+        ThermostatSettings::getTemperatureRampFrequency();
+
+    if (frequency > effectiveRampSteps)
+        throw InputFileException(std::format(
+            "Temperature ramp frequency {} is larger than the number of "
+            "ramping steps {}",
+            frequency,
+            effectiveRampSteps
+        ));
+}
+
+/**
+ * @brief validates manostat keyword dependencies
+ *
+ * @throws InputFileException if a manostat is selected without `pressure`
+ */
+void InputFileReader::validateManostat() const
+{
+    const auto manostatType = ManostatSettings::getManostatType();
+
+    if (manostatType != ManostatType::NONE && !getKeywordSet("pressure"))
+        throw InputFileException(std::format(
+            "Pressure not set for {} manostat",
+            string(manostatType)
+        ));
 }
 
 /**
@@ -58,5 +238,19 @@ void InputFileReader::validateReactionFieldCoulomb() const
             "Missing required keyword \"rf_epsilon\" in input file: it must "
             "be set when the Coulomb long-range correction is set to "
             "\"reaction-field\"."
+        );
+}
+
+/**
+ * @brief validates ring-polymer keyword dependencies
+ *
+ * @throws InputFileException if a ring-polymer job omits `rpmd_n_replica`
+ */
+void InputFileReader::validateRingPolymer() const
+{
+    if (Settings::isRingPolymerMDActivated() &&
+        !getKeywordSet("rpmd_n_replica"))
+        throw InputFileException(
+            "Number of beads not set for ring polymer simulation"
         );
 }

--- a/src/settings/manostatSettings.cpp
+++ b/src/settings/manostatSettings.cpp
@@ -140,16 +140,6 @@ void ManostatSettings::setIsotropy(const Isotropy &isotropy)
 }
 
 /**
- * @brief sets the pressureSet to bool in settings
- *
- * @param pressureSet
- */
-void ManostatSettings::setPressureSet(const bool pressureSet)
-{
-    _isPressureSet = pressureSet;
-}
-
-/**
  * @brief sets the targetPressure to double in settings
  *
  * @param target
@@ -204,13 +194,6 @@ void ManostatSettings::set2DAnisotropicAxis(const size_t index)
  * standard getter methods *
  *                         *
  ***************************/
-
-/**
- * @brief get if pressure is set
- *
- * @return bool
- */
-bool ManostatSettings::isPressureSet() { return _isPressureSet; }
 
 /**
  * @brief get if manostat is Berendsen based

--- a/src/settings/ringPolymerSettings.cpp
+++ b/src/settings/ringPolymerSettings.cpp
@@ -31,8 +31,7 @@ using settings::RingPolymerSettings;
  */
 void RingPolymerSettings::setNumberOfBeads(const size_t numberOfBeads)
 {
-    _numberOfBeads    = numberOfBeads;
-    _numberOfBeadsSet = true;
+    _numberOfBeads = numberOfBeads;
 }
 
 /**
@@ -41,10 +40,3 @@ void RingPolymerSettings::setNumberOfBeads(const size_t numberOfBeads)
  * @return size_t
  */
 size_t RingPolymerSettings::getNumberOfBeads() { return _numberOfBeads; }
-
-/**
- * @brief check if number of beads for ring polymer md is set
- *
- * @return bool
- */
-bool RingPolymerSettings::isNumberOfBeadsSet() { return _numberOfBeadsSet; }

--- a/src/settings/timingsSettings.cpp
+++ b/src/settings/timingsSettings.cpp
@@ -37,8 +37,7 @@ using settings::TimingsSettings;
  */
 void TimingsSettings::setTimeStep(const double timeStep)
 {
-    _timeStep      = timeStep;
-    _isTimeStepSet = true;
+    _timeStep = timeStep;
 }
 
 /**
@@ -58,8 +57,7 @@ void TimingsSettings::setStepCount(const size_t stepCount)
  */
 void TimingsSettings::setNumberOfSteps(const size_t numberOfSteps)
 {
-    _numberOfSteps      = numberOfSteps;
-    _isNumberOfStepsSet = true;
+    _numberOfSteps = numberOfSteps;
 }
 
 /********************
@@ -88,17 +86,3 @@ size_t TimingsSettings::getStepCount() { return _stepCount; }
  * @return size_t
  */
 size_t TimingsSettings::getNumberOfSteps() { return _numberOfSteps; }
-
-/**
- * @brief check if the time step is set
- *
- * @return bool
- */
-bool TimingsSettings::isTimeStepSet() { return _isTimeStepSet; }
-
-/**
- * @brief check if the number of steps is set
- *
- * @return bool
- */
-bool TimingsSettings::isNumberOfStepsSet() { return _isNumberOfStepsSet; }

--- a/src/setup/manostatSetup.cpp
+++ b/src/setup/manostatSetup.cpp
@@ -27,7 +27,6 @@
 
 #include "berendsenManostat.hpp"             // for BerendsenManostat
 #include "constants/conversionFactors.hpp"   // for _PS_TO_FS_
-#include "exceptions.hpp"         // for InputFileException, customException
 #include "manostat.hpp"           // for BerendsenManostat, Manostat, manostat
 #include "manostatSettings.hpp"   // for ManostatSettings
 #include "mdEngine.hpp"           // for Engine
@@ -39,7 +38,6 @@ using namespace setup;
 using namespace engine;
 using namespace settings;
 using namespace manostat;
-using namespace customException;
 using namespace constants;
 
 /**
@@ -69,24 +67,14 @@ ManostatSetup::ManostatSetup(MDEngine &engine) : _engine(engine){};
 /**
  * @brief setup manostat
  *
- * @details checks if a manostat was set in the input file,
- * If a manostat was selected than the user has to provide a target pressure for
- * the manostat.
- *
  * @note the base class manostat does not apply any pressure coupling to the
  * system and therefore it represents the none manostat.
- *
- * @throws InputFileException if no pressure was set for the manostat
- *
  */
 void ManostatSetup::setup()
 {
     using enum ManostatType;
 
     const auto manostatType = ManostatSettings::getManostatType();
-
-    if (manostatType != NONE)
-        isPressureSet();
 
     if (manostatType == BERENDSEN)
         setupBerendsenManostat();
@@ -98,21 +86,6 @@ void ManostatSetup::setup()
         _engine.makeManostat(Manostat());
 
     writeSetupInfo();
-}
-
-/**
- * @brief check if pressure is set for the manostat
- *
- * @throws InputFileException if no pressure was set for the manostat
- *
- */
-void ManostatSetup::isPressureSet() const
-{
-    if (!ManostatSettings::isPressureSet())
-        throw InputFileException(std::format(
-            "Pressure not set for {} manostat",
-            string(ManostatSettings::getManostatType())
-        ));
 }
 
 /**

--- a/src/setup/qmSetup.cpp
+++ b/src/setup/qmSetup.cpp
@@ -75,10 +75,6 @@ QMSetup::QMSetup(QMMDEngine &engine) : _engine(engine) {}
  */
 void QMSetup::setup()
 {
-    setupQMMethodFennol();
-
-    setupQMMethodMace();
-
     setupQMMethod();
 
     setupQMMethodAseDftbPlus();
@@ -115,70 +111,6 @@ void QMSetup::setupQMMethodAseDftbPlus()
         !QMSettings::isThirdOrderDftbSet())
         QMSettings::setUseThirdOrderDftb(true);
 
-    if (!QMSettings::useThirdOrderDftb() && QMSettings::isHubbardDerivsSet())
-        throw InputFileException(
-            "You have set custom Hubbard derivatives but disabled 3rd order "
-            "DFTB. "
-            "This setup is invalid."
-        );
-}
-
-/**
- * @brief setup the FeNNol method of the system
- *
- */
-void QMSetup::setupQMMethodFennol()
-{
-    if (QMSettings::getQMMethod() != QMMethod::FENNOL)
-        return;
-
-    if (QMSettings::getFennolModelPath() == "")
-        throw InputFileException(
-            "The FeNNol QM runner has been selected but the "
-            "\"fennol_model_path\" keyword has not been set. This setup is "
-            "invalid."
-        );
-}
-
-/**
- * @brief setup the MACE method of the system
- *
- */
-void QMSetup::setupQMMethodMace()
-{
-    if (QMSettings::getQMMethod() != QMMethod::MACE)
-        return;
-
-    if (QMSettings::getMaceModelType() != MaceModelType::MACE_MP)
-    {
-        const auto modelSize = QMSettings::getMaceModel();
-        if (modelSize != MaceModel::SMALL && modelSize != MaceModel::MEDIUM &&
-            modelSize != MaceModel::LARGE)
-            throw InputFileException(
-                std::format(
-                    "The '{}' model size is only compatible with the '{}' "
-                    "model type.",
-                    string(modelSize),
-                    string(MaceModelType::MACE_MP)
-                )
-            );
-    }
-
-    if (QMSettings::getMaceModel() == MaceModel::CUSTOM &&
-        QMSettings::getMaceModelPath().empty())
-        throw InputFileException(
-            "You have requested a custom MACE model but haven't provided a "
-            "MACE model path."
-            "This setup is invalid."
-        );
-
-    if (QMSettings::getMaceModel() != MaceModel::CUSTOM &&
-        !QMSettings::getMaceModelPath().empty())
-        throw InputFileException(
-            "You have set a custom MACE model path without requesting a custom "
-            "mace model size."
-            "This setup is invalid."
-        );
 }
 
 /**

--- a/src/setup/ringPolymerSetup.cpp
+++ b/src/setup/ringPolymerSetup.cpp
@@ -89,11 +89,6 @@ RingPolymerSetup::RingPolymerSetup(RingPolymerEngine &engine)
  */
 void RingPolymerSetup::setup()
 {
-    if (!RingPolymerSettings::isNumberOfBeadsSet())
-        throw InputFileException(
-            "Number of beads not set for ring polymer simulation"
-        );
-
     setupPhysicalData();
 
     setupSimulationBox();

--- a/src/setup/setup.cpp
+++ b/src/setup/setup.cpp
@@ -30,7 +30,6 @@
 #include "forceFieldSettings.hpp"           // for ForceFieldSettings
 #include "forceFieldSetup.hpp"              // for setupForceField
 #include "guffDatReader.hpp"                // for readGuffDat, readInput
-#include "hessianSettings.hpp"              // for HessianSettings
 #include "hybridSetup.hpp"                  // for setupQMMM
 #include "inputFileReader.hpp"              // for readInputFile
 #include "intraNonBondedReader.hpp"         // for readIntraNonBondedFile
@@ -53,14 +52,12 @@
 #include "simulationBoxSetup.hpp"           // for setupSimulationBox
 #include "thermostatSetup.hpp"              // for setupThermostat
 #include "timer.hpp"                        // for Timings
-#include "timingsSettings.hpp"              // for TimingsSettings
 #include "topologyReader.hpp"               // for readTopologyFile
 
 using namespace engine;
 using namespace input;
 using namespace timings;
 using namespace settings;
-using namespace customException;
 using namespace guffdat;
 using namespace molDescriptor;
 using namespace restartFile;
@@ -84,28 +81,6 @@ void setup::setupRequestedJob(const std::string &inputFileName, Engine &engine)
     startSetup(simulationTimer, setupTimer, engine);
 
     readInputFile(inputFileName, engine);
-
-    if (!TimingsSettings::isNumberOfStepsSet())
-        if (
-            Settings::isMDJobType() ||
-            Settings::isOptJobType() ||
-            (
-                Settings::getJobtype() == JobType::MM_HESSIAN &&
-                HessianSettings::optimizeBeforeHessian()
-            )
-        )
-            throw UserInputException(std::format(
-                "Job type {} selected. Please set nstep in the input file.",
-                string(Settings::getJobtype())
-            ));
-
-    if (!TimingsSettings::isTimeStepSet())
-        if (Settings::isMDJobType())
-            throw UserInputException(std::format(
-                "Molecular Dynamics job type {} selected. Please set the "
-                "time step in the input file.",
-                string(Settings::getJobtype())
-            ));
 
     setupOutputFiles(engine);
 

--- a/src/setup/thermostatSetup.cpp
+++ b/src/setup/thermostatSetup.cpp
@@ -75,15 +75,8 @@ ThermostatSetup::ThermostatSetup(MDEngine &engine) : _engine(engine){};
 /**
  * @brief setup thermostat
  *
- * @details checks if a thermostat was set in the input file,
- * If a thermostat was selected than the user has to provide a target
- * temperature for the thermostat.
- *
  * @note the base class Thermostat does not apply any temperature coupling to
  * the system and therefore it represents the none thermostat.
- *
- * @throws InputFileException if no temperature was set for the thermostat
- *
  */
 void ThermostatSetup::setup()
 {
@@ -92,7 +85,7 @@ void ThermostatSetup::setup()
     const auto thermostatType = ThermostatSettings::getThermostatType();
 
     if (thermostatType != NONE)
-        isTargetTemperatureSet();
+        setupTargetTemperature();
 
     switch (thermostatType)
     {
@@ -113,37 +106,12 @@ void ThermostatSetup::setup()
 }
 
 /**
- * @brief check if target temperature is set
- *
- * @throws InputFileException if neither target nor end temperature is set
- * @throws InputFileException if both target and end temperature are set
- *
+ * @brief keeps target and end temperature synchronized
  */
-void ThermostatSetup::isTargetTemperatureSet() const
+void ThermostatSetup::setupTargetTemperature() const
 {
     const auto targetTempDefined = ThermostatSettings::isTemperatureSet();
     const auto endTempDefined    = ThermostatSettings::isEndTemperatureSet();
-
-    /************************************************************
-     * Check if exactly one of target or end temperature is set *
-     ************************************************************/
-
-    if (!targetTempDefined && !endTempDefined)
-        throw InputFileException(std::format(
-            "Target or end temperature not set for {} thermostat",
-            string(ThermostatSettings::getThermostatType())
-        ));
-
-    if (targetTempDefined && endTempDefined)
-        throw InputFileException(std::format(
-            "Both target and end temperature set for {} thermostat. They "
-            "are mutually exclusive as they are treated as synonyms",
-            string(ThermostatSettings::getThermostatType())
-        ));
-
-    /**************************************************
-     * Block to unify the target and end temperature. *
-     **************************************************/
 
     if (endTempDefined)
     {
@@ -248,11 +216,6 @@ void ThermostatSetup::setupNoseHooverThermostat()
  * @details if the start temperature is defined, the temperature ramp is
  * enabled
  *
- * @throws InputFileException if the number of steps is smaller than the
- * number
- * @throws InputFileException if the temperature ramp frequency is larger
- * than the number of steps
- *
  */
 void ThermostatSetup::setupTemperatureRamp()
 {
@@ -284,25 +247,10 @@ void ThermostatSetup::setupTemperatureRamp()
         steps = TimingsSettings::getNumberOfSteps();
         ThermostatSettings::setTemperatureRampSteps(steps);
     }
-    else if (steps > TimingsSettings::getNumberOfSteps())
-        throw InputFileException(std::format(
-            "Number of total simulation steps {} is smaller than the "
-            "number of temperature ramping steps {}",
-            TimingsSettings::getNumberOfSteps(),
-            steps
-        ));
 
     _engine.getThermostat().setTemperatureRampingSteps(steps);
 
     const auto frequency = ThermostatSettings::getTemperatureRampFrequency();
-
-    if (frequency > steps)
-        throw InputFileException(std::format(
-            "Temperature ramp frequency {} is larger than the number of "
-            "ramping steps {}",
-            frequency,
-            steps
-        ));
 
     const auto targetTemp   = ThermostatSettings::getTargetTemperature();
     const auto tempDelta    = targetTemp - startTemp;

--- a/tests/src/input/CMakeLists.txt
+++ b/tests/src/input/CMakeLists.txt
@@ -3,6 +3,7 @@ set(source_files
     testMoldescriptorReader.cpp
     testGuffDatReader.cpp
     testInputFileReader.cpp
+    testInputValidation.cpp
     testIntraNonBondedReader.cpp
     testCommandLineArgs.cpp
     testMShakeReader.cpp

--- a/tests/src/input/inputFileParsing/testManostatParser.cpp
+++ b/tests/src/input/inputFileParsing/testManostatParser.cpp
@@ -41,14 +41,11 @@ using namespace input;
  */
 TEST_F(TestInputFileReader, ParsePressure)
 {
-    EXPECT_EQ(settings::ManostatSettings::isPressureSet(), false);
-
     ManostatInputParser      parser(*_engine);
     std::vector<std::string> lineElements = {"pressure", "=", "300.0"};
     parser.parsePressure(lineElements, 0);
 
     EXPECT_EQ(settings::ManostatSettings::getTargetPressure(), 300.0);
-    EXPECT_EQ(settings::ManostatSettings::isPressureSet(), true);
 }
 
 /**

--- a/tests/src/input/testInputValidation.cpp
+++ b/tests/src/input/testInputValidation.cpp
@@ -1,0 +1,370 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <memory>   // for make_unique, unique_ptr
+#include <string>   // for string
+
+#include "exceptions.hpp"            // for InputFileException
+#include "hessianSettings.hpp"       // for HessianSettings
+#include "inputFileReader.hpp"       // for InputFileReader
+#include "manostatSettings.hpp"      // for ManostatSettings
+#include "optEngine.hpp"             // for OptEngine
+#include "potentialSettings.hpp"     // for PotentialSettings
+#include "qmSettings.hpp"            // for QMSettings
+#include "settings.hpp"              // for Settings
+#include "thermostatSettings.hpp"    // for ThermostatSettings
+#include "throwWithMessage.hpp"      // for ASSERT_THROW_MSG
+#include "timingsSettings.hpp"       // for TimingsSettings
+
+using namespace customException;
+using namespace input;
+using namespace settings;
+
+class TestInputValidation : public ::testing::Test
+{
+   protected:
+    void SetUp() override
+    {
+        Settings::setJobtype(JobType::NONE);
+        HessianSettings::setOptimizeBeforeHessian(false);
+
+        ManostatSettings::setManostatType(ManostatType::NONE);
+
+        ThermostatSettings::setThermostatType(ThermostatType::NONE);
+        ThermostatSettings::setTemperatureSet(false);
+        ThermostatSettings::setStartTemperatureSet(false);
+        ThermostatSettings::setEndTemperatureSet(false);
+        ThermostatSettings::setTemperatureRampSteps(0);
+        ThermostatSettings::setTemperatureRampFrequency(1);
+
+        PotentialSettings::setCoulombLongRangeType(
+            CoulombLongRangeType::SHIFTED
+        );
+
+        QMSettings::setQMMethod(QMMethod::NONE);
+        QMSettings::setMaceModel(MaceModel::MEDIUM);
+        QMSettings::setMaceModelType(MaceModelType::MACE_MP);
+        QMSettings::setMaceModelPath("");
+        QMSettings::setSlakosType(SlakosType::NONE);
+        QMSettings::setUseThirdOrderDftb(false);
+        QMSettings::setIsThirdOrderDftbSet(false);
+        QMSettings::setIsHubbardDerivsSet(false);
+        QMSettings::setFennolModelPath("");
+
+        _engine = std::make_unique<engine::OptEngine>();
+        _reader = std::make_unique<InputFileReader>("input.in", *_engine);
+    }
+
+    void setKeyword(const std::string &keyword)
+    {
+        _reader->setKeywordCount(keyword, 1);
+    }
+
+    void configureMDJob(const JobType jobType)
+    {
+        Settings::setJobtype(jobType);
+        TimingsSettings::setNumberOfSteps(100);
+        setKeyword("nstep");
+        setKeyword("timestep");
+    }
+
+    std::unique_ptr<engine::OptEngine> _engine;
+    std::unique_ptr<InputFileReader>   _reader;
+};
+
+TEST_F(TestInputValidation, requiresNumberOfStepsForMD)
+{
+    Settings::setJobtype(JobType::MM_MD);
+    setKeyword("timestep");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        UserInputException,
+        "Job type MM_MD selected. Please set nstep in the input file."
+    );
+}
+
+TEST_F(TestInputValidation, requiresNumberOfStepsForOptimization)
+{
+    Settings::setJobtype(JobType::MM_OPT);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        UserInputException,
+        "Job type MM_OPT selected. Please set nstep in the input file."
+    );
+}
+
+TEST_F(TestInputValidation, requiresNumberOfStepsForPreoptimizedHessian)
+{
+    Settings::setJobtype(JobType::MM_HESSIAN);
+    HessianSettings::setOptimizeBeforeHessian(true);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        UserInputException,
+        "Job type MM_HESSIAN selected. Please set nstep in the input file."
+    );
+}
+
+TEST_F(TestInputValidation, hessianWithoutOptimizationNeedsNoTimings)
+{
+    Settings::setJobtype(JobType::MM_HESSIAN);
+
+    EXPECT_NO_THROW(_reader->validateInputConfiguration());
+}
+
+TEST_F(TestInputValidation, requiresTimeStepForMD)
+{
+    Settings::setJobtype(JobType::MM_MD);
+    setKeyword("nstep");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        UserInputException,
+        "Molecular Dynamics job type MM_MD selected. Please set the time step "
+        "in the input file."
+    );
+}
+
+TEST_F(TestInputValidation, requiresPressureForManostat)
+{
+    ManostatSettings::setManostatType(ManostatType::BERENDSEN);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Pressure not set for berendsen manostat"
+    );
+}
+
+TEST_F(TestInputValidation, requiresTemperatureForThermostat)
+{
+    ThermostatSettings::setThermostatType(ThermostatType::BERENDSEN);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Target or end temperature not set for berendsen thermostat"
+    );
+}
+
+TEST_F(TestInputValidation, rejectsBothThermostatTemperatures)
+{
+    ThermostatSettings::setThermostatType(ThermostatType::BERENDSEN);
+    setKeyword("temp");
+    setKeyword("end_temp");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Both target and end temperature set for berendsen thermostat. They "
+        "are mutually exclusive as they are treated as synonyms"
+    );
+}
+
+TEST_F(TestInputValidation, rejectsTemperatureRampLongerThanSimulation)
+{
+    configureMDJob(JobType::MM_MD);
+    ThermostatSettings::setThermostatType(ThermostatType::BERENDSEN);
+    ThermostatSettings::setTemperatureRampSteps(200);
+    setKeyword("temp");
+    setKeyword("start_temp");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Number of total simulation steps 100 is smaller than the number of "
+        "temperature ramping steps 200"
+    );
+}
+
+TEST_F(TestInputValidation, rejectsTemperatureRampFrequencyAboveRampSteps)
+{
+    configureMDJob(JobType::MM_MD);
+    ThermostatSettings::setThermostatType(ThermostatType::BERENDSEN);
+    ThermostatSettings::setTemperatureRampSteps(2);
+    ThermostatSettings::setTemperatureRampFrequency(4);
+    setKeyword("temp");
+    setKeyword("start_temp");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Temperature ramp frequency 4 is larger than the number of ramping "
+        "steps 2"
+    );
+}
+
+TEST_F(TestInputValidation, acceptsDefaultTemperatureRampLength)
+{
+    configureMDJob(JobType::MM_MD);
+    ThermostatSettings::setThermostatType(ThermostatType::BERENDSEN);
+    ThermostatSettings::setTemperatureRampFrequency(100);
+    setKeyword("temp");
+    setKeyword("start_temp");
+
+    EXPECT_NO_THROW(_reader->validateInputConfiguration());
+}
+
+TEST_F(TestInputValidation, requiresReplicaCountForRingPolymer)
+{
+    configureMDJob(JobType::RING_POLYMER_QM_MD);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Number of beads not set for ring polymer simulation"
+    );
+}
+
+TEST_F(TestInputValidation, acceptsReplicaCountForRingPolymer)
+{
+    configureMDJob(JobType::RING_POLYMER_QM_MD);
+    setKeyword("rpmd_n_replica");
+
+    EXPECT_NO_THROW(_reader->validateInputConfiguration());
+}
+
+TEST_F(TestInputValidation, rejectsHubbardDerivativesWithoutThirdOrder)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::ASEDFTBPLUS);
+    QMSettings::setSlakosType(SlakosType::CUSTOM);
+    QMSettings::setUseThirdOrderDftb(false);
+    setKeyword("third_order");
+    setKeyword("hubbard_derivs");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "You have set custom Hubbard derivatives but disabled 3rd order DFTB. "
+        "This setup is invalid."
+    );
+}
+
+TEST_F(TestInputValidation, acceptsHubbardDerivativesWithThirdOrder)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::ASEDFTBPLUS);
+    QMSettings::setSlakosType(SlakosType::CUSTOM);
+    QMSettings::setUseThirdOrderDftb(true);
+    setKeyword("third_order");
+    setKeyword("hubbard_derivs");
+
+    EXPECT_NO_THROW(_reader->validateInputConfiguration());
+}
+
+#ifdef WITH_ASE
+TEST_F(TestInputValidation, acceptsThreeObDefaultThirdOrder)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::ASEDFTBPLUS);
+    QMSettings::setSlakosType(SlakosType::THREEOB);
+    QMSettings::setUseThirdOrderDftb(false);
+    setKeyword("hubbard_derivs");
+
+    EXPECT_NO_THROW(_reader->validateInputConfiguration());
+}
+#endif
+
+TEST_F(TestInputValidation, requiresFennolModelPath)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::FENNOL);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "The FeNNol QM runner has been selected but the "
+        "\"fennol_model_path\" keyword has not been set. This setup is invalid."
+    );
+}
+
+TEST_F(TestInputValidation, acceptsFennolModelPath)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::FENNOL);
+    setKeyword("fennol_model_path");
+
+    EXPECT_NO_THROW(_reader->validateInputConfiguration());
+}
+
+TEST_F(TestInputValidation, rejectsMaceModelForWrongModelType)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::MACE);
+    QMSettings::setMaceModelType(MaceModelType::MACE_OFF);
+    QMSettings::setMaceModel(MaceModel::MEDIUMOMAT0);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "The 'medium-omat-0' model size is only compatible with the 'mace_mp' "
+        "model type."
+    );
+}
+
+TEST_F(TestInputValidation, requiresPathForCustomMaceModel)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::MACE);
+    QMSettings::setMaceModel(MaceModel::CUSTOM);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "You have requested a custom MACE model but haven't provided a MACE "
+        "model path.This setup is invalid."
+    );
+}
+
+TEST_F(TestInputValidation, rejectsPathForBundledMaceModel)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::MACE);
+    QMSettings::setMaceModel(MaceModel::MEDIUMOMAT0);
+    setKeyword("mace_model_path");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "You have set a custom MACE model path without requesting a custom "
+        "mace model size.This setup is invalid."
+    );
+}
+
+TEST_F(TestInputValidation, acceptsValidConditionalKeywords)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::MACE);
+    QMSettings::setMaceModel(MaceModel::CUSTOM);
+    ManostatSettings::setManostatType(ManostatType::BERENDSEN);
+    ThermostatSettings::setThermostatType(ThermostatType::BERENDSEN);
+    setKeyword("mace_model_path");
+    setKeyword("pressure");
+    setKeyword("temp");
+
+    EXPECT_NO_THROW(_reader->validateInputConfiguration());
+}

--- a/tests/src/input/testInputValidation.cpp
+++ b/tests/src/input/testInputValidation.cpp
@@ -184,6 +184,15 @@ TEST_F(TestInputValidation, rejectsBothThermostatTemperatures)
     );
 }
 
+TEST_F(TestInputValidation, acceptsEndTemperatureForThermostat)
+{
+    configureMDJob(JobType::MM_MD);
+    ThermostatSettings::setThermostatType(ThermostatType::BERENDSEN);
+    setKeyword("end_temp");
+
+    EXPECT_NO_THROW(_reader->validateInputConfiguration());
+}
+
 TEST_F(TestInputValidation, rejectsTemperatureRampLongerThanSimulation)
 {
     configureMDJob(JobType::MM_MD);
@@ -277,6 +286,23 @@ TEST_F(TestInputValidation, acceptsHubbardDerivativesWithThirdOrder)
 }
 
 #ifdef WITH_ASE
+TEST_F(TestInputValidation, rejectsExplicitlyDisabledThreeObThirdOrder)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::ASEDFTBPLUS);
+    QMSettings::setSlakosType(SlakosType::THREEOB);
+    QMSettings::setUseThirdOrderDftb(false);
+    setKeyword("third_order");
+    setKeyword("hubbard_derivs");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "You have set custom Hubbard derivatives but disabled 3rd order DFTB. "
+        "This setup is invalid."
+    );
+}
+
 TEST_F(TestInputValidation, acceptsThreeObDefaultThirdOrder)
 {
     configureMDJob(JobType::QM_MD);
@@ -324,6 +350,16 @@ TEST_F(TestInputValidation, rejectsMaceModelForWrongModelType)
         "The 'medium-omat-0' model size is only compatible with the 'mace_mp' "
         "model type."
     );
+}
+
+TEST_F(TestInputValidation, acceptsStandardMaceModelForNonMpType)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::MACE);
+    QMSettings::setMaceModelType(MaceModelType::MACE_OFF);
+    QMSettings::setMaceModel(MaceModel::SMALL);
+
+    EXPECT_NO_THROW(_reader->validateInputConfiguration());
 }
 
 TEST_F(TestInputValidation, requiresPathForCustomMaceModel)

--- a/tests/src/setup/testManostatSetup.cpp
+++ b/tests/src/setup/testManostatSetup.cpp
@@ -30,12 +30,23 @@
 #include "manostatSettings.hpp"    // for ManostatSettings
 #include "manostatSetup.hpp"       // for ManostatSetup, setupManostat, setup
 #include "mdEngine.hpp"            // for MDEngine
+#include "settings.hpp"            // for JobType, Settings
 #include "stochasticRescalingManostat.hpp"   // for StochasticRescalingManostat
 #include "testSetup.hpp"                     // for TestSetup
 
 using namespace setup;
 using namespace settings;
 using namespace manostat;
+
+TEST_F(TestSetup, setupManostatSkipsNonMDJobs)
+{
+    const auto jobType = Settings::getJobtype();
+    Settings::setJobtype(JobType::MM_OPT);
+
+    EXPECT_NO_THROW(setupManostat(*_engine));
+
+    Settings::setJobtype(jobType);
+}
 
 TEST_F(TestSetup, setupManostatNone)
 {

--- a/tests/src/setup/testManostatSetup.cpp
+++ b/tests/src/setup/testManostatSetup.cpp
@@ -25,7 +25,6 @@
 #include <string>   // for allocator, basic_string
 
 #include "berendsenManostat.hpp"   // for BerendsenManostat
-#include "exceptions.hpp"          // for InputFileException, customException
 #include "gtest/gtest.h"           // for Message, TestPartResult
 #include "manostat.hpp"            // for BerendsenManostat, Manostat
 #include "manostatSettings.hpp"    // for ManostatSettings
@@ -33,7 +32,6 @@
 #include "mdEngine.hpp"            // for MDEngine
 #include "stochasticRescalingManostat.hpp"   // for StochasticRescalingManostat
 #include "testSetup.hpp"                     // for TestSetup
-#include "throwWithMessage.hpp"              // for throwWithMessage
 
 using namespace setup;
 using namespace settings;
@@ -49,23 +47,10 @@ TEST_F(TestSetup, setupManostatNone)
     EXPECT_EQ(manostat.getIsotropy(), Isotropy::NONE);
 }
 
-TEST_F(TestSetup, setupManostatPressureMissing)
-{
-    ManostatSetup manostatSetup(*_mdEngine);
-
-    ManostatSettings::setManostatType("berendsen");
-    EXPECT_THROW_MSG(
-        manostatSetup.setup(),
-        customException::InputFileException,
-        "Pressure not set for berendsen manostat"
-    );
-}
-
 TEST_F(TestSetup, setupManostatBerendsen)
 {
     ManostatSettings::setManostatType("berendsen");
     ManostatSettings::setIsotropy("isotropic");
-    ManostatSettings::setPressureSet(true);
     ManostatSettings::setTargetPressure(300.0);
     ManostatSettings::setTauManostat(0.2);
     ManostatSettings::setCompressibility(4.0);
@@ -85,7 +70,6 @@ TEST_F(TestSetup, setupManostatNoneIsotropyDefaultsToIsotropic)
 {
     ManostatSettings::setManostatType(ManostatType::BERENDSEN);
     ManostatSettings::setIsotropy(Isotropy::NONE);
-    ManostatSettings::setPressureSet(true);
     ManostatSettings::setTargetPressure(300.0);
     ManostatSettings::setTauManostat(0.2);
     ManostatSettings::setCompressibility(4.0);
@@ -102,7 +86,6 @@ TEST_F(TestSetup, setupManostatSemiIsotropicBerendsen)
 {
     ManostatSettings::setManostatType("berendsen");
     ManostatSettings::setIsotropy("semi_isotropic");
-    ManostatSettings::setPressureSet(true);
     ManostatSettings::setTargetPressure(300.0);
     ManostatSettings::setTauManostat(0.2);
     ManostatSettings::setCompressibility(4.0);
@@ -123,7 +106,6 @@ TEST_F(TestSetup, setupManostatAnisotropicBerendsen)
 {
     ManostatSettings::setManostatType("berendsen");
     ManostatSettings::setIsotropy("anisotropic");
-    ManostatSettings::setPressureSet(true);
     ManostatSettings::setTargetPressure(300.0);
     ManostatSettings::setTauManostat(0.2);
     ManostatSettings::setCompressibility(4.0);
@@ -144,7 +126,6 @@ TEST_F(TestSetup, setupManostatFullAnisotropicBerendsen)
 {
     ManostatSettings::setManostatType("berendsen");
     ManostatSettings::setIsotropy("full_anisotropic");
-    ManostatSettings::setPressureSet(true);
     ManostatSettings::setTargetPressure(300.0);
     ManostatSettings::setTauManostat(0.2);
     ManostatSettings::setCompressibility(4.0);
@@ -165,7 +146,6 @@ TEST_F(TestSetup, setupManostatSStochasticRescaling)
 {
     ManostatSettings::setManostatType(ManostatType::STOCHASTIC_RESCALING);
     ManostatSettings::setIsotropy("isotropic");
-    ManostatSettings::setPressureSet(true);
     ManostatSettings::setTargetPressure(300.0);
     ManostatSettings::setTauManostat(0.2);
     ManostatSettings::setCompressibility(4.0);
@@ -186,7 +166,6 @@ TEST_F(TestSetup, setupManostatSemiIsotropicSStochasticRescaling)
 {
     ManostatSettings::setManostatType(ManostatType::STOCHASTIC_RESCALING);
     ManostatSettings::setIsotropy("semi_isotropic");
-    ManostatSettings::setPressureSet(true);
     ManostatSettings::setTargetPressure(300.0);
     ManostatSettings::setTauManostat(0.2);
     ManostatSettings::setCompressibility(4.0);
@@ -207,7 +186,6 @@ TEST_F(TestSetup, setupManostatAnisotropicSStochasticRescaling)
 {
     ManostatSettings::setManostatType(ManostatType::STOCHASTIC_RESCALING);
     ManostatSettings::setIsotropy("anisotropic");
-    ManostatSettings::setPressureSet(true);
     ManostatSettings::setTargetPressure(300.0);
     ManostatSettings::setTauManostat(0.2);
     ManostatSettings::setCompressibility(4.0);
@@ -228,7 +206,6 @@ TEST_F(TestSetup, setupManostatFullAnisotropicSStochasticRescaling)
 {
     ManostatSettings::setManostatType(ManostatType::STOCHASTIC_RESCALING);
     ManostatSettings::setIsotropy("full_anisotropic");
-    ManostatSettings::setPressureSet(true);
     ManostatSettings::setTargetPressure(300.0);
     ManostatSettings::setTauManostat(0.2);
     ManostatSettings::setCompressibility(4.0);

--- a/tests/src/setup/testQMSetup.cpp
+++ b/tests/src/setup/testQMSetup.cpp
@@ -192,81 +192,6 @@ TEST(TestQMSetup, setupQMMethodAseDftbPlusCustom)
     EXPECT_EQ(QMSettings::useThirdOrderDftb(), false);
 }
 
-TEST(TestQMSetup, setupQMMethodAseDftbPlusHubbardDerivsNo3rdOrder)
-{
-    engine::QMMDEngine engine;
-    QMSetup            qmSetup{QMSetup(engine)};
-
-    QMSettings::setQMMethod(QMMethod::ASEDFTBPLUS);
-    QMSettings::setSlakosType("custom");
-    QMSettings::setIsThirdOrderDftbSet(true);
-    QMSettings::setUseThirdOrderDftb(false);
-    QMSettings::setIsHubbardDerivsSet(true);
-    QMSettings::setHubbardDerivs({{"H", 1.0}});
-
-    ASSERT_THROW_MSG(
-        qmSetup.setupQMMethodAseDftbPlus(),
-        customException::InputFileException,
-        "You have set custom Hubbard derivatives but disabled 3rd order DFTB. "
-        "This setup is invalid."
-    );
-}
-
-TEST(TestQMSetup, setupQMMethodMaceOffInvalidModelSize)
-{
-    engine::QMMDEngine engine;
-    QMSetup            qmSetup{QMSetup(engine)};
-
-    QMSettings::setQMMethod(QMMethod::MACE);
-    QMSettings::setMaceModelType("mace-off");
-    QMSettings::setMaceModel("medium-omat-0");
-
-    ASSERT_THROW_MSG(
-        qmSetup.setupQMMethodMace(),
-        customException::InputFileException,
-        "The 'medium-omat-0' model size is only compatible with the 'mace_mp' "
-        "model type."
-    );
-}
-
-TEST(TestQMSetup, setupQMMethodMaceRedundantModelPath)
-{
-    engine::QMMDEngine engine;
-    QMSetup            qmSetup{QMSetup(engine)};
-
-    QMSettings::setQMMethod(QMMethod::MACE);
-    QMSettings::setMaceModelType("mace-mp");
-    QMSettings::setMaceModel("medium-omat-0");
-    QMSettings::setMaceModelPath("https://not-a-valid-url");
-
-    ASSERT_THROW_MSG(
-        qmSetup.setupQMMethodMace(),
-        customException::InputFileException,
-        "You have set a custom MACE model path without requesting a custom "
-        "mace model size."
-        "This setup is invalid."
-    );
-}
-
-TEST(TestQMSetup, setupQMMethodMaceMissingModelPath)
-{
-    engine::QMMDEngine engine;
-    QMSetup            qmSetup{QMSetup(engine)};
-
-    QMSettings::setQMMethod(QMMethod::MACE);
-    QMSettings::setMaceModelType("mace-mp");
-    QMSettings::setMaceModel("custom");
-    QMSettings::setMaceModelPath("");
-
-    ASSERT_THROW_MSG(
-        qmSetup.setupQMMethodMace(),
-        customException::InputFileException,
-        "You have requested a custom MACE model but haven't provided a "
-        "MACE model path."
-        "This setup is invalid."
-    );
-}
-
 TEST(TestQMSetup, setupQMLoopTimeLimitDefault)
 {
     auto _engine  = new engine::QMMDEngine();
@@ -384,23 +309,6 @@ TEST(TestQMSetup, setupQMLoopTimeLimitPositive)
     ::remove("default.log");
     delete _engine;
     delete _qmSetup;
-}
-
-TEST(TestQMSetup, setupQMMethodFennol)
-{
-    engine::QMMDEngine engine;
-    QMSetup            qmSetup{QMSetup(engine)};
-
-    QMSettings::setQMMethod(QMMethod::FENNOL);
-    ASSERT_THROW_MSG(
-        qmSetup.setupQMMethodFennol(),
-        customException::InputFileException,
-        "The FeNNol QM runner has been selected but the "
-        "\"fennol_model_path\" keyword has not been set. This setup is "
-        "invalid."
-    );
-    QMSettings::setFennolModelPath("/patH/to/fennol_model.fnx");
-    ASSERT_NO_THROW(qmSetup.setupQMMethodFennol());
 }
 
 TEST(TestQMSetup, setupQMRunnerFennol)

--- a/tests/src/setup/testRingPolymerSetup.cpp
+++ b/tests/src/setup/testRingPolymerSetup.cpp
@@ -22,7 +22,6 @@
 
 #include <gtest/gtest.h>
 
-#include "exceptions.hpp"
 #include "ringPolymerqmmdEngine.hpp"
 #include "ringPolymerSettings.hpp"
 #include "ringPolymerSetup.hpp"
@@ -31,25 +30,11 @@
 
 using namespace setup;
 using namespace settings;
-using namespace customException;
 
 TEST_F(TestSetup, setupRingPolymerIsNoOpWhenNotActivated)
 {
     Settings::setIsRingPolymerMDActivated(false);
     EXPECT_NO_THROW(setupRingPolymer(*_engine));
-}
-
-TEST_F(TestSetup, ringPolymerSetupThrowsWhenNumberOfBeadsNotSet)
-{
-    Settings::setIsRingPolymerMDActivated(true);
-
-    // Construct a RingPolymerEngine on the stack — it's a derived MDEngine.
-    engine::RingPolymerQMMDEngine rpEngine;
-
-    RingPolymerSetup s(rpEngine);
-    EXPECT_THROW(s.setup(), InputFileException);
-
-    Settings::setIsRingPolymerMDActivated(false);   // restore
 }
 
 TEST_F(TestSetup, ringPolymerSetupPhysicalDataResizesBeads)

--- a/tests/src/setup/testThermostatSetup.cpp
+++ b/tests/src/setup/testThermostatSetup.cpp
@@ -28,7 +28,6 @@
 #include "berendsenThermostat.hpp"           // for BerendsenThermostat
 #include "constants/conversionFactors.hpp"   // for _FS_TO_S_, _KG_TO_GRAM_
 #include "constants/natureConstants.hpp"     // for _UNIVERSAL_GAS_CONSTANT_
-#include "exceptions.hpp"             // for InputFileException, customException
 #include "gtest/gtest.h"              // for Message, TestPartResult
 #include "langevinThermostat.hpp"     // for LangevinThermostat
 #include "mdEngine.hpp"               // for MDEngine
@@ -37,7 +36,6 @@
 #include "thermostat.hpp"             // for BerendsenThermostat, Thermostat
 #include "thermostatSettings.hpp"     // for ThermostatSettings
 #include "thermostatSetup.hpp"        // for ThermostatSetup, setupThermostat
-#include "throwWithMessage.hpp"       // for EXPECT_THROW_MSG
 #include "timingsSettings.hpp"        // for TimingsSettings
 #include "velocityRescalingThermostat.hpp"   // for VelocityRescalingThermostat
 
@@ -49,38 +47,6 @@ TEST_F(TestSetup, setupThermostat_no_thermostat)
 
     settings::TimingsSettings::setTimeStep(0.1);
     EXPECT_NO_THROW(thermostatSetup.setup());
-}
-
-TEST_F(TestSetup, setupThermostat_both_target_and_end_temp_set)
-{
-    ThermostatSetup thermostatSetup(*_mdEngine);
-
-    settings::ThermostatSettings::setEndTemperature(400);
-    settings::ThermostatSettings::setTargetTemperature(300);
-    settings::ThermostatSettings::setThermostatType("berendsen");
-    EXPECT_THROW_MSG(
-        thermostatSetup.setup(),
-        customException::InputFileException,
-        "Both target and end temperature set for berendsen thermostat. They "
-        "are mutually exclusive as they are treated as synonyms"
-    );
-
-    // needed because otherwise subsequent executions of .setup() will fail
-    // because the end temperature is automatically set to the target
-    // temperature for consistency
-    settings::ThermostatSettings::setEndTemperatureSet(false);
-}
-
-TEST_F(TestSetup, setupThermostat_no_target_or_end_temp_set)
-{
-    ThermostatSetup thermostatSetup(*_mdEngine);
-
-    settings::ThermostatSettings::setThermostatType("berendsen");
-    EXPECT_THROW_MSG(
-        thermostatSetup.setup(),
-        customException::InputFileException,
-        "Target or end temperature not set for berendsen thermostat"
-    );
 }
 
 TEST_F(TestSetup, setupThermostat_temp_ramping)
@@ -136,24 +102,6 @@ TEST_F(TestSetup, setupThermostat_temp_ramping)
         2
     );
 
-    settings::ThermostatSettings::setTemperatureRampSteps(200);
-    settings::ThermostatSettings::setEndTemperatureSet(false);
-    EXPECT_THROW_MSG(
-        thermostatSetup.setup(),
-        customException::InputFileException,
-        "Number of total simulation steps 100 is smaller than the number of "
-        "temperature ramping steps 200"
-    );
-
-    settings::ThermostatSettings::setTemperatureRampSteps(2);
-    settings::ThermostatSettings::setTemperatureRampFrequency(4);
-    settings::ThermostatSettings::setEndTemperatureSet(false);
-    EXPECT_THROW_MSG(
-        thermostatSetup.setup(),
-        customException::InputFileException,
-        "Temperature ramp frequency 4 is larger than the number of ramping "
-        "steps 2"
-    );
 }
 
 TEST_F(TestSetup, setupThermostat_only_end_temp_defined)


### PR DESCRIPTION
Moves conditional keyword checks from setup classes into `InputFileReader`.

Adds focused coverage for timing, thermostat, manostat, ring-polymer, and QM dependencies.

Closes #295