### PR TITLE
ci: check changed C++ formatting

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -1,0 +1,57 @@
+name: Clang Format Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - '.clang-format'
+      - '.github/workflows/clang_format.yml'
+      - '**/*.c'
+      - '**/*.cc'
+      - '**/*.cpp'
+      - '**/*.cxx'
+      - '**/*.h'
+      - '**/*.hh'
+      - '**/*.hpp'
+      - '**/*.hxx'
+      - '!external/**'
+  workflow_dispatch:
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-24.04
+    name: Check Changed C++ Formatting
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install clang-format
+        run: python -m pip install clang-format==20.1.3
+
+      - name: Check formatting
+        run: |
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          if [[ -z "$base_sha" ]]; then
+            base_sha="HEAD^"
+            head_sha="HEAD"
+          fi
+
+          clang-format --style=file --dump-config > /dev/null
+          git-clang-format \
+            --diff \
+            --binary "$(command -v clang-format)" \
+            --extensions c,cc,cpp,cxx,h,hh,hpp,hxx \
+            "$base_sha" \
+            "$head_sha" \
+            -- apps benchmarks include src tests


### PR DESCRIPTION
Checks only changed C++ lines with clang-format 20.1.3, so existing formatting debt does not block unrelated PRs.

Closes #179