### PR TITLE
doc: split user and developer changelogs

### DIFF
--- a/.github/workflows/check-pr-for-release-version.yml
+++ b/.github/workflows/check-pr-for-release-version.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Check PR Title or Description
         run: |
           title="${{ github.event.pull_request.title }}"
@@ -28,3 +31,9 @@ jobs:
             echo "❌ Invalid PR. Title or description must contain: Release-x.y.z (e.g., Release-1.2.3)"
             exit 1
           fi
+
+      - name: Test changelog tooling
+        run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+
+      - name: Check user release notes
+        run: python3 scripts/update_changelog.py --check

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -42,28 +42,26 @@ jobs:
           echo "✅ Found release version: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
-      # git-cliff renders the Next Release section from conventional
-      # commits when no curated content exists. The script preserves any
-      # curated entries in CHANGELOG.md verbatim, so this binary is only
-      # actually invoked for releases where Next Release is empty.
+      # git-cliff generates the developer changelog from conventional commits.
+      # CHANGELOG.md is curated for users in the release pull request.
       - name: Install git-cliff
         uses: taiki-e/install-action@v2
         with:
           tool: git-cliff
 
-      - name: Update CHANGELOG.md
+      - name: Update changelogs
         run: |
           version="${{ steps.extract_version.outputs.version }}"
           python3 scripts/update_changelog.py "$version"
 
-      - name: Commit and push changelog update
+      - name: Commit and push changelog updates
         run: |
           version="${{ steps.extract_version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add CHANGELOG.md changes/
-          git commit -m "docs: update changelog for $version"
+          git add CHANGELOG.md DEV-CHANGELOG.md changes/
+          git commit -m "docs: update changelogs for $version"
           git push origin HEAD:main
 
       - name: Create Git tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,154 +62,222 @@ implementation changes are documented in
 
 ### Bug Fixes
 
-- Correct the time-unit conversion in SHAKE velocity corrections.
+- Added unit conversion from fs to s in applyShake routine
+
+### Build
+
+- Added mstd-0.0.2 as git submodule to external directory for future generalizations
 
 ## [v0.6.3](https://github.com/MolarVerse/PQ/releases/tag/v0.6.3) - 2025-11-12
 
 ### Bug Fixes
 
-- Fix a segmentation fault when using the `bonded` force field.
-- Pin Eigen to a working version.
+- Fixed segfault when setting force-field to "bonded"
+- Eigen version finally fixed to 5.0.0 (latest aka master broken on 28.09.25)
 
 ### Enhancements
 
-- Wrap atom positions in triclinic boxes before writing trajectory output.
-- Write atom charges to `.chrg` output for pure QM-MD jobs.
+- Atom positions of triclinic boxes are now wrapped into the simulation box
+  when written to the trajectory output file
+- Atom charges are now written to the .chrg output file in case of pure QM-MD jobs
+
+### CI
+
+- Daily CI workflow added to build and test the codebase
+- Automatic git tag creation on new release via GitHub Actions
 
 ## [v0.6.2](https://github.com/MolarVerse/PQ/releases/tag/v0.6.2) - 2025-08-22
 
+### Workflow
+
+- added/updated git hooks for commit messages
+- added license header check in CI workflow
+
 ### Bug Fixes
 
-- Reject NaN and infinite values in restart-file input.
-- Prevent the velocity-rescaling thermostat from producing invalid velocities.
+- NaN and Inf are recognized as invalid in .rst file input 
+- VelocityRescalingThermostat is prevented from generating -nan velocities
+
+### Tests
+
+- added integration tests for QM programs
+
+### Build
+
+- Suppress googletest warnings for double promotion
+- Fix warnings when building the Sphinx documentation
 
 ## [v0.6.1](https://github.com/MolarVerse/PQ/releases/tag/v0.6.1) - 2025-07-25
 
 ### Enhancements
 
-- Add `random_seed` for reproducible simulations.
-- Report the QM loop time limit in the log.
-- Set the default QM loop time limit to one hour.
-- Refresh the example simulations and add three new examples.
+- new random_seed keyword for reproducibility
+- QM loop time limit info gets printed to the .log file
+- QM loop time limit default value is set to 3600 (1 hour)
+- Cleaned up example runs and added three new examples
 
 ### Bug Fixes
 
-- Treat atom index zero as out of bounds in topology files.
-- Preserve letter casing in `qm_script_full_path`.
+- Index 0 is now correctly out of bounds in topology file
+- The path provided for qm_script_full_path preserves its letter casing
+
+### Internal
+
+- added function to check boolean strings in input file
+
+### CI
+
+- CI workflow for macOS architecture removed
 
 ## [v0.6.0](https://github.com/MolarVerse/PQ/releases/tag/v0.6.0) - 2025-04-02
 
 ### Enhancements
 
-- Add new MACE models.
-- Add the ASE-based xTB calculator.
-- Add a keyword for loading a custom MACE model from a URL.
-- Add an option to overwrite existing output files.
+- new MACE models added
+- ASE based xTB calculator added
+- new keyword added to set custom MACE model *via* url
+- option to overwrite existing output files added
 
 ### Bug Fixes
 
-- Print temperature setup correctly in the log output.
+- Temperature setup now gets correctly printed to the .log output file
+
+### CI
+
+- Combined all CI workflows into a single workflow file
+
+### Testing
+
+- Added `src/QM` to ignore for code coverage reports
 
 ## [v0.5.3](https://github.com/MolarVerse/PQ/releases/tag/v0.5.3) - 2025-02-03
 
 ### Enhancements
 
-- Add the ASE interface for DFTB+ calculations.
-- Add `freset_forces` for resetting forces after each step.
-- Ignore `init_velocities` when non-zero velocities are already present.
-- Add a `force` option for reinitializing velocities.
+- ASE interface for DFTB+ calculations added
+- Add a new keyword 'freset_forces' to reset forces to zero after each step
+- init_velocities keyword is ignored if non-zero velocities are present
+- init_velocities can now be forced via the 'force' option
 
 ### Bug Fixes
 
-- Print volume correctly in the log output.
+- Volume now gets correctly printed to the .log output file
+
+### CI
+
+- Updated CMakeLists.txt to support macOS arm64 architecture.
+- Added CI workflow for macOS arm64 architecture.
 
 ## [v0.5.2](https://github.com/MolarVerse/PQ/releases/tag/v0.5.2) - 2025-01-05
 
 ### Enhancements
 
-- Give reference output its own file and `reference_file` input keyword.
-- Add citations for supported QM programs, velocity Verlet, RATTLE, and PQ.
-- Include BibTeX entries in `.ref` output.
+- The reference output file is now decoupled from the .log output file and is given
+  its own input file keyword 'reference_file'
+- Citations added in the .ref output file for the available QM programs,
+  the v-Verlet integrator, the RATTLE algorithm and PQ itself
+- BibTeX entries are now included in the .ref output file
+
+### CI
+
+- CI workflows removed `on push` events
+- building and testing workflows are deployed now only if relevant files change
+- Added checks to PRs if latest base commit is included in changes of PR
 
 ### Bug Fixes
 
-- Fix full-anisotropic coupling with the stochastic cell-rescaling manostat.
+- CI for Release build updated to install all integration test dependencies
+- Full anistrop coupling works now with stochastic cell rescaling manostat
 
 ## [v0.5.1](https://github.com/MolarVerse/PQ/releases/tag/v0.5.1) - 2025-01-05
 
 ### Enhancements
 
-- Restore old Nose-Hoover chain parameters when restarting.
-- Add `dftb_file` for selecting the DFTB+ input template.
-- Accept input keys case-insensitively and with either `-` or `_`.
+- Nose-Hoover chain restarting now including old chain parameters
+- 'dftb_file' keyword added to change default input file dtfb.template
+  for dftbplus QMMD
+- Input keys in input file can now be given case-insensitive as well as with '-' or '_'
+- Checks for `CHANGELOG.md` modifications on pull requests and pulls
 
 ### Bug Fixes
 
-- Fix QM atom updates in QM-MD calculations.
+- Fixed QM atoms update for QM-MD calculations
+
+### Testing
+
+- Integration test added for DFTB+ calculation
 
 ## [v0.4.5](https://github.com/MolarVerse/PQ/releases/tag/v0.4.5) - 2024-07-13
 
 ### Bug Fixes
 
-- Implement the analytic minimum-image convention for triclinic cells.
+- Minimal Image Convention for triclinic cells now implemented with analytic extension
 
 ## [v0.4.4](https://github.com/MolarVerse/PQ/releases/tag/v0.4.4) - 2024-07-09
 
 ### Bug Fixes
 
-- Fix anisotropic NPT calculations.
+- Anisotropic NPT calculations now working correctly
 
 ### Known Bugs
 
-- The minimum-image convention for triclinic cells is approximate.
+- Minimal Image Convention for triclinic cells only approximate
 
 ## [v0.4.3](https://github.com/MolarVerse/PQ/releases/tag/v0.4.3) - 2024-07-08
 
 ### Bug Fixes
 
-- Correct virial evaluation in MACE NPT calculations.
+- MACE NPT calculations bug fix - virial evaluation is now correct
 
 ### Known Bugs
 
-- Anisotropic NPT calculations do not work correctly.
-- The minimum-image convention for triclinic cells is approximate.
+- Anisotropic NPT calculations not working properly!
+- Minimal Image Convention for triclinic cells only approximate
 
 ## [v0.4.2](https://github.com/MolarVerse/PQ/releases/tag/v0.4.2) - 2024-07-04
 
 ### Bug Fixes
 
-- Fix segmentation faults in isotropic manostats.
-- Always write the latest tag as the version number in output files.
+- Isotropic manostats producing SEGFAULTS is now fixed
+- Version number in output files is now always the latest tag
+
+### Testing
+
+-Integration Test added for an exemplary NPT calculation using Berendsen-Thermostat and -Manostat (isotropic)
 
 ### Known Bugs
 
-- MACE NPT calculations do not work.
-- Anisotropic NPT calculations do not work correctly.
-- The minimum-image convention for triclinic cells is approximate.
+- MACE NPT calculations not working!
+- Anisotropic NPT calculations not working properly!
+- Minimal Image Convention for triclinic cells only approximate
 
 ## [v0.4.1](https://github.com/MolarVerse/PQ/releases/tag/v0.4.1) - 2024-07-02
 
 ### Enhancements
 
-- Expand log output with the important simulation settings.
+- Logfile output updated to give all important information about the simulation settings
+
+### CI
+
+- added CI workflow for Kokkos enabled compilations
 
 ### Known Bugs
 
-- Isotropic manostats can produce segmentation faults.
-- MACE NPT calculations do not work.
-- Anisotropic NPT calculations do not work correctly.
-- The minimum-image convention for triclinic cells is approximate.
+- Isotropic manostats producing SEGFAULTS
+- MACE NPT calculations not working!
+- Anisotropic NPT calculations not working properly!
+- Minimal Image Convention for triclinic cells only approximate
 
 ## [v0.4.0](https://github.com/MolarVerse/PQ/releases/tag/v0.4.0) - 2024-07-01
 
 ### Features
 
-- Add M-SHAKE.
-- Add the MACE neural-network potential for QM-MD calculations.
-- Add the steepest-descent and ADAM optimizers.
+- M-Shake
+- MACE Neural Network Potential for QM-MD calculations
+- Steepest-Descent Optimizer and ADAM optimizer
 
 ### Known Bugs
 
-- MACE NPT calculations do not work.
-- Anisotropic NPT calculations do not work correctly.
-- The minimum-image convention for triclinic cells is approximate.
+- MACE NPT calculations not working!
+- Anisotropic NPT calculations not working properly!
+- Minimal Image Convention for triclinic cells only approximate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,475 +1,215 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+User-visible changes to PQ are documented here. Build, CI, test, and
+implementation changes are documented in
+[DEV-CHANGELOG.md](DEV-CHANGELOG.md).
 
 ## Next Release
 
-### Enhancements
+### New Features
 
-- Add keyword "remove_net_force" for removing total net force when reading in 
-  forces from QM calculations
-- Add FeNNol neural network potential as ASE QM runner
-- Add keywords "mshake-iter" and "mshake-tolerance"
+- Add the `mm-hessian` job for molecular-mechanics Hessian calculations, with
+  optional geometry optimization.
+- Add Reaction Field as a long-range electrostatics method.
+- Add FeNNol as an ASE-based QM runner.
+- Add `mace_mode` to choose between accurate and accelerated MACE execution;
+  accelerated mode requires matching cuequivariance packages.
+- Add `remove_net_force` for removing the total net force from imported QM
+  forces.
+- Add `mshake-iter` and `mshake-tolerance` for controlling M-SHAKE convergence.
 
-### Refactor
+### Changes
 
-- Rename keyword "mace_model_size" to "mace_model" and add deprecation warning
-
-### Build
-
-- Faster builds: link-time optimization (`-flto`) is now opt-in via
-  `BUILD_WITH_LTO` (default OFF) instead of always-on in Release builds;
-  `ccache` is used automatically as a compiler launcher when available; and a
-  faster linker (`mold`/`lld`) is used automatically on Linux when available
-- Fixed compilation with `-DBUILD_WITH_ASE=Off`: the built-in SLAKOS path
-  (`__SLAKOS_DIR__`) is now guarded, so non-ASE builds compile and report a
-  clear error only if a built-in SLAKOS set is actually requested
-
-### CI
-
-- Faster CI: install and use the `mold` linker, and build with all available
-  cores instead of two
-- Faster CI: build with `-DBUILD_WITH_NATIVE=Off` (portable, no `-march=native`)
-  so compilation can be cached across runs with `ccache`
-- New `BUILD_WITH_NATIVE` option (default ON) to toggle `-march=native`
-- Faster CI: cache the conda environment (integration-test dependencies),
-  skipping reinstall on a cache hit
-- Enabled compilation with Clang/Apple Clang (matched the `requires`-clause form
-  on Vector3D compound-assignment operators and fixed a narrowing conversion in
-  TriclinicBox)
-- Faster CI: also trigger the build workflow on push to `dev`/`main` so the
-  `ccache` and conda-env caches get populated on the base branch and
-  subsequently-opened PRs start warm instead of cold
-- Performance-regression gate: fixed-work benchmarks (`BUILD_WITH_PERF_BENCH`)
-  run under callgrind; CI fails if a benchmark's instruction count regresses vs
-  the base branch (deterministic, so not flaky)
-- Perf gate now triggers only on PRs that touch code, benchmarks, build
-  config, or the gate itself; doc / changelog / unrelated-workflow PRs no
-  longer spend ~5 min building benchmarks for a no-op diff
-- Perf gate now caches the base-branch instruction counts keyed on the base
-  commit SHA; on a hit the whole base checkout + build + callgrind run is
-  skipped (≈ half the workflow), with identical numerics (callgrind is
-  deterministic per binary)
-- Per-PR changelog edits are no longer required: the `## Next Release`
-  section is auto-generated from conventional-commit subjects at release
-  time via `git-cliff` (see `cliff.toml`). The `Check Changelog` CI gate
-  and the legacy `changes/` fragment flow are deprecated; existing
-  curated `## Next Release` entries are preserved by the release script
-  unchanged
+- Rename `mace_model_size` to `mace_model`; the old keyword remains available
+  with a deprecation warning.
+- Validate incompatible input settings before simulation setup.
 
 ### Bug Fixes
 
-- `AngleForceField::calculateEnergyAndForces` no longer divides by
-  `sin(alpha)` when the angle is collinear (alpha ≈ 0 or π): the
-  bend-force decomposition is now gated on `|sin(alpha)| >= 1e-10`,
-  preventing NaN forces for linear-equilibrium parametrizations (e.g.
-  CO₂ with α₀ = 180°) and transient collinear configurations. Energy
-  contribution and the linker correction below are unaffected
-- `BerendsenThermostat::applyThermostat` no longer produces NaN
-  velocities when called with zero kinetic energy: the `T_target / T`
-  ratio would diverge and `0.0 * Inf = NaN` corrupted every atom's
-  velocity. The thermostat now skips silently when `_temperature` is
-  (approximately) zero, mirroring the velocity-rescaling NaN guard
-  added in v0.6.2
-- `kernel::distVecAndDist2(pos_i, pos_j)` (no-PBC overload) now
-  correctly returns `dot(r_ij, r_ij)` for the squared distance instead
-  of `dot(pos_i, pos_j)`. The only caller, `MShake::initMShakeReferences`,
-  was therefore storing wrong reference squared bond lengths, so
-  `applyMShake` was driving the constraint toward an incorrect target
-  and could not converge
-- Multiple M-SHAKE fixes in `applyMShake`:
-  - inner loop now iterates upper-triangular `(k+1 .. nAtoms)` bond
-    pairs instead of a rectangular `(nAtoms-1)²` grid, matching the
-    matrix-init loop. The previous loop wrote past the
-    `(nBonds, nBonds)` `mShakeMatrix` and read past
-    `bondsUnconstrained` for any molecule with `nAtoms ≥ 3`
-  - convergence check inverted: the loop now breaks when `converged`
-    is true, not when it's false (the old code exited the iteration
-    the first time anything wasn't converged)
-  - new `shakeIterations` parameter bounds the inner SHAKE iterations
-    and throws `MShakeException` instead of looping forever if the
-    constraint solver fails to converge
-  - `dt` is now converted from fs to s via `_FS_TO_S_` (mirroring the
-    v0.6.4 fix to `applyShake`); the position adjustment was
-    unaffected (dt² cancels), but the velocity correction
-    `posAdjustment / (mass * dt)` was being divided by raw fs,
-    leaving velocities essentially uncorrected by M-SHAKE
-  - `MDEngine::takeStepBeforeForces` now snapshots `_positionOld` via
-    `SimulationBox::updateOldPositions()` before the integrator's
-    first half-step when M-SHAKE is active. Without this, M-SHAKE's
-    `bondPrev` reference was whatever the `.rst` file initialised
-    `_positionOld` to (or `(0,0,0)` for files missing the old-position
-    columns), so `posAdjustment = solution * bondPrev = 0` and the
-    solver never converged
-- `ExternalQMRunner::readForceFile` now throws `QMRunnerException` if the
-  QM energy or any force component read from the external force file is
-  NaN/Inf, mirroring the v0.6.2 NaN/Inf input-file guard. Previously a
-  failed/garbage QM calculation silently propagated NaN into the
-  trajectory
+- Fix M-SHAKE convergence, iteration limits, previous-position handling, and
+  velocity corrections for constrained molecules.
+- Prevent undefined forces for collinear angle configurations, including
+  linear equilibrium geometries such as CO2.
+- Prevent the Berendsen thermostat from producing invalid velocities when the
+  kinetic energy is zero.
+- Reject non-finite energies and forces from external QM calculations instead
+  of propagating them into a trajectory.
+- Count non-adjacent duplicate atom types correctly.
+- Reject periodic cell-list layouts in which neighbor offsets refer to the same
+  cell more than once.
+- Recompute Langevin noise when the friction setting changes.
+- Preserve molecular geometry and wrap positions correctly during stochastic
+  cell rescaling.
 
-### Internal
+### Performance
 
-- Added missing trailing newline at end of `src/simulationBox/simulationBox.cpp`
-- `CoulombPotential::getCoulombRadiusCutOff()`, `getCoulombEnergyCutOff()`
-  and `getCoulombForceCutOff()` are now `inline` in the header so the
-  per-pair call in `Potential::calculateSingleInteraction` can be elided
-  without LTO
-- Cell-list rebuild no longer constructs a temporary `std::vector<size_t>`
-  per atom: `try_emplace(cellIndexScalar, std::vector<size_t>({j}))` +
-  fallback `push_back` replaced by a single `mapCellIndexToAtomIndex[cellIndexScalar].push_back(j)`
-- `utilities::isZero<T>(a)` helper added to `mathUtilities.hpp`,
-  centralizing the exact-zero check (`a == T(0)`). Callers that need a
-  tolerance can still use `compare(a, T(0), tol)`
-- Add option to queue warnings before the .log output file has been created
-  and flush them to the file at the end of the setup
-- Rename `MaceRunner` class to `AseMaceRunner` and `ASEQMRunner` to `AseQMRunner` for consistency
-- Add .clangd file for clangd language server
+- Skip inactive terms in Guff pair-potential calculations.
 
-### Tests
+### Build and Compatibility
 
-- New unit test asserting that `PotentialBruteForce::calculateForces` and
-  `PotentialCellList::calculateForces` produce identical per-atom forces and
-  intermolecular energies for the same configuration, guarding the
-  brute-force/cell-list equivalence under hot-path refactors
-- `testResetKinetics` revived: the file was 500 lines of commented-out
-  tests targeting an old 6-arg constructor; replaced with 6 working
-  tests covering the 7-arg constructor's getters, the temperature /
-  momentum / angular-momentum setters, `resetTemperature` (lambda
-  rescaling, finite output), `resetMomentum` (drives total linear
-  momentum to ~0), `resetAngularMomentum` (finite velocities), and
-  `resetForces` (zeros per-atom forces). The previously 0%-covered
-  97-line `src/resetKinetics/resetKinetics.cpp` is now exercised
-- Coverage for `ManostatSettings`, `ConstraintSettings`, `FileSettings`,
-  and `ConvergenceSettings` static-class setters/getters (manostat type
-  + isotropy string round-trips, shake/rattle tolerances + max-iters,
-  input/output file-name round-trips, optional energy/force convergence
-  thresholds)
-- Coverage for the `kernel::dist*` family (no-PBC `distVec` /
-  `distVecAndDist2` matching analytical subtraction and squared norm;
-  PBC overloads choosing the minimum-image displacement on a known
-  orthorhombic box; consistency between `distSquared`, `distVec`, and
-  `distVecAndDist2` under PBC) — these tests caught a real bug in the
-  no-PBC `distVecAndDist2` that's also fixed here
-- Coverage for `opt::LearningRateStrategy` and its three concrete
-  variants (`ConstantLRStrategy`, `ConstantDecayLRStrategy`,
-  `ExpDecayLR`): constructor stores the initial rate, the constant
-  strategy's `updateLearningRate` is a no-op, the constant-decay
-  variant decays only on frequency hits, the exponential-decay variant
-  matches the analytical `initial * exp(-decay * step / nEpochs)` and
-  is monotonically decreasing, and the base class's
-  `checkLearningRate` clamps to the min/max bounds and appends a
-  warning
-- Expanded coverage for `mathUtilities` (`compare` with tolerance,
-  `compare(Vec3D)` with tolerance, `kroneckerDelta`); `Thermostat`
-  variants (`VelocityRescaling`: tau getter/setter, thermostat type,
-  apply doesn't produce NaN; `Langevin`: sigma after construction,
-  setters/getters, sigma recompute on target-temperature change,
-  thermostat type; `NoseHoover`: thermostat type, coupling-frequency
-  setter/getter, chi/zeta index setter); and `Manostat` variants
-  (`BerendsenManostat`: tau and compressibility getters, manostat type
-  and isotropy; isotropy and type for `SemiIsotropic`, `Anisotropic`,
-  and `FullAnisotropic` Berendsen)
-- Coverage for `JCouplingType` and `JCouplingForceField` (operator==
-  contract, getter/setter coverage, default symmetry flags)
-- Expanded coverage for `PhysicalData` energy/virial accumulators
-  (`addCoulombEnergy`, `addNonCoulombEnergy`, `addBondEnergy`,
-  `addAngleEnergy`, `addDihedralEnergy`, `addImproperEnergy`,
-  `addRingPolymerEnergy`, `addVirial`); and `CellList` lifecycle
-  (`activate`/`deactivate`/`isActive` toggle; `clone` preserves the
-  configured cell counts, neighbour-cell count, and activation state)
-- Coverage for `opt::Convergence` (all four `ConvStrategy` branches
-  in `checkConvergence`, `calcEnergyConvergence` / `calcForceConvergence`
-  flag flips above/below threshold, disabled-flag short-circuits,
-  threshold getters)
-- Coverage for `opt::Optimizer` via `SteepestDescent` (constructor stores
-  `nEpochs`, `maxHistoryLength`, `clone`, history-index out-of-range
-  exception, `updateHistory` populates deques and trims to the history
-  cap, offset-indexed `getEnergy` / `getMaxForce` / `getRMSForce` /
-  `getForces` / `getPositions`, `setConvergence` / `getConvergence`
-  round-trip, `hasConverged` for flat-energy/zero-force vs. large-force)
-- Coverage for `setup::OptimizerSetup` (free `setupOptimizer` no-op when
-  not an opt job; `setupLearningRateStrategy` for `CONSTANT`,
-  `CONSTANT_DECAY`, `EXPONENTIAL_DECAY` and exception paths for
-  `LINESEARCH_WOLFE` / `NONE` / missing decay; `setupMinMaxLR`
-  min ≥ max guard; `setupEmptyOptimizer` for `STEEPEST_DESCENT`,
-  `ADAM`, exception for `NONE`; `setupConvergence` writes back into
-  the optimizer; `setupEvaluator` for `MM_OPT` and exception for
-  non-opt jobs; full `setup()` happy path)
-- Coverage for `setup::HybridSetup` (free `setupHybrid` no-op when QMMM
-  inactive; `parseSelectionNoPython` for single index, comma list,
-  range, mixed range+list, empty input throws; `parseSelection`
-  empty-string returns `{0}`, sorts and dedupes, throws on
-  letters without Python bindings; `setup()` throws not-implemented)
-- Coverage for `output::OptOutput::write` (step column, all four
-  convergence-threshold columns, `ABSOLUTE` zeros the relative-energy
-  indicator, `RELATIVE` zeros the absolute-energy indicator, disabled
-  energy convergence zeros both energy indicators)
-- Coverage for `output::TimingsOutput::write` (header rows present,
-  `Total` row present, sub-timer registered via `Timer::startTimingsSection`
-  is listed in the per-section block)
-- Coverage for both `JCouplingSection` parsers (parameter-file: 7- and
-  8-element lines with `+` / `-` / `0` symmetry, wrong-count throws;
-  topology-file: keyword, `endedNormally`, 5-element happy path,
-  wrong-count throws, duplicate-atom-index throws)
-- Coverage for `opt::SteepestDescent::update` (single-step
-  `pos_new = pos + lr * force`, old position stored, PBC wrap on
-  out-of-box updated positions, no-op at zero learning rate)
-- Coverage for `opt::Adam::update` (analytic step-1 reduction to
-  `pos_new ≈ pos + lr * sign(force)` with per-component sign
-  preservation, old position stored, PBC wrap, no-op on zero force;
-  both constructors and `clone` / `maxHistoryLength`)
-- Coverage for `opt::MMEvaluator` (`clone` produces an `MMEvaluator`
-  instance; `evaluate()` walks copy-old, force-reset, cell-list update,
-  brute-force inter-non-bonded, intra-non-bonded, bonded-interaction
-  steps without throwing on a minimal one-molecule box; per-atom force
-  buffer is zeroed when there are no inter-molecular pairs)
-- Coverage for the previously 0%-covered `Output::write()` writers
-  (`BoxFileOutput`, `StressOutput`, `VirialOutput`,
-  `RingPolymerEnergyOutput`, `references::ReferencesOutput`): step
-  column, all tensor components / box parameters / per-replica
-  energies present; one line per call; ring-polymer sum/max
-  aggregators reduce to expected scalars; references file emits the
-  fixed header + bibtex banner and tolerates non-existent registered
-  reference files
-- Coverage for `setup::resetKinetics::ResetKineticsSetup`
-  (free `setupResetKinetics` no-op when not an MD job; happy path
-  populates the MDEngine's `ResetKinetics`; zero-frequency conversion
-  to `numberOfSteps + 1`; non-zero frequencies accepted)
-- Coverage for `setup::OutputFilesSetup` (Opt-job path replaces
-  defaults and assigns the `.opt` file; MD path runs without throwing;
-  RPMD path also assigns ring-polymer output filenames)
-- Coverage for `setup::RingPolymerSetup` (free `setupRingPolymer`
-  no-op when RPMD inactive; `setup()` throws when number of beads not
-  set; `setupPhysicalData` / `setupSimulationBox` succeed with beads
-  configured)
+- Add support for Clang and Apple Clang.
+- Allow builds without ASE even when built-in SLAKOS data is unavailable.
+- Make native optimizations and link-time optimization configurable, and use
+  available compiler caches and faster linkers automatically.
 
-### Internal
+### Documentation
 
-- `CellList::getCells()` and `Cell::getNeighbourCells()` now return by
-  `const &` instead of by value, and `VelocityVerlet::secondStep` no longer
-  copies the per-atom `shared_ptr` into its lambda parameter
+- Rework the quick start, examples, troubleshooting, setup-file guidance, and
+  reference manual.
 
 <!-- insertion marker -->
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31
 
 ### Bug Fixes
 
-- Added unit conversion from fs to s in applyShake routine
-
-### Build
-
-- Added mstd-0.0.2 as git submodule to external directory for future generalizations
+- Correct the time-unit conversion in SHAKE velocity corrections.
 
 ## [v0.6.3](https://github.com/MolarVerse/PQ/releases/tag/v0.6.3) - 2025-11-12
 
 ### Bug Fixes
 
-- Fixed segfault when setting force-field to "bonded"
-- Eigen version finally fixed to 5.0.0 (latest aka master broken on 28.09.25)
+- Fix a segmentation fault when using the `bonded` force field.
+- Pin Eigen to a working version.
 
 ### Enhancements
 
-- Atom positions of triclinic boxes are now wrapped into the simulation box
-  when written to the trajectory output file
-- Atom charges are now written to the .chrg output file in case of pure QM-MD jobs
-
-### CI
-
-- Daily CI workflow added to build and test the codebase
-- Automatic git tag creation on new release via GitHub Actions
+- Wrap atom positions in triclinic boxes before writing trajectory output.
+- Write atom charges to `.chrg` output for pure QM-MD jobs.
 
 ## [v0.6.2](https://github.com/MolarVerse/PQ/releases/tag/v0.6.2) - 2025-08-22
 
-### Workflow
-
-- added/updated git hooks for commit messages
-- added license header check in CI workflow
-
 ### Bug Fixes
 
-- NaN and Inf are recognized as invalid in .rst file input 
-- VelocityRescalingThermostat is prevented from generating -nan velocities
-
-### Tests
-
-- added integration tests for QM programs
-
-### Build
-
-- Suppress googletest warnings for double promotion
-- Fix warnings when building the Sphinx documentation
+- Reject NaN and infinite values in restart-file input.
+- Prevent the velocity-rescaling thermostat from producing invalid velocities.
 
 ## [v0.6.1](https://github.com/MolarVerse/PQ/releases/tag/v0.6.1) - 2025-07-25
 
 ### Enhancements
 
-- new random_seed keyword for reproducibility
-- QM loop time limit info gets printed to the .log file
-- QM loop time limit default value is set to 3600 (1 hour)
-- Cleaned up example runs and added three new examples
+- Add `random_seed` for reproducible simulations.
+- Report the QM loop time limit in the log.
+- Set the default QM loop time limit to one hour.
+- Refresh the example simulations and add three new examples.
 
 ### Bug Fixes
 
-- Index 0 is now correctly out of bounds in topology file
-- The path provided for qm_script_full_path preserves its letter casing
-
-### Internal
-
-- added function to check boolean strings in input file
-
-### CI
-
-- CI workflow for macOS architecture removed
+- Treat atom index zero as out of bounds in topology files.
+- Preserve letter casing in `qm_script_full_path`.
 
 ## [v0.6.0](https://github.com/MolarVerse/PQ/releases/tag/v0.6.0) - 2025-04-02
 
 ### Enhancements
 
-- new MACE models added
-- ASE based xTB calculator added
-- new keyword added to set custom MACE model *via* url
-- option to overwrite existing output files added
+- Add new MACE models.
+- Add the ASE-based xTB calculator.
+- Add a keyword for loading a custom MACE model from a URL.
+- Add an option to overwrite existing output files.
 
 ### Bug Fixes
 
-- Temperature setup now gets correctly printed to the .log output file
-
-### CI
-
-- Combined all CI workflows into a single workflow file
-
-### Testing
-
-- Added `src/QM` to ignore for code coverage reports
+- Print temperature setup correctly in the log output.
 
 ## [v0.5.3](https://github.com/MolarVerse/PQ/releases/tag/v0.5.3) - 2025-02-03
 
 ### Enhancements
 
-- ASE interface for DFTB+ calculations added
-- Add a new keyword 'freset_forces' to reset forces to zero after each step
-- init_velocities keyword is ignored if non-zero velocities are present
-- init_velocities can now be forced via the 'force' option
+- Add the ASE interface for DFTB+ calculations.
+- Add `freset_forces` for resetting forces after each step.
+- Ignore `init_velocities` when non-zero velocities are already present.
+- Add a `force` option for reinitializing velocities.
 
 ### Bug Fixes
 
-- Volume now gets correctly printed to the .log output file
-
-### CI
-
-- Updated CMakeLists.txt to support macOS arm64 architecture.
-- Added CI workflow for macOS arm64 architecture.
+- Print volume correctly in the log output.
 
 ## [v0.5.2](https://github.com/MolarVerse/PQ/releases/tag/v0.5.2) - 2025-01-05
 
 ### Enhancements
 
-- The reference output file is now decoupled from the .log output file and is given
-  its own input file keyword 'reference_file'
-- Citations added in the .ref output file for the available QM programs,
-  the v-Verlet integrator, the RATTLE algorithm and PQ itself
-- BibTeX entries are now included in the .ref output file
-
-### CI
-
-- CI workflows removed `on push` events
-- building and testing workflows are deployed now only if relevant files change
-- Added checks to PRs if latest base commit is included in changes of PR
+- Give reference output its own file and `reference_file` input keyword.
+- Add citations for supported QM programs, velocity Verlet, RATTLE, and PQ.
+- Include BibTeX entries in `.ref` output.
 
 ### Bug Fixes
 
-- CI for Release build updated to install all integration test dependencies
-- Full anistrop coupling works now with stochastic cell rescaling manostat
+- Fix full-anisotropic coupling with the stochastic cell-rescaling manostat.
 
 ## [v0.5.1](https://github.com/MolarVerse/PQ/releases/tag/v0.5.1) - 2025-01-05
 
 ### Enhancements
 
-- Nose-Hoover chain restarting now including old chain parameters
-- 'dftb_file' keyword added to change default input file dtfb.template
-  for dftbplus QMMD
-- Input keys in input file can now be given case-insensitive as well as with '-' or '_'
-- Checks for `CHANGELOG.md` modifications on pull requests and pulls
+- Restore old Nose-Hoover chain parameters when restarting.
+- Add `dftb_file` for selecting the DFTB+ input template.
+- Accept input keys case-insensitively and with either `-` or `_`.
 
 ### Bug Fixes
 
-- Fixed QM atoms update for QM-MD calculations
-
-### Testing
-
-- Integration test added for DFTB+ calculation
+- Fix QM atom updates in QM-MD calculations.
 
 ## [v0.4.5](https://github.com/MolarVerse/PQ/releases/tag/v0.4.5) - 2024-07-13
 
 ### Bug Fixes
 
-- Minimal Image Convention for triclinic cells now implemented with analytic extension
+- Implement the analytic minimum-image convention for triclinic cells.
 
 ## [v0.4.4](https://github.com/MolarVerse/PQ/releases/tag/v0.4.4) - 2024-07-09
 
 ### Bug Fixes
 
-- Anisotropic NPT calculations now working correctly
+- Fix anisotropic NPT calculations.
 
 ### Known Bugs
 
-- Minimal Image Convention for triclinic cells only approximate
+- The minimum-image convention for triclinic cells is approximate.
 
 ## [v0.4.3](https://github.com/MolarVerse/PQ/releases/tag/v0.4.3) - 2024-07-08
 
 ### Bug Fixes
 
-- MACE NPT calculations bug fix - virial evaluation is now correct
+- Correct virial evaluation in MACE NPT calculations.
 
 ### Known Bugs
 
-- Anisotropic NPT calculations not working properly!
-- Minimal Image Convention for triclinic cells only approximate
+- Anisotropic NPT calculations do not work correctly.
+- The minimum-image convention for triclinic cells is approximate.
 
 ## [v0.4.2](https://github.com/MolarVerse/PQ/releases/tag/v0.4.2) - 2024-07-04
 
 ### Bug Fixes
 
-- Isotropic manostats producing SEGFAULTS is now fixed
-- Version number in output files is now always the latest tag
-
-### Testing
-
--Integration Test added for an exemplary NPT calculation using Berendsen-Thermostat and -Manostat (isotropic)
+- Fix segmentation faults in isotropic manostats.
+- Always write the latest tag as the version number in output files.
 
 ### Known Bugs
 
-- MACE NPT calculations not working!
-- Anisotropic NPT calculations not working properly!
-- Minimal Image Convention for triclinic cells only approximate
+- MACE NPT calculations do not work.
+- Anisotropic NPT calculations do not work correctly.
+- The minimum-image convention for triclinic cells is approximate.
 
 ## [v0.4.1](https://github.com/MolarVerse/PQ/releases/tag/v0.4.1) - 2024-07-02
 
 ### Enhancements
 
-- Logfile output updated to give all important information about the simulation settings
-
-### CI
-
-- added CI workflow for Kokkos enabled compilations
+- Expand log output with the important simulation settings.
 
 ### Known Bugs
 
-- Isotropic manostats producing SEGFAULTS
-- MACE NPT calculations not working!
-- Anisotropic NPT calculations not working properly!
-- Minimal Image Convention for triclinic cells only approximate
+- Isotropic manostats can produce segmentation faults.
+- MACE NPT calculations do not work.
+- Anisotropic NPT calculations do not work correctly.
+- The minimum-image convention for triclinic cells is approximate.
 
 ## [v0.4.0](https://github.com/MolarVerse/PQ/releases/tag/v0.4.0) - 2024-07-01
 
 ### Features
 
-- M-Shake
-- MACE Neural Network Potential for QM-MD calculations
-- Steepest-Descent Optimizer and ADAM optimizer
+- Add M-SHAKE.
+- Add the MACE neural-network potential for QM-MD calculations.
+- Add the steepest-descent and ADAM optimizers.
 
 ### Known Bugs
 
-- MACE NPT calculations not working!
-- Anisotropic NPT calculations not working properly!
-- Minimal Image Convention for triclinic cells only approximate
+- MACE NPT calculations do not work.
+- Anisotropic NPT calculations do not work correctly.
+- The minimum-image convention for triclinic cells is approximate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ implementation changes are documented in
 
 - Rename `mace_model_size` to `mace_model`; the old keyword remains available
   with a deprecation warning.
-- Validate incompatible input settings before simulation setup.
 
 ### Bug Fixes
 

--- a/DEV-CHANGELOG.md
+++ b/DEV-CHANGELOG.md
@@ -9,7 +9,6 @@ in `CHANGELOG.md`.
 
 ### Enhancements
 
-- Add input-file validation.
 - Implement Reaction Field long-range correction.
 - Add `mace_mode` for selecting accurate or accelerated MACE execution.
 - Add `mshake-iter` and `mshake-tolerance`.

--- a/DEV-CHANGELOG.md
+++ b/DEV-CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Build, CI, test, refactor, and implementation changes are documented here.
 User-visible release notes are documented in [CHANGELOG.md](CHANGELOG.md).
+This split starts with the next release; older release entries remain unchanged
+in `CHANGELOG.md`.
 
 ## Next Release
 
@@ -90,92 +92,3 @@ User-visible release notes are documented in [CHANGELOG.md](CHANGELOG.md).
 - Refresh the reference manual, quick start, examples, and troubleshooting.
 
 <!-- insertion marker -->
-## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31
-
-### Build
-
-- Add mstd 0.0.2 as a submodule for future generalizations.
-
-## [v0.6.3](https://github.com/MolarVerse/PQ/releases/tag/v0.6.3) - 2025-11-12
-
-### CI
-
-- Add the daily build and test workflow.
-- Add automatic tag creation for releases.
-
-## [v0.6.2](https://github.com/MolarVerse/PQ/releases/tag/v0.6.2) - 2025-08-22
-
-### Workflow
-
-- Add and update commit-message hooks.
-- Add the license-header check.
-
-### Tests
-
-- Add integration tests for QM programs.
-
-### Build
-
-- Suppress GoogleTest double-promotion warnings.
-- Fix warnings in Sphinx documentation builds.
-
-## [v0.6.1](https://github.com/MolarVerse/PQ/releases/tag/v0.6.1) - 2025-07-25
-
-### Internal
-
-- Add a helper for validating boolean input strings.
-
-### CI
-
-- Remove the macOS workflow.
-
-## [v0.6.0](https://github.com/MolarVerse/PQ/releases/tag/v0.6.0) - 2025-04-02
-
-### CI
-
-- Combine the CI workflows.
-
-### Tests
-
-- Exclude `src/QM` from coverage reports.
-
-## [v0.5.3](https://github.com/MolarVerse/PQ/releases/tag/v0.5.3) - 2025-02-03
-
-### Build
-
-- Add macOS arm64 support to CMake.
-
-### CI
-
-- Add the macOS arm64 workflow.
-
-## [v0.5.2](https://github.com/MolarVerse/PQ/releases/tag/v0.5.2) - 2025-01-05
-
-### CI
-
-- Run build and test workflows only for relevant changes.
-- Check that pull requests include the latest base commit.
-- Install all integration-test dependencies in release builds.
-
-## [v0.5.1](https://github.com/MolarVerse/PQ/releases/tag/v0.5.1) - 2025-01-05
-
-### Workflow
-
-- Add changelog checks for pull requests.
-
-### Tests
-
-- Add a DFTB+ integration test.
-
-## [v0.4.2](https://github.com/MolarVerse/PQ/releases/tag/v0.4.2) - 2024-07-04
-
-### Tests
-
-- Add an isotropic NPT integration test using the Berendsen thermostat and
-  manostat.
-
-## [v0.4.1](https://github.com/MolarVerse/PQ/releases/tag/v0.4.1) - 2024-07-02
-
-### CI
-
-- Add a Kokkos build workflow.

--- a/DEV-CHANGELOG.md
+++ b/DEV-CHANGELOG.md
@@ -1,0 +1,181 @@
+# Developer Changelog
+
+Build, CI, test, refactor, and implementation changes are documented here.
+User-visible release notes are documented in [CHANGELOG.md](CHANGELOG.md).
+
+## Next Release
+
+### Enhancements
+
+- Add input-file validation.
+- Implement Reaction Field long-range correction.
+- Add `mace_mode` for selecting accurate or accelerated MACE execution.
+- Add `mshake-iter` and `mshake-tolerance`.
+- Add FeNNol references and its QM runner.
+- Add the MM Hessian workflow.
+- Add net-force removal for imported QM forces.
+
+### Bug Fixes
+
+- Refresh the Langevin noise amplitude after friction changes.
+- Preserve molecular geometry during manostat scaling.
+- Reject aliased cell-list layouts.
+- Guard SLAKOS tests in builds without ASE.
+- Count non-adjacent atom types correctly.
+- Export the potential force kernels.
+- Correct M-SHAKE loop bounds, convergence, iteration limits, time units, and
+  previous-position handling.
+- Reject non-finite external QM energies and forces.
+- Correct the no-PBC squared-distance calculation.
+- Guard the Berendsen thermostat against zero-temperature invalid values.
+- Guard angle-force division for collinear configurations.
+
+### Performance
+
+- Skip zero-coefficient terms in `GuffPair::calculate`.
+
+### Build
+
+- Enforce exhaustive enum switches.
+- Guard the built-in SLAKOS path in builds without ASE.
+- Add `BUILD_WITH_NATIVE` for controlling native compiler optimizations.
+- Add Clang and Apple Clang support.
+- Detect available compiler caches and faster linkers.
+- Make link-time optimization opt-in through `BUILD_WITH_LTO`.
+
+### CI
+
+- Split user and developer changelogs and require curated user notes in release
+  pull requests.
+- Replace per-PR changelog edits with release-time generation.
+- Cache base-branch performance instruction counts.
+- Run the performance gate only for relevant changes.
+- Post performance results as a persistent pull-request comment.
+- Add the callgrind instruction-count regression gate.
+- Warm build caches from `dev` and `main`.
+- Cache the integration-test environment.
+- Build portable binaries for reusable compiler caches.
+- Fix integration-test environment setup.
+
+### Tests
+
+- Add explicit coverage for enum sentinels.
+- Add Reaction Field unit and long-range-correction tests.
+- Add the math and algorithm regression suite.
+- Cover the renamed ASE MACE runner.
+- Add M-SHAKE keyword, convergence, unit, loop-bound, and state tests.
+- Add FeNNol parser and runner tests.
+- Add Hessian-builder tests.
+- Add brute-force and cell-list force-equivalence tests.
+- Expand coverage for reset kinetics, output writers, optimizers, evaluators,
+  settings, force fields, thermostats, manostats, cell lists, and setup paths.
+- Add fixed-work performance benchmarks for force kernels, pair potentials,
+  linear algebra, box transforms, integration, kinetics, and constraints.
+
+### Internal
+
+- Remove default branches from enum switches and share sentinel fallbacks.
+- Move input validation into the engine configuration path.
+- Prefix performance benchmark filenames.
+- Add language-server configuration.
+- Rename the ASE-based MACE runner classes consistently.
+- Return cell and neighbor collections by constant reference.
+- Avoid a temporary vector during cell-list rebuilds.
+- Inline Coulomb cutoff getters.
+
+### Documentation
+
+- Update the feature list and PQ reference.
+- Document Reaction Field, M-SHAKE, and FeNNol.
+- Refresh the reference manual, quick start, examples, and troubleshooting.
+
+<!-- insertion marker -->
+## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31
+
+### Build
+
+- Add mstd 0.0.2 as a submodule for future generalizations.
+
+## [v0.6.3](https://github.com/MolarVerse/PQ/releases/tag/v0.6.3) - 2025-11-12
+
+### CI
+
+- Add the daily build and test workflow.
+- Add automatic tag creation for releases.
+
+## [v0.6.2](https://github.com/MolarVerse/PQ/releases/tag/v0.6.2) - 2025-08-22
+
+### Workflow
+
+- Add and update commit-message hooks.
+- Add the license-header check.
+
+### Tests
+
+- Add integration tests for QM programs.
+
+### Build
+
+- Suppress GoogleTest double-promotion warnings.
+- Fix warnings in Sphinx documentation builds.
+
+## [v0.6.1](https://github.com/MolarVerse/PQ/releases/tag/v0.6.1) - 2025-07-25
+
+### Internal
+
+- Add a helper for validating boolean input strings.
+
+### CI
+
+- Remove the macOS workflow.
+
+## [v0.6.0](https://github.com/MolarVerse/PQ/releases/tag/v0.6.0) - 2025-04-02
+
+### CI
+
+- Combine the CI workflows.
+
+### Tests
+
+- Exclude `src/QM` from coverage reports.
+
+## [v0.5.3](https://github.com/MolarVerse/PQ/releases/tag/v0.5.3) - 2025-02-03
+
+### Build
+
+- Add macOS arm64 support to CMake.
+
+### CI
+
+- Add the macOS arm64 workflow.
+
+## [v0.5.2](https://github.com/MolarVerse/PQ/releases/tag/v0.5.2) - 2025-01-05
+
+### CI
+
+- Run build and test workflows only for relevant changes.
+- Check that pull requests include the latest base commit.
+- Install all integration-test dependencies in release builds.
+
+## [v0.5.1](https://github.com/MolarVerse/PQ/releases/tag/v0.5.1) - 2025-01-05
+
+### Workflow
+
+- Add changelog checks for pull requests.
+
+### Tests
+
+- Add a DFTB+ integration test.
+
+## [v0.4.2](https://github.com/MolarVerse/PQ/releases/tag/v0.4.2) - 2024-07-04
+
+### Tests
+
+- Add an isotropic NPT integration test using the Berendsen thermostat and
+  manostat.
+
+## [v0.4.1](https://github.com/MolarVerse/PQ/releases/tag/v0.4.1) - 2024-07-02
+
+### CI
+
+- Add a Kokkos build workflow.

--- a/changes/241.internal.md
+++ b/changes/241.internal.md
@@ -1,2 +1,0 @@
-- `GuffPair::calculate` gates each `pow`/`exp` term on its coefficient being
-  non-zero, skipping the transcendental call when the term contributes nothing

--- a/changes/README.md
+++ b/changes/README.md
@@ -1,16 +1,16 @@
 # Changelog fragments (deprecated)
 
-> **Note:** as of the auto-changelog migration, PRs no longer need to add
-> a changelog fragment or edit `CHANGELOG.md`. The Next Release section
-> is generated from your conventional-commit subjects (`fix:`, `feat:`,
-> `build:`, `ci:`, `test:`, `refactor:`, `perf:`, …) at release time by
-> `git-cliff`, configured in `cliff.toml` at the repo root.
->
-> Write a clean commit subject and you're done; the release script does
-> the rest.
+Regular pull requests do not edit `CHANGELOG.md`, `DEV-CHANGELOG.md`, or add
+changelog fragments.
 
-This directory is kept only so any legacy `<slug>.<type>.md` fragments
-opened before the migration still get folded into the next release
-(`scripts/update_changelog.py` reads them on its way through).
+For a release:
 
-You can safely ignore this directory in new PRs.
+1. Curate the user-visible changes under `## Next Release` in `CHANGELOG.md`.
+2. Open the release pull request. Its release check requires at least one
+   user-facing bullet.
+3. After merge, `scripts/update_changelog.py` stamps the curated user notes and
+   generates `DEV-CHANGELOG.md` from conventional commits.
+
+The release script still accepts old `<slug>.<type>.md` fragments from branches
+created before this workflow. Those fragments are included only in the
+developer changelog and removed after release.

--- a/changes/atom-type-counting.bugfix.md
+++ b/changes/atom-type-counting.bugfix.md
@@ -1,1 +1,0 @@
-- Count non-adjacent duplicate atom types correctly when determining molecule and molecule-type atom-type counts.

--- a/changes/cell-list-alias-guard.bugfix.md
+++ b/changes/cell-list-alias-guard.bugfix.md
@@ -1,1 +1,0 @@
-- Reject periodic cell-list neighbor layouts where neighbour offsets can alias the same cell.

--- a/changes/changelog-fragments.ci.md
+++ b/changes/changelog-fragments.ci.md
@@ -1,4 +1,0 @@
-- Per-PR changelog **fragments** under `changes/` replace the
-  conflict-prone `## Next Release` editing flow. Each PR adds one tiny
-  `changes/<slug>.<type>.md` instead of touching `CHANGELOG.md`; the
-  release script collates them. See `changes/README.md`.

--- a/changes/docs-reference-refresh.doc.md
+++ b/changes/docs-reference-refresh.doc.md
@@ -1,3 +1,0 @@
-- Refresh the Sphinx documentation with quick-start, examples and
-  troubleshooting pages, a clearer reference manual, setup-file documentation
-  and contributor formatting guidance

--- a/changes/langevin-friction-sigma.bugfix.md
+++ b/changes/langevin-friction-sigma.bugfix.md
@@ -1,1 +1,0 @@
-- Recompute the Langevin noise amplitude when friction changes so thermostat setters keep dependent state consistent.

--- a/changes/mace-cueq.enhancement.md
+++ b/changes/mace-cueq.enhancement.md
@@ -1,6 +1,0 @@
-- New `mace_mode` input option for MACE QM runs: `accurate` (default, the
-  exact e3nn reference) or `fast` (cuequivariance-accelerated kernels —
-  substantially faster for MD, at the cost of not being bit-identical to the
-  e3nn reference). `fast` requires `cuequivariance`, `cuequivariance-torch`
-  and the matching CUDA ops package `cuequivariance-ops-torch-cuXX` (not pulled
-  in automatically), where `XX` matches the CUDA build of the installed `torch`.

--- a/changes/math-regression-invariants.test.md
+++ b/changes/math-regression-invariants.test.md
@@ -1,4 +1,0 @@
-- Add a regression suite for pair-potential force/energy derivative consistency,
-  cutoff shifting, periodic distance and cell-list wrapping invariants,
-  zero-force velocity-Verlet behavior, Langevin zero-friction noise, and a
-  zipped MM-MD smoke fixture.

--- a/changes/mm-hessian.enhancement.md
+++ b/changes/mm-hessian.enhancement.md
@@ -1,1 +1,0 @@
-- Added an `mm-hessian` job type for molecular-mechanics Hessian generation with optional pre-optimization.

--- a/changes/potential-force-linkage.bugfix.md
+++ b/changes/potential-force-linkage.bugfix.md
@@ -1,1 +1,0 @@
-- Export brute-force and cell-list force-kernel definitions so the potential equivalence test can link and run.

--- a/changes/stochastic-rescale-pbc.bugfix.md
+++ b/changes/stochastic-rescale-pbc.bugfix.md
@@ -1,3 +1,0 @@
-- Stochastic rescaling now uses length scaling for isotropic `mu` and wraps
-  molecule-COM-scaled atom positions into the scaled box instead of leaving
-  boundary-crossing positions outside the cell

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,18 +1,20 @@
-# git-cliff configuration for PQ.
+# git-cliff configuration for PQ's developer changelog.
 #
-# Generates the CHANGELOG.md "Next Release" section from conventional
-# commits since the last tag, so per-PR changelog edits are no longer
-# required. Verbosity is kept under control by:
+# Generates the DEV-CHANGELOG.md release section from conventional commits
+# since the last tag. CHANGELOG.md is curated separately for users in the
+# release PR. Regular PRs do not edit either file.
+#
+# Developer-changelog verbosity is kept under control by:
 #
 #   * skipping merge commits and trivial types (chore/style/format),
-#   * grouping all commits under PQ's existing CHANGELOG sections so a
+#   * grouping all commits under stable developer sections so a
 #     20-commit release renders as ~6 short sections rather than one
 #     long wall of bullets,
 #   * keeping each entry to the commit subject only (no body),
 #   * de-duplicating identical entries.
 #
-# The maintainer always reviews the generated Next Release section in
-# the release PR before tagging.
+# The generated output is the technical record; user-facing release notes are
+# reviewed separately in CHANGELOG.md.
 
 [changelog]
 header = ""
@@ -63,8 +65,8 @@ ignore_tags = ""
 topo_order = false
 sort_commits = "newest"
 
-# Map every prefix the commit-msg hook accepts to one of PQ's CHANGELOG
-# sections, plus skip rules for the noisy ones.
+# Map every prefix the commit-msg hook accepts to a developer changelog
+# section, plus skip rules for the noisy ones.
 commit_parsers = [
   # Skip merge commits, GitHub release PR bodies, and revert markers.
   { message = "^[Mm]erge ", skip = true },

--- a/scripts/tests/test_update_changelog.py
+++ b/scripts/tests/test_update_changelog.py
@@ -1,0 +1,132 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "update_changelog.py"
+SPEC = importlib.util.spec_from_file_location("update_changelog", SCRIPT)
+CHANGELOG = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHANGELOG)
+
+
+class ChangelogTests(unittest.TestCase):
+    def test_user_notes_require_a_bullet(self):
+        self.assertFalse(
+            CHANGELOG.has_user_release_notes(
+                ["", "### Bug Fixes", "", "No release notes yet."]
+            )
+        )
+        self.assertTrue(
+            CHANGELOG.has_user_release_notes(
+                ["", "### Bug Fixes", "", "- Fix trajectory output."]
+            )
+        )
+
+    def test_stamp_keeps_empty_next_release_and_history(self):
+        lines = [
+            "# Changelog",
+            "",
+            "## Next Release",
+            "",
+            "### Bug Fixes",
+            "",
+            "- Fix trajectory output.",
+            "",
+            "<!-- insertion marker -->",
+            "## [v1.0.0](release-url) - 2025-01-01",
+        ]
+
+        head, body, tail = CHANGELOG.split_next_release(
+            lines, "CHANGELOG.md"
+        )
+        stamped = CHANGELOG.stamp_release(
+            head, body, tail, "v1.1.0", "MolarVerse/PQ"
+        )
+
+        next_index = stamped.index("## Next Release")
+        marker_index = stamped.index("<!-- insertion marker -->")
+        release_index = next(
+            index
+            for index, line in enumerate(stamped)
+            if line.startswith("## [v1.1.0]")
+        )
+        old_release_index = stamped.index(
+            "## [v1.0.0](release-url) - 2025-01-01"
+        )
+
+        self.assertLess(next_index, marker_index)
+        self.assertLess(marker_index, release_index)
+        self.assertLess(release_index, old_release_index)
+        self.assertIn(
+            "- Fix trajectory output.",
+            stamped[release_index:old_release_index],
+        )
+        self.assertFalse(
+            CHANGELOG.has_user_release_notes(
+                stamped[next_index + 1 : marker_index]
+            )
+        )
+
+    def test_release_updates_both_changelogs_and_consumes_fragments(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            user_changelog = root / "CHANGELOG.md"
+            dev_changelog = root / "DEV-CHANGELOG.md"
+            changes_dir = root / "changes"
+            changes_dir.mkdir()
+
+            user_changelog.write_text(
+                "# Changelog\n\n"
+                "## Next Release\n\n"
+                "### Bug Fixes\n\n"
+                "- Fix trajectory output.\n\n"
+                "<!-- insertion marker -->\n"
+                "## [v1.0.0](release-url) - 2025-01-01\n",
+                encoding="utf-8",
+            )
+            dev_changelog.write_text(
+                "# Developer Changelog\n\n"
+                "## Next Release\n\n"
+                "### Internal\n\n"
+                "- Stale preview.\n\n"
+                "<!-- insertion marker -->\n"
+                "## [v1.0.0](release-url) - 2025-01-01\n",
+                encoding="utf-8",
+            )
+            fragment = changes_dir / "legacy.test.md"
+            fragment.write_text("- Cover the parser.\n", encoding="utf-8")
+
+            generated = {
+                section: [] for section in CHANGELOG.ORDER
+            }
+            generated["Internal"] = ["- Refactor the parser."]
+
+            with (
+                mock.patch.object(
+                    CHANGELOG, "USER_CHANGELOG", user_changelog
+                ),
+                mock.patch.object(
+                    CHANGELOG, "DEV_CHANGELOG", dev_changelog
+                ),
+                mock.patch.object(CHANGELOG, "CHANGES_DIR", changes_dir),
+                mock.patch.object(
+                    CHANGELOG, "run_git_cliff", return_value=generated
+                ),
+            ):
+                CHANGELOG.update_changelogs("v1.1.0")
+
+            user_text = user_changelog.read_text(encoding="utf-8")
+            dev_text = dev_changelog.read_text(encoding="utf-8")
+
+            self.assertIn("## Next Release\n\n<!-- insertion marker -->", user_text)
+            self.assertIn("- Fix trajectory output.", user_text)
+            self.assertIn("- Refactor the parser.", dev_text)
+            self.assertIn("- Cover the parser.", dev_text)
+            self.assertNotIn("- Stale preview.", dev_text)
+            self.assertFalse(fragment.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -1,22 +1,18 @@
 #!/usr/bin/env python3
-"""Stamp a release version into CHANGELOG.md, auto-generating the section
-from conventional commits when no curated content exists yet.
+"""Stamp user and developer changelogs for a release.
 
-Behavior:
+`CHANGELOG.md` is curated in the release pull request and contains only
+user-visible changes. `DEV-CHANGELOG.md` is generated from conventional
+commits at release time and contains the complete technical record.
 
-  1. If `## Next Release` already contains subsections with bullets, that
-     content is left as-is and stamped with the new version. Existing
-     legacy `changes/<slug>.<type>.md` fragments (if any) are folded in
-     under the matching section so they aren't lost.
-  2. If `## Next Release` is empty (no subsections), git-cliff is invoked
-     to render fresh bullets from conventional commits since the previous
-     tag, using cliff.toml at the repo root.
-  3. The section header is then rewritten to
-     `## [<version>](...) - <date>` and the `<!-- insertion marker -->`
-     is moved above it. Consumed fragments are unlinked.
+Regular pull requests do not edit either file. This keeps changelog curation
+out of the normal merge path while still requiring reviewed user release notes.
 
-Usage: update_changelog.py <version>
+Usage:
+    update_changelog.py --check
+    update_changelog.py <version>
 """
+
 import os
 import re
 import subprocess
@@ -24,20 +20,18 @@ import sys
 from datetime import date
 from pathlib import Path
 
-# Fragment type -> CHANGELOG section heading. Legacy: kept so a fragment
-# left over from the deprecated changes/ flow still ends up in the right
-# section.
+# Fragment type -> developer changelog section. Fragments are deprecated, but
+# this keeps fragments from older branches from being lost when they merge.
 SECTIONS = {
-    "bugfix":      "Bug Fixes",
-    "build":       "Build",
-    "ci":          "CI",
-    "internal":    "Internal",
-    "test":        "Tests",
+    "bugfix": "Bug Fixes",
+    "build": "Build",
+    "ci": "CI",
+    "internal": "Internal",
+    "test": "Tests",
     "enhancement": "Enhancements",
-    "doc":         "Documentation",
+    "doc": "Documentation",
 }
 
-# Section order in the rendered changelog (matches cliff.toml).
 ORDER = [
     "Breaking Changes",
     "Enhancements",
@@ -52,190 +46,256 @@ ORDER = [
 
 ROOT = Path(__file__).resolve().parent.parent
 CHANGES_DIR = ROOT / "changes"
-CHANGELOG = ROOT / "CHANGELOG.md"
+USER_CHANGELOG = ROOT / "CHANGELOG.md"
+DEV_CHANGELOG = ROOT / "DEV-CHANGELOG.md"
 CLIFF_TOML = ROOT / "cliff.toml"
 
 FRAGMENT_RE = re.compile(r"^([^.]+)\.([^.]+)\.md$")
+USER_BULLET_RE = re.compile(r"^\s*-\s+\S")
 
 
 def read_fragments():
-    """Group fragment bodies by section (legacy `changes/` flow)."""
+    """Group legacy fragment bodies by developer changelog section."""
     if not CHANGES_DIR.is_dir():
-        return {s: [] for s in ORDER}, []
-    grouped = {s: [] for s in ORDER}
+        return {section: [] for section in ORDER}, []
+
+    grouped = {section: [] for section in ORDER}
     consumed = []
     for path in sorted(CHANGES_DIR.glob("*.md")):
         if path.name == "README.md":
             continue
-        m = FRAGMENT_RE.match(path.name)
-        if not m:
+
+        match = FRAGMENT_RE.match(path.name)
+        if not match:
             sys.exit(f"unexpected fragment name: {path.name}")
-        _, kind = m.groups()
+
+        _, kind = match.groups()
         if kind not in SECTIONS:
             sys.exit(
                 f"unknown fragment type '{kind}' in {path.name}; "
                 f"allowed: {sorted(SECTIONS)}"
             )
-        grouped[SECTIONS[kind]].append(path.read_text(encoding="utf-8").rstrip())
+
+        grouped[SECTIONS[kind]].append(
+            path.read_text(encoding="utf-8").rstrip()
+        )
         consumed.append(path)
+
     return grouped, consumed
 
 
-def split_next_release(lines):
-    """Locate the `## Next Release` block and split the file around it.
+def split_next_release(lines, changelog):
+    """Return the file head, Next Release body, and release-history tail."""
+    next_index = None
+    end_index = len(lines)
 
-    Returns (head, body, tail) where head/tail are the lines before/after
-    the block (inclusive of `## Next Release` and `<!-- insertion marker -->`
-    respectively), and body is the bullet content between them.
-    """
-    next_idx = None
-    end_idx = len(lines)
-    for i, line in enumerate(lines):
-        if next_idx is None and re.match(r"^##\s+Next Release\s*$", line):
-            next_idx = i
+    for index, line in enumerate(lines):
+        if next_index is None and re.match(r"^##\s+Next Release\s*$", line):
+            next_index = index
             continue
-        if next_idx is not None and (
-            re.match(r"^##\s+\[", line) or "<!-- insertion marker -->" in line
+        if next_index is not None and (
+            re.match(r"^##\s+\[", line)
+            or "<!-- insertion marker -->" in line
         ):
-            end_idx = i
+            end_index = index
             break
-    if next_idx is None:
-        sys.exit("could not find '## Next Release' in CHANGELOG.md")
-    return lines[:next_idx + 1], lines[next_idx + 1:end_idx], lines[end_idx:]
+
+    if next_index is None:
+        sys.exit(f"could not find '## Next Release' in {changelog}")
+
+    return (
+        lines[: next_index + 1],
+        lines[next_index + 1 : end_index],
+        lines[end_index:],
+    )
 
 
 def parse_subsections(body_lines):
-    """Parse subsections inside the `## Next Release` block.
-
-    Returns dict[section_heading] -> list of raw bullet lines.
-    """
-    sections = {s: [] for s in ORDER}
+    """Parse `###` sections into a mapping of headings to bullet lines."""
+    sections = {section: [] for section in ORDER}
     current = None
+
     for raw in body_lines:
-        m = re.match(r"^###\s+(.+?)\s*$", raw)
-        if m:
-            current = m.group(1).strip()
+        match = re.match(r"^###\s+(.+?)\s*$", raw)
+        if match:
+            current = match.group(1).strip()
             sections.setdefault(current, [])
             continue
         if current and raw.strip():
             sections[current].append(raw)
+
     return sections
 
 
 def render_sections(sections):
-    """Render the per-section dict back into markdown lines."""
-    out = []
+    """Render developer changelog sections in a stable order."""
+    output = []
+
     for section in ORDER:
-        bullets = [b for b in sections.get(section, []) if b.strip()]
+        bullets = [line for line in sections.get(section, []) if line.strip()]
         if not bullets:
             continue
-        out.append(f"### {section}")
-        out.append("")
-        out.extend(bullets)
-        out.append("")
-    # Any custom section not in ORDER goes at the end, preserving order
-    # of first appearance.
+        output.extend([f"### {section}", "", *bullets, ""])
+
     for section, bullets in sections.items():
         if section in ORDER:
             continue
-        bullets = [b for b in bullets if b.strip()]
+        bullets = [line for line in bullets if line.strip()]
         if not bullets:
             continue
-        out.append(f"### {section}")
-        out.append("")
-        out.extend(bullets)
-        out.append("")
-    return out
+        output.extend([f"### {section}", "", *bullets, ""])
+
+    return output
 
 
 def run_git_cliff():
-    """Generate per-section bullets via git-cliff for commits since the
-    last tag. Returns dict[section_heading] -> list of raw bullet lines."""
+    """Generate developer sections from commits since the latest tag."""
     if not CLIFF_TOML.is_file():
         sys.exit(f"cliff.toml not found at {CLIFF_TOML}")
+
     result = subprocess.run(
         [
             "git-cliff",
             "--unreleased",
-            "--strip", "all",
-            "--config", str(CLIFF_TOML),
+            "--strip",
+            "all",
+            "--config",
+            str(CLIFF_TOML),
         ],
         capture_output=True,
         text=True,
         cwd=ROOT,
+        check=False,
     )
     if result.returncode != 0:
         sys.exit(
             "git-cliff failed (exit "
             f"{result.returncode}): {result.stderr.strip()}"
         )
+
     return parse_subsections(result.stdout.splitlines())
 
 
-def stamp_release(head_lines, body_lines, tail_lines, version, repo):
-    """Replace the `## Next Release` heading with the versioned heading
-    and put the `<!-- insertion marker -->` above it. Strips any prior
-    insertion-marker line out of the tail."""
-    new_header = (
+def has_user_release_notes(body_lines):
+    """Return whether the user changelog contains at least one bullet."""
+    return any(USER_BULLET_RE.match(line) for line in body_lines)
+
+
+def trim_blank_lines(lines):
+    """Remove blank lines at both edges without changing inner formatting."""
+    start = 0
+    end = len(lines)
+
+    while start < end and not lines[start].strip():
+        start += 1
+    while end > start and not lines[end - 1].strip():
+        end -= 1
+
+    return lines[start:end]
+
+
+def stamp_release(head, body, tail, version, repo):
+    """Move a Next Release body under a version while keeping Next Release."""
+    release_header = (
         f"## [{version}](https://github.com/{repo}/releases/tag/{version}) "
         f"- {date.today().isoformat()}"
     )
-    # Replace the last line of head ("## Next Release") with the marker +
-    # the versioned header.
-    head = head_lines[:-1] + ["<!-- insertion marker -->", new_header, ""]
-    # Drop any lingering insertion-marker lines in the tail.
-    tail = [line for line in tail_lines if "<!-- insertion marker -->" not in line]
-    return head + body_lines + tail
+    clean_body = trim_blank_lines(body)
+    clean_tail = [
+        line for line in tail if "<!-- insertion marker -->" not in line
+    ]
+    clean_tail = trim_blank_lines(clean_tail)
+
+    output = [
+        *trim_blank_lines(head),
+        "",
+        "<!-- insertion marker -->",
+        release_header,
+        "",
+        *clean_body,
+    ]
+    if clean_tail:
+        output.extend(["", *clean_tail])
+
+    return output
 
 
-def main():
-    if len(sys.argv) != 2:
-        sys.exit(f"usage: {sys.argv[0]} <version>")
-    if not CHANGELOG.exists():
-        sys.exit("CHANGELOG.md not found")
+def load_changelog(path):
+    if not path.is_file():
+        sys.exit(f"{path.name} not found")
+    return path.read_text(encoding="utf-8").splitlines()
 
-    version = sys.argv[1]
+
+def check_user_changelog():
+    lines = load_changelog(USER_CHANGELOG)
+    _, body, _ = split_next_release(lines, USER_CHANGELOG.name)
+    if not has_user_release_notes(body):
+        sys.exit(
+            "CHANGELOG.md needs at least one user-facing bullet under "
+            "'## Next Release' before release"
+        )
+    print("CHANGELOG.md contains curated user release notes")
+
+
+def update_changelogs(version):
     repo = os.getenv("GITHUB_REPOSITORY", "MolarVerse/PQ")
 
-    lines = CHANGELOG.read_text(encoding="utf-8").splitlines()
-    head, body, tail = split_next_release(lines)
+    user_lines = load_changelog(USER_CHANGELOG)
+    user_head, user_body, user_tail = split_next_release(
+        user_lines, USER_CHANGELOG.name
+    )
+    if not has_user_release_notes(user_body):
+        sys.exit(
+            "CHANGELOG.md needs curated user release notes before release"
+        )
 
-    curated = parse_subsections(body)
-    has_curated_content = any(
-        any(line.strip() for line in bullets)
-        for bullets in curated.values()
+    dev_lines = load_changelog(DEV_CHANGELOG)
+    dev_head, _, dev_tail = split_next_release(
+        dev_lines, DEV_CHANGELOG.name
     )
 
-    fragment_bullets, consumed_fragments = read_fragments()
+    dev_sections = run_git_cliff()
+    fragment_sections, consumed_fragments = read_fragments()
+    for section, bullets in fragment_sections.items():
+        dev_sections.setdefault(section, []).extend(bullets)
 
-    if has_curated_content:
-        # Preserve curated content; only merge in any leftover fragments.
-        sections = curated
-        for s, bullets in fragment_bullets.items():
-            sections.setdefault(s, []).extend(bullets)
-        source = "curated CHANGELOG.md Next Release content"
-        if any(fragment_bullets.values()):
-            source += " + legacy fragments"
-    else:
-        # No curated content: auto-generate from conventional commits.
-        sections = run_git_cliff()
-        for s, bullets in fragment_bullets.items():
-            sections.setdefault(s, []).extend(bullets)
-        source = "git-cliff (commits since the last tag)"
-        if any(fragment_bullets.values()):
-            source += " + legacy fragments"
+    user_output = stamp_release(
+        user_head, user_body, user_tail, version, repo
+    )
+    dev_output = stamp_release(
+        dev_head,
+        render_sections(dev_sections),
+        dev_tail,
+        version,
+        repo,
+    )
 
-    body_out = [""] + render_sections(sections)
-    out_lines = stamp_release(head, body_out, tail, version, repo)
-
-    CHANGELOG.write_text("\n".join(out_lines) + "\n", encoding="utf-8")
+    USER_CHANGELOG.write_text(
+        "\n".join(user_output) + "\n", encoding="utf-8"
+    )
+    DEV_CHANGELOG.write_text(
+        "\n".join(dev_output) + "\n", encoding="utf-8"
+    )
     for path in consumed_fragments:
         path.unlink()
 
     print(
-        f"CHANGELOG.md stamped as {version} from {source}; "
-        f"consumed {len(consumed_fragments)} fragment(s)"
+        f"stamped {USER_CHANGELOG.name} from curated release notes and "
+        f"{DEV_CHANGELOG.name} from conventional commits; consumed "
+        f"{len(consumed_fragments)} legacy fragment(s)"
     )
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} --check | <version>")
+
+    argument = sys.argv[1]
+    if argument == "--check":
+        check_user_changelog()
+        return
+
+    update_changelogs(argument)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
From the next release onward, `CHANGELOG.md` contains concise user-visible changes and `DEV-CHANGELOG.md` contains build, CI, test, and implementation history. Existing released entries remain unchanged. Release PRs curate user notes; developer notes remain generated from conventional commits.

Closes #315