### PR TITLE
fix: reject failed external QM results

### DIFF
--- a/include/QM/external/externalQMRunner.hpp
+++ b/include/QM/external/externalQMRunner.hpp
@@ -24,6 +24,9 @@
 
 #define _EXTERNAL_QM_RUNNER_HPP_
 
+#include <string>
+#include <string_view>
+
 #include "qmRunner.hpp"
 #include "typeAliases.hpp"
 
@@ -39,6 +42,11 @@ namespace QM
         std::string       _scriptPath  = SCRIPT_PATH_;
         const std::string _singularity = SINGULARITY_;
         const std::string _staticBuild = STATIC_BUILD_;
+
+        void executeCommand(
+            std::string_view command,
+            std::string_view program
+        ) const;
 
        public:
         ExternalQMRunner()           = default;

--- a/src/QM/external/dftbplusRunner.cpp
+++ b/src/QM/external/dftbplusRunner.cpp
@@ -22,8 +22,8 @@
 
 #include "dftbplusRunner.hpp"
 
+#include <cmath>     // for isfinite
 #include <cstddef>   // for size_t
-#include <cstdlib>   // for system
 #include <format>    // for format
 #include <fstream>   // for ofstream
 #include <string>    // for string
@@ -147,7 +147,7 @@ void DFTBPlusRunner::execute()
         reuseCharges,
         FileSettings::getDFTBFileName()
     );
-    ::system(command.c_str());
+    executeCommand(command, "DFTB+");
 
     _isFirstExecution = false;
 }
@@ -178,9 +178,27 @@ void DFTBPlusRunner::readStressTensor(Box &box, PhysicalData &data)
 
     StaticMatrix3x3<double> stress;
 
-    stressFile >> stress[0][0] >> stress[0][1] >> stress[0][2];
-    stressFile >> stress[1][0] >> stress[1][1] >> stress[1][2];
-    stressFile >> stress[2][0] >> stress[2][1] >> stress[2][2];
+    if (!(stressFile >> stress[0][0] >> stress[0][1] >> stress[0][2] >>
+          stress[1][0] >> stress[1][1] >> stress[1][2] >> stress[2][0] >>
+          stress[2][1] >> stress[2][2]))
+        throw QMRunnerException(
+            std::format(
+                "Incomplete {} stress tensor \"{}\"",
+                string(QMSettings::getQMMethod()),
+                stressFileName
+            )
+        );
+
+    for (size_t row = 0; row < 3; ++row)
+        for (size_t column = 0; column < 3; ++column)
+            if (!std::isfinite(stress[row][column]))
+                throw QMRunnerException(
+                    std::format(
+                        "Invalid value in {} stress tensor \"{}\"",
+                        string(QMSettings::getQMMethod()),
+                        stressFileName
+                    )
+                );
 
     const auto conversion = _HARTREE_PER_BOHR3_TO_KCAL_PER_MOL_PER_ANGSTROM3_;
     stress                = stress * conversion;

--- a/src/QM/external/externalQMRunner.cpp
+++ b/src/QM/external/externalQMRunner.cpp
@@ -23,7 +23,10 @@
 #include "externalQMRunner.hpp"
 
 #include <algorithm>    // for __for_each_fn, for_each
-#include <cmath>        // for isnan, isinf
+#include <array>        // for array
+#include <cmath>        // for isfinite
+#include <cstdlib>      // for system
+#include <filesystem>   // for remove
 #include <format>       // for format
 #include <fstream>      // for ofstream
 #include <string>       // for string
@@ -52,6 +55,13 @@ void ExternalQMRunner::run(SimulationBox &simBox, PhysicalData &physicalData)
 {
     writeCoordsFile(simBox);
 
+    const auto resultFiles = std::array{
+        FileSettings::getQMForcesTempFileName(),
+        FileSettings::getQMChargesTempFileName(),
+        FileSettings::getStressTensorTempFileName()
+    };
+    for (const auto &file : resultFiles) std::filesystem::remove(file);
+
     std::jthread timeoutThread{[this](const std::stop_token stopToken)
                                { throwAfterTimeout(stopToken); }};
 
@@ -64,6 +74,18 @@ void ExternalQMRunner::run(SimulationBox &simBox, PhysicalData &physicalData)
     readChargeFile(simBox);
 
     readStressTensor(simBox.getBox(), physicalData);
+}
+
+void ExternalQMRunner::executeCommand(
+    const std::string_view command,
+    const std::string_view program
+) const
+{
+    const auto status = std::system(std::string(command).c_str());
+    if (status != EXIT_SUCCESS)
+        throw QMRunnerException(
+            std::format("{} command failed with status {}", program, status)
+        );
 }
 
 /**
@@ -106,14 +128,23 @@ void ExternalQMRunner::readForceFile(
 
     double energy = 0.0;
 
-    forceFile >> energy;
+    if (!(forceFile >> energy))
+        throw QMRunnerException(
+            std::format(
+                "Cannot read QM energy from {} force file \"{}\"",
+                string(QMSettings::getQMMethod()),
+                forceFileName
+            )
+        );
 
-    if (std::isnan(energy) || std::isinf(energy))
-        throw QMRunnerException(std::format(
-            "Invalid QM energy (NaN/Inf) in {} force file \"{}\"",
-            string(QMSettings::getQMMethod()),
-            forceFileName
-        ));
+    if (!std::isfinite(energy))
+        throw QMRunnerException(
+            std::format(
+                "Invalid QM energy (NaN/Inf) in {} force file \"{}\"",
+                string(QMSettings::getQMMethod()),
+                forceFileName
+            )
+        );
 
     physicalData.setQMEnergy(energy * _HARTREE_TO_KCAL_PER_MOL_);
 
@@ -121,16 +152,25 @@ void ExternalQMRunner::readForceFile(
     {
         auto grad = linearAlgebra::Vec3D();
 
-        forceFile >> grad[0] >> grad[1] >> grad[2];
-
-        for (size_t i = 0; i < 3; ++i)
-            if (std::isnan(grad[i]) || std::isinf(grad[i]))
-                throw QMRunnerException(std::format(
-                    "Invalid QM force component (NaN/Inf) in {} force file "
-                    "\"{}\"",
+        if (!(forceFile >> grad[0] >> grad[1] >> grad[2]))
+            throw QMRunnerException(
+                std::format(
+                    "Incomplete {} force file \"{}\"",
                     string(QMSettings::getQMMethod()),
                     forceFileName
-                ));
+                )
+            );
+
+        for (size_t i = 0; i < 3; ++i)
+            if (!std::isfinite(grad[i]))
+                throw QMRunnerException(
+                    std::format(
+                        "Invalid QM force component (NaN/Inf) in {} force file "
+                        "\"{}\"",
+                        string(QMSettings::getQMMethod()),
+                        forceFileName
+                    )
+                );
 
         atom->setForce(-grad * _HARTREE_PER_BOHR_TO_KCAL_PER_MOL_PER_ANGSTROM_);
     };
@@ -178,12 +218,27 @@ void ExternalQMRunner::readChargeFile(SimulationBox &box)
 
     box.resetQMCharges();
 
-    auto readCharges = [&chargeFile](auto &atom)
+    auto readCharges = [&chargeFile, &chargeFileName](auto &atom)
     {
         auto index  = 0;     // Read and discard the first column (index)
         auto charge = 0.0;   // Read the second column (charge value)
 
-        chargeFile >> index >> charge;
+        if (!(chargeFile >> index >> charge))
+            throw QMRunnerException(
+                std::format(
+                    "Incomplete {} charge file \"{}\"",
+                    string(QMSettings::getQMMethod()),
+                    chargeFileName
+                )
+            );
+        if (!std::isfinite(charge))
+            throw QMRunnerException(
+                std::format(
+                    "Invalid value in {} charge file \"{}\"",
+                    string(QMSettings::getQMMethod()),
+                    chargeFileName
+                )
+            );
 
         atom->setQMCharge(charge);
     };

--- a/src/QM/external/pyscfRunner.cpp
+++ b/src/QM/external/pyscfRunner.cpp
@@ -22,8 +22,7 @@
 
 #include "pyscfRunner.hpp"
 
-#include <stdlib.h>   // for system, size_t
-
+#include <cstddef>   // for size_t
 #include <format>    // for format
 #include <fstream>   // for ofstream, operator<<, basic_ostream
 #include <string>    // for allocator, string, operator+, operator<<
@@ -86,5 +85,5 @@ void PySCFRunner::execute()
 
     const auto command = std::format("python {} > pyscf.out", scriptFileName);
 
-    ::system(command.c_str());
+    executeCommand(command, "PySCF");
 }

--- a/src/QM/external/turbomoleRunner.cpp
+++ b/src/QM/external/turbomoleRunner.cpp
@@ -22,11 +22,10 @@
 
 #include "turbomoleRunner.hpp"
 
-#include <cstddef>      // for size_t
-#include <cstdlib>      // for system
-#include <format>       // for format
-#include <fstream>      // for ofstream
-#include <string>       // for string
+#include <cstddef>   // for size_t
+#include <format>    // for format
+#include <fstream>   // for ofstream
+#include <string>    // for string
 
 #include "atom.hpp"              // for Atom
 #include "constants.hpp"         // for constants
@@ -94,7 +93,7 @@ void TurbomoleRunner::execute()
     const auto reuseCharges = _isFirstExecution ? 1 : 0;
 
     const auto command = std::format("{} 0 {} 0 0 0", scriptFile, reuseCharges);
-    ::system(command.c_str());
+    executeCommand(command, "Turbomole");
 
     _isFirstExecution = false;
 }

--- a/tests/src/CMakeLists.txt
+++ b/tests/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(setup)
+add_subdirectory(QM)
 add_subdirectory(simulationBox)
 add_subdirectory(linearAlgebra)
 add_subdirectory(manostat)

--- a/tests/src/QM/CMakeLists.txt
+++ b/tests/src/QM/CMakeLists.txt
@@ -1,0 +1,24 @@
+add_executable(testExternalQMRunner
+    testExternalQMRunner.cpp
+)
+
+target_include_directories(testExternalQMRunner
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/tests/include/macros
+)
+
+target_link_libraries(testExternalQMRunner
+    PRIVATE
+    externalQM
+    gtest
+    gmock
+    pq_test_main
+)
+
+add_test(
+    NAME testExternalQMRunner
+    COMMAND testExternalQMRunner
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests
+)
+
+set_property(TEST testExternalQMRunner PROPERTY LABELS QM)

--- a/tests/src/QM/testExternalQMRunner.cpp
+++ b/tests/src/QM/testExternalQMRunner.cpp
@@ -1,0 +1,237 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "atom.hpp"
+#include "dftbplusRunner.hpp"
+#include "exceptions.hpp"
+#include "externalQMRunner.hpp"
+#include "fileSettings.hpp"
+#include "physicalData.hpp"
+#include "qmSettings.hpp"
+#include "settings.hpp"
+#include "simulationBox.hpp"
+
+using customException::QMRunnerException;
+using physicalData::PhysicalData;
+using settings::FileSettings;
+using settings::JobType;
+using settings::QMMethod;
+using settings::QMSettings;
+using settings::Settings;
+using simulationBox::Atom;
+using simulationBox::SimulationBox;
+using testing::HasSubstr;
+
+namespace
+{
+    void writeFile(const std::string_view fileName, const std::string_view text)
+    {
+        auto file = std::ofstream(std::string(fileName));
+        file << text;
+    }
+
+    class ExternalQMRunnerHarness : public QM::ExternalQMRunner
+    {
+       private:
+        bool _sawStaleResults = false;
+
+       public:
+        void writeCoordsFile(SimulationBox &) override {}
+
+        void execute() override
+        {
+            _sawStaleResults = std::filesystem::exists(
+                                   FileSettings::getQMForcesTempFileName()
+                               ) ||
+                               std::filesystem::exists(
+                                   FileSettings::getQMChargesTempFileName()
+                               ) ||
+                               std::filesystem::exists(
+                                   FileSettings::getStressTensorTempFileName()
+                               );
+
+            writeFile(FileSettings::getQMForcesTempFileName(), "0\n0 0 0\n");
+            writeFile(FileSettings::getQMChargesTempFileName(), "1 0\n");
+        }
+
+        void runCommand(
+            const std::string_view command,
+            const std::string_view program
+        ) const
+        {
+            executeCommand(command, program);
+        }
+
+        [[nodiscard]] bool sawStaleResults() const { return _sawStaleResults; }
+    };
+
+    class ExternalQMRunnerTest : public testing::Test
+    {
+       protected:
+        std::filesystem::path   _originalPath;
+        std::filesystem::path   _workPath;
+        SimulationBox           _simulationBox;
+        PhysicalData            _physicalData;
+        ExternalQMRunnerHarness _runner;
+        QM::DFTBPlusRunner      _dftbRunner;
+
+        QMMethod _qmMethod;
+        JobType  _jobType;
+        bool     _removeNetForce;
+        double   _timeLimit;
+
+        void SetUp() override
+        {
+            _qmMethod       = QMSettings::getQMMethod();
+            _jobType        = Settings::getJobtype();
+            _removeNetForce = QMSettings::getRemoveNetForce();
+            _timeLimit      = QMSettings::getQMLoopTimeLimit();
+            _originalPath   = std::filesystem::current_path();
+
+            const auto stamp =
+                std::chrono::steady_clock::now().time_since_epoch().count();
+            _workPath = std::filesystem::temp_directory_path() /
+                        ("pq-external-qm-" + std::to_string(stamp));
+            ASSERT_TRUE(std::filesystem::create_directory(_workPath));
+            std::filesystem::current_path(_workPath);
+
+            QMSettings::setQMMethod(QMMethod::DFTBPLUS);
+            QMSettings::setRemoveNetForce(false);
+            QMSettings::setQMLoopTimeLimit(0.0);
+            Settings::setJobtype(JobType::QM_MD);
+
+            auto atom = std::make_shared<Atom>();
+            atom->setName("H");
+            _simulationBox.addAtom(atom);
+            _simulationBox.addQMAtom(atom);
+            _simulationBox.setBoxDimensions({10.0, 10.0, 10.0});
+        }
+
+        void TearDown() override
+        {
+            QMSettings::setQMMethod(_qmMethod);
+            QMSettings::setRemoveNetForce(_removeNetForce);
+            QMSettings::setQMLoopTimeLimit(_timeLimit);
+            Settings::setJobtype(_jobType);
+
+            std::filesystem::current_path(_originalPath);
+            std::error_code error;
+            std::filesystem::remove_all(_workPath, error);
+            EXPECT_FALSE(error);
+        }
+    };
+}   // namespace
+
+TEST_F(ExternalQMRunnerTest, propagatesCommandFailure)
+{
+    EXPECT_NO_THROW(_runner.runCommand("true", "External QM"));
+
+    try
+    {
+        _runner.runCommand("false", "External QM");
+        FAIL() << "Expected the failed command to throw";
+    }
+    catch (const QMRunnerException &error)
+    {
+        EXPECT_THAT(error.what(), HasSubstr("External QM command failed"));
+    }
+}
+
+TEST_F(ExternalQMRunnerTest, removesStaleResultsBeforeExecution)
+{
+    writeFile(FileSettings::getQMForcesTempFileName(), "stale");
+    writeFile(FileSettings::getQMChargesTempFileName(), "stale");
+    writeFile(FileSettings::getStressTensorTempFileName(), "stale");
+
+    EXPECT_NO_THROW(_runner.run(_simulationBox, _physicalData));
+    EXPECT_FALSE(_runner.sawStaleResults());
+    EXPECT_FALSE(
+        std::filesystem::exists(FileSettings::getStressTensorTempFileName())
+    );
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsIncompleteForces)
+{
+    writeFile(FileSettings::getQMForcesTempFileName(), "0\n0 0\n");
+
+    EXPECT_THROW(
+        _runner.readForceFile(_simulationBox, _physicalData),
+        QMRunnerException
+    );
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsNonFiniteForces)
+{
+    writeFile(FileSettings::getQMForcesTempFileName(), "0\nnan 0 0\n");
+
+    EXPECT_THROW(
+        _runner.readForceFile(_simulationBox, _physicalData),
+        QMRunnerException
+    );
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsIncompleteCharges)
+{
+    writeFile(FileSettings::getQMChargesTempFileName(), "1\n");
+
+    EXPECT_THROW(_runner.readChargeFile(_simulationBox), QMRunnerException);
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsNonFiniteCharges)
+{
+    writeFile(FileSettings::getQMChargesTempFileName(), "1 nan\n");
+
+    EXPECT_THROW(_runner.readChargeFile(_simulationBox), QMRunnerException);
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsIncompleteStressTensor)
+{
+    writeFile(FileSettings::getStressTensorTempFileName(), "0 0 0\n0 0 0\n");
+
+    EXPECT_THROW(
+        _dftbRunner.readStressTensor(_simulationBox.getBox(), _physicalData),
+        QMRunnerException
+    );
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsNonFiniteStressTensor)
+{
+    writeFile(
+        FileSettings::getStressTensorTempFileName(),
+        "nan 0 0\n0 0 0\n0 0 0\n"
+    );
+
+    EXPECT_THROW(
+        _dftbRunner.readStressTensor(_simulationBox.getBox(), _physicalData),
+        QMRunnerException
+    );
+}


### PR DESCRIPTION
Closes #333.

- propagate external wrapper failures as QM runner errors
- remove stale QM result files before each calculation
- validate energy, force, charge, and stress output before using it

Tests:
- testExternalQMRunner: 8 passed
- Debug PQ build
- formatting and license checks