### PR TITLE
fix: restore energy metadata build

### DIFF
--- a/src/setup/outputFilesSetup.cpp
+++ b/src/setup/outputFilesSetup.cpp
@@ -120,8 +120,7 @@ void OutputFilesSetup::setup()
         mdEngine.getStressOutput().setFilename(stressFile);
         mdEngine.getBoxFileOutput().setFilename(boxFile);
 
-        if (OutputFileSettings::getIncludeOutputMetadata() &&
-            TimingsSettings::isTimeStepSet())
+        if (OutputFileSettings::getIncludeOutputMetadata())
         {
             const auto timeStep = TimingsSettings::getTimeStep();
             _engine.getEnergyOutput().writeHeader(timeStep);


### PR DESCRIPTION
Fixes the build regression after #312 by removing a stale timestep-state check. MD inputs already require `timestep` through `InputFileReader`.