### PR TITLE
ci: test static Singularity builds

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -105,8 +105,43 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 
+  static-singularity-build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt update
+          sudo apt install gcc-13 g++-13 mold
+        shell: bash
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: static-singularity
+
+      - name: Build project
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_WITH_SINGULARITY=ON \
+            -DBUILD_WITH_TESTS=ON \
+            -DBUILD_WITH_ASE=OFF \
+            -DBUILD_WITH_NATIVE=OFF
+          cmake --build build --parallel "$(nproc)"
+        env:
+          CC: gcc-13
+          CXX: g++-13
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure -j1
+
   notification:
-    needs: daily-build-and-test
+    needs: [daily-build-and-test, static-singularity-build]
     runs-on: ubuntu-latest
     if: always() # Run even if previous jobs fail
     
@@ -115,8 +150,10 @@ jobs:
         run: |
           echo "Daily CI Results:"
           echo "Build jobs status: ${{ needs.daily-build-and-test.result }}"
+          echo "Static Singularity build status: ${{ needs.static-singularity-build.result }}"
           
-          if [[ "${{ needs.daily-build-and-test.result }}" != "success" ]]; then
+          if [[ "${{ needs.daily-build-and-test.result }}" != "success" ||
+                "${{ needs.static-singularity-build.result }}" != "success" ]]; then
             echo "❌ Some daily CI jobs failed. Check the workflow logs for details."
             exit 1
           else

--- a/tests/src/setup/testQMSetup.cpp
+++ b/tests/src/setup/testQMSetup.cpp
@@ -22,7 +22,8 @@
 
 #include <gtest/gtest.h>   // for Test, TestInfo (ptr only), InitGoogleTest, RUN_ALL_TESTS
 
-#include <string>   // for allocator, basic_string
+#include <string>        // for allocator, basic_string
+#include <string_view>   // for string_view
 
 #include "dftbplusRunner.hpp"     // for DFTBPlusRunner
 #include "exceptions.hpp"         // for InputFileException
@@ -40,13 +41,28 @@
 using setup::QMSetup;
 using namespace settings;
 
+namespace
+{
+    void setBuildCompatibleQMScript()
+    {
+        QMSettings::setQMScript("");
+        QMSettings::setQMScriptFullPath("");
+
+        if (std::string_view(SINGULARITY_) == "ON" ||
+            std::string_view(STATIC_BUILD_) == "ON")
+            QMSettings::setQMScriptFullPath("test");
+        else
+            QMSettings::setQMScript("test");
+    }
+}   // namespace
+
 TEST(TestQMSetup, setupDftbplus)
 {
     engine::QMMDEngine engine;
     auto               setupQM = setup::QMSetup(engine);
 
     settings::QMSettings::setQMMethod(settings::QMMethod::DFTBPLUS);
-    settings::QMSettings::setQMScript("test");
+    setBuildCompatibleQMScript();
     setupQM.setup();
 
     EXPECT_EQ(
@@ -70,7 +86,7 @@ TEST(TestQMSetup, setupPySCF)
     auto               setupQM = setup::QMSetup(engine);
 
     settings::QMSettings::setQMMethod(settings::QMMethod::PYSCF);
-    settings::QMSettings::setQMScript("test");
+    setBuildCompatibleQMScript();
     setupQM.setup();
 
     EXPECT_EQ(
@@ -94,7 +110,7 @@ TEST(TestQMSetup, setupTurbomoleRunner)
     auto               setupQM = setup::QMSetup(engine);
 
     settings::QMSettings::setQMMethod(settings::QMMethod::TURBOMOLE);
-    settings::QMSettings::setQMScript("test");
+    setBuildCompatibleQMScript();
     setupQM.setup();
 
     EXPECT_EQ(


### PR DESCRIPTION
Adds a daily static build with Singularity enabled and runs the unit suite serially. Updates QM setup tests to use the required full script path in static/Singularity builds.

Closes #36