### PR TITLE
fix: validate numeric input values

### DIFF
--- a/include/utilities/stringUtilities.hpp
+++ b/include/utilities/stringUtilities.hpp
@@ -46,10 +46,10 @@ namespace utilities
     std::string toLowerAndReplaceDashesCopy(std::string);
     std::string toLowerAndReplaceDashesCopy(std::string_view);
     std::string firstLetterToUpperCaseCopy(std::string);
-
     void addSpaces(std::string &, const std::string &, const size_t);
 
     std::uint_fast32_t stringToUintFast32t(const std::string &);
+    int                stringToInt(const std::string &);
     double             stringToFiniteDouble(const std::string &);
 
     bool fileExists(const std::string &);

--- a/src/input/inputFileParser/QMInputParser.cpp
+++ b/src/input/inputFileParser/QMInputParser.cpp
@@ -25,6 +25,7 @@
 #include <format>          // for format
 #include <functional>      // for _Bind_front_t, bind_front
 #include <sstream>         // for stringstream
+#include <stdexcept>       // for invalid_argument, out_of_range
 #include <unordered_map>   // for unordered_map
 
 #include "engine.hpp"             // for Engine
@@ -268,7 +269,7 @@ void QMInputParser::parseQMLoopTimeLimit(
 )
 {
     checkCommand(lineElements, lineNumber);
-    QMSettings::setQMLoopTimeLimit(std::stod(lineElements[2]));
+    QMSettings::setQMLoopTimeLimit(stringToFiniteDouble(lineElements[2]));
 }
 
 /**
@@ -554,14 +555,36 @@ void QMInputParser::parseHubbardDerivs(
     std::string       item;
     while (std::getline(ss, item, ','))
     {
-        std::stringstream pairStream(item);
-        std::string       element;
-        double            value;
-        if (std::getline(pairStream, element, ':') && pairStream >> value)
+        const auto separator = item.find(':');
+
+        if (separator == std::string::npos || 0 == separator ||
+            separator + 1 == item.size() ||
+            item.find(':', separator + 1) != std::string::npos)
         {
-            hubbardDerivs[element] = value;
+            throw InputFileException(
+                std::format(
+                    "Invalid hubbard_derivs format \"{}\" in input file.",
+                    derivs
+                )
+            );
         }
-        else
+
+        const auto element = item.substr(0, separator);
+        try
+        {
+            hubbardDerivs[element] =
+                stringToFiniteDouble(item.substr(separator + 1));
+        }
+        catch (const std::invalid_argument &)
+        {
+            throw InputFileException(
+                std::format(
+                    "Invalid hubbard_derivs format \"{}\" in input file.",
+                    derivs
+                )
+            );
+        }
+        catch (const std::out_of_range &)
         {
             throw InputFileException(
                 std::format(

--- a/src/input/inputFileParser/cellListInputParser.cpp
+++ b/src/input/inputFileParser/cellListInputParser.cpp
@@ -91,13 +91,15 @@ void CellListInputParser::parseCellListActivated(
         _engine.getCellList().deactivate();
 
     else
-        throw InputFileException(std::format(
-            "Invalid cell-list keyword \"{}\" "
-            "at line {} in input file\n"
-            "Possible keywords are \"on\" and \"off\"",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Invalid cell-list keyword \"{}\" "
+                "at line {} in input file\n"
+                "Possible keywords are \"on\" and \"off\"",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }
 
 /**
@@ -117,7 +119,7 @@ void CellListInputParser::parseNumberOfCells(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto cellNumber = stoi(lineElements[2]);
+    const auto cellNumber = stringToInt(lineElements[2]);
 
     if (cellNumber <= 0)
         throw InputFileException(

--- a/src/input/inputFileParser/constraintsInputParser.cpp
+++ b/src/input/inputFileParser/constraintsInputParser.cpp
@@ -33,6 +33,7 @@
 #include "exceptions.hpp"           // for InputFileException
 #include "references.hpp"           // for ReferencesOutput
 #include "referencesOutput.hpp"     // for ReferencesOutput
+#include "stringUtilities.hpp"      // for stringToFiniteDouble, stringToInt
 
 using namespace input;
 using namespace engine;
@@ -168,9 +169,9 @@ void ConstraintsInputParser::parseShakeTolerance(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto tolerance = stod(lineElements[2]);
+    const auto tolerance = utilities::stringToFiniteDouble(lineElements[2]);
 
-    if (tolerance < 0.0)
+    if (tolerance <= 0.0)
         throw InputFileException("Shake tolerance must be positive");
 
     ConstraintSettings::setShakeTolerance(tolerance);
@@ -192,9 +193,9 @@ void ConstraintsInputParser::parseShakeIteration(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto iteration = stoi(lineElements[2]);
+    const auto iteration = utilities::stringToInt(lineElements[2]);
 
-    if (iteration < 0)
+    if (iteration <= 0)
         throw InputFileException("Maximum shake iterations must be positive");
 
     ConstraintSettings::setShakeMaxIter(size_t(iteration));
@@ -216,9 +217,9 @@ void ConstraintsInputParser::parseRattleTolerance(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto tolerance = stod(lineElements[2]);
+    const auto tolerance = utilities::stringToFiniteDouble(lineElements[2]);
 
-    if (tolerance < 0.0)
+    if (tolerance <= 0.0)
         throw InputFileException("Rattle tolerance must be positive");
 
     ConstraintSettings::setRattleTolerance(tolerance);
@@ -240,9 +241,9 @@ void ConstraintsInputParser::parseRattleIteration(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto iteration = stoi(lineElements[2]);
+    const auto iteration = utilities::stringToInt(lineElements[2]);
 
-    if (iteration < 0)
+    if (iteration <= 0)
         throw InputFileException("Maximum rattle iterations must be positive");
 
     ConstraintSettings::setRattleMaxIter(size_t(iteration));
@@ -264,9 +265,9 @@ void ConstraintsInputParser::parseMShakeTolerance(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto tolerance = stod(lineElements[2]);
+    const auto tolerance = utilities::stringToFiniteDouble(lineElements[2]);
 
-    if (tolerance < 0.0)
+    if (tolerance <= 0.0)
         throw InputFileException("MShake tolerance must be positive");
 
     ConstraintSettings::setMShakeTolerance(tolerance);
@@ -288,9 +289,9 @@ void ConstraintsInputParser::parseMShakeIteration(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto iteration = stoi(lineElements[2]);
+    const auto iteration = utilities::stringToInt(lineElements[2]);
 
-    if (iteration < 0)
+    if (iteration <= 0)
         throw InputFileException("Maximum MShake iterations must be positive");
 
     ConstraintSettings::setMShakeMaxIter(size_t(iteration));

--- a/src/input/inputFileParser/convergenceInputParser.cpp
+++ b/src/input/inputFileParser/convergenceInputParser.cpp
@@ -155,13 +155,15 @@ void ConvInputParser::parseEnergyConvergenceStrategy(
         ConvSettings::setEnergyConvStrategy(RELATIVE);
 
     else
-        throw InputFileException(std::format(
-            "Unknown energy convergence strategy \"{}\" in input file "
-            "at line {}.\n"
-            "Possible options are: rigorous, loose, absolute, relative",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Unknown energy convergence strategy \"{}\" in input file "
+                "at line {}.\n"
+                "Possible options are: rigorous, loose, absolute, relative",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }
 
 /**
@@ -186,13 +188,15 @@ void ConvInputParser::parseUseEnergyConvergence(
         ConvSettings::setUseEnergyConv(false);
 
     else
-        throw InputFileException(std::format(
-            "Unknown option \"{}\" for use-energy-conv in input file "
-            "at line {}.\n"
-            "Possible options are: true, false",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Unknown option \"{}\" for use-energy-conv in input file "
+                "at line {}.\n"
+                "Possible options are: true, false",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }
 
 /**
@@ -217,13 +221,15 @@ void ConvInputParser::parseUseForceConvergence(
         ConvSettings::setUseForceConv(false);
 
     else
-        throw InputFileException(std::format(
-            "Unknown option \"{}\" for use-force-conv in input file "
-            "at line {}.\n"
-            "Possible options are: true, false",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Unknown option \"{}\" for use-force-conv in input file "
+                "at line {}.\n"
+                "Possible options are: true, false",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }
 
 /**
@@ -248,13 +254,15 @@ void ConvInputParser::parseUseMaxForceConvergence(
         ConvSettings::setUseMaxForceConv(false);
 
     else
-        throw InputFileException(std::format(
-            "Unknown option \"{}\" for use-max-force-conv in input file "
-            "at line {}.\n"
-            "Possible options are: true, false",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Unknown option \"{}\" for use-max-force-conv in input file "
+                "at line {}.\n"
+                "Possible options are: true, false",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }
 
 /**
@@ -279,13 +287,15 @@ void ConvInputParser::parseUseRMSForceConvergence(
         ConvSettings::setUseRMSForceConv(false);
 
     else
-        throw InputFileException(std::format(
-            "Unknown option \"{}\" for use-rms-force-conv in input file "
-            "at line {}.\n"
-            "Possible options are: true, false",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Unknown option \"{}\" for use-rms-force-conv in input file "
+                "at line {}.\n"
+                "Possible options are: true, false",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }
 
 /**
@@ -304,14 +314,16 @@ void ConvInputParser::parseEnergyConvergence(
 {
     checkCommandArray(lineElements, lineNumber);
 
-    const auto energyConvergence = std::stod(lineElements[2]);
+    const auto energyConvergence = stringToFiniteDouble(lineElements[2]);
 
     if (energyConvergence <= 0.0)
-        throw InputFileException(std::format(
-            "Energy convergence must be greater than 0.0 in input file "
-            "at line {}.",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Energy convergence must be greater than 0.0 in input file "
+                "at line {}.",
+                lineNumber
+            )
+        );
 
     ConvSettings::setEnergyConv(energyConvergence);
 }
@@ -332,15 +344,18 @@ void ConvInputParser::parseRelativeEnergyConvergence(
 {
     checkCommandArray(lineElements, lineNumber);
 
-    const auto relativeEnergyConvergence = std::stod(lineElements[2]);
+    const auto relativeEnergyConvergence =
+        stringToFiniteDouble(lineElements[2]);
 
     if (relativeEnergyConvergence <= 0.0)
-        throw InputFileException(std::format(
-            "Relative energy convergence must be greater than 0.0 in input "
-            "file "
-            "at line {}.",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Relative energy convergence must be greater than 0.0 in input "
+                "file "
+                "at line {}.",
+                lineNumber
+            )
+        );
 
     ConvSettings::setRelEnergyConv(relativeEnergyConvergence);
 }
@@ -361,15 +376,18 @@ void ConvInputParser::parseAbsoluteEnergyConvergence(
 {
     checkCommandArray(lineElements, lineNumber);
 
-    const auto absoluteEnergyConvergence = std::stod(lineElements[2]);
+    const auto absoluteEnergyConvergence =
+        stringToFiniteDouble(lineElements[2]);
 
     if (absoluteEnergyConvergence <= 0.0)
-        throw InputFileException(std::format(
-            "Absolute energy convergence must be greater than 0.0 in input "
-            "file "
-            "at line {}.",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Absolute energy convergence must be greater than 0.0 in input "
+                "file "
+                "at line {}.",
+                lineNumber
+            )
+        );
 
     ConvSettings::setAbsEnergyConv(absoluteEnergyConvergence);
 }
@@ -390,14 +408,16 @@ void ConvInputParser::parseForceConvergence(
 {
     checkCommandArray(lineElements, lineNumber);
 
-    const auto forceConvergence = std::stod(lineElements[2]);
+    const auto forceConvergence = stringToFiniteDouble(lineElements[2]);
 
     if (forceConvergence <= 0.0)
-        throw InputFileException(std::format(
-            "Force convergence must be greater than 0.0 in input file "
-            "at line {}.",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Force convergence must be greater than 0.0 in input file "
+                "at line {}.",
+                lineNumber
+            )
+        );
 
     ConvSettings::setForceConv(forceConvergence);
 }
@@ -418,14 +438,16 @@ void ConvInputParser::parseMaxForceConvergence(
 {
     checkCommandArray(lineElements, lineNumber);
 
-    const auto maxForceConvergence = std::stod(lineElements[2]);
+    const auto maxForceConvergence = stringToFiniteDouble(lineElements[2]);
 
     if (maxForceConvergence <= 0.0)
-        throw InputFileException(std::format(
-            "Max force convergence must be greater than 0.0 in input file "
-            "at line {}.",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Max force convergence must be greater than 0.0 in input file "
+                "at line {}.",
+                lineNumber
+            )
+        );
 
     ConvSettings::setMaxForceConv(maxForceConvergence);
 }
@@ -446,14 +468,16 @@ void ConvInputParser::parseRMSForceConvergence(
 {
     checkCommandArray(lineElements, lineNumber);
 
-    const auto rmsForceConvergence = std::stod(lineElements[2]);
+    const auto rmsForceConvergence = stringToFiniteDouble(lineElements[2]);
 
     if (rmsForceConvergence <= 0.0)
-        throw InputFileException(std::format(
-            "RMS force convergence must be greater than 0.0 in input file "
-            "at line {}.",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "RMS force convergence must be greater than 0.0 in input file "
+                "at line {}.",
+                lineNumber
+            )
+        );
 
     ConvSettings::setRMSForceConv(rmsForceConvergence);
 }

--- a/src/input/inputFileParser/coulombLongRangeInputParser.cpp
+++ b/src/input/inputFileParser/coulombLongRangeInputParser.cpp
@@ -131,7 +131,7 @@ void CoulombLongRangeInputParser::parseWolfParameter(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto wolfParameter = stod(lineElements[2]);
+    const auto wolfParameter = stringToFiniteDouble(lineElements[2]);
 
     if (wolfParameter < 0.0)
         throw InputFileException("Wolf parameter cannot be negative");
@@ -153,7 +153,7 @@ void CoulombLongRangeInputParser::parseReactionFieldEpsilon(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto epsilon = stod(lineElements[2]);
+    const auto epsilon = stringToFiniteDouble(lineElements[2]);
 
     if (epsilon < 1.0)
         throw InputFileException(

--- a/src/input/inputFileParser/generalInputParser.cpp
+++ b/src/input/inputFileParser/generalInputParser.cpp
@@ -177,7 +177,7 @@ void GeneralInputParser::parseDimensionality(
 
     std::erase(dimensionalityString, 'd');
 
-    const auto dimensionality = std::stoi(dimensionalityString);
+    const auto dimensionality = stringToInt(dimensionalityString);
 
     if (dimensionality == 3)
         Settings::setDimensionality(size_t(dimensionality));

--- a/src/input/inputFileParser/hessianInputParser.cpp
+++ b/src/input/inputFileParser/hessianInputParser.cpp
@@ -54,10 +54,7 @@ HessianInputParser::HessianInputParser(pq::Engine &engine)
     );
     addKeyword(
         std::string("optimize_before_hessian"),
-        std::bind_front(
-            &HessianInputParser::parseOptimizeBeforeHessian,
-            this
-        ),
+        std::bind_front(&HessianInputParser::parseOptimizeBeforeHessian, this),
         false
     );
     addKeyword(
@@ -92,14 +89,16 @@ void HessianInputParser::parseDisplacement(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto displacement = std::stod(lineElements[2]);
+    const auto displacement = stringToFiniteDouble(lineElements[2]);
 
     if (displacement <= 0.0)
-        throw InputFileException(std::format(
-            "Hessian displacement must be greater than 0 in input file "
-            "at line {}",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Hessian displacement must be greater than 0 in input file "
+                "at line {}",
+                lineNumber
+            )
+        );
 
     HessianSettings::setDisplacement(displacement);
 }
@@ -124,10 +123,12 @@ void HessianInputParser::parseBuilder(
     HessianSettings::setBuilder(lineElements[2]);
 
     if (HessianSettings::getBuilder() == NONE)
-        throw InputFileException(std::format(
-            "Invalid hessian_builder \"{}\" in input file at line {} - "
-            "possible values are: central, forward, five-point, analytic",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Invalid hessian_builder \"{}\" in input file at line {} - "
+                "possible values are: central, forward, five-point, analytic",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }

--- a/src/input/inputFileParser/hybridInputParser.cpp
+++ b/src/input/inputFileParser/hybridInputParser.cpp
@@ -149,11 +149,13 @@ void HybridInputParser::parseUseQMCharges(
         HybridSettings::setUseQMCharges(false);
 
     else
-        throw InputFileException(std::format(
-            "Invalid qm_charges \"{}\" in input file\n"
-            "Possible values are: qm, mm",
-            lineElements[2]
-        ));
+        throw InputFileException(
+            std::format(
+                "Invalid qm_charges \"{}\" in input file\n"
+                "Possible values are: qm, mm",
+                lineElements[2]
+            )
+        );
 
     throw UserInputException("Not implemented");
 }
@@ -171,14 +173,16 @@ void HybridInputParser::parseCoreRadius(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto coreRadius = std::stod(lineElements[2]);
+    const auto coreRadius = stringToFiniteDouble(lineElements[2]);
 
     if (coreRadius < 0.0)
-        throw InputFileException(std::format(
-            "Invalid {} {} in input file - must be a positive number",
-            lineElements[0],
-            lineElements[2]
-        ));
+        throw InputFileException(
+            std::format(
+                "Invalid {} {} in input file - must be a positive number",
+                lineElements[0],
+                lineElements[2]
+            )
+        );
 
     HybridSettings::setCoreRadius(coreRadius);
 
@@ -198,14 +202,16 @@ void HybridInputParser::parseLayerRadius(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto layerRadius = std::stod(lineElements[2]);
+    const auto layerRadius = stringToFiniteDouble(lineElements[2]);
 
     if (layerRadius < 0.0)
-        throw InputFileException(std::format(
-            "Invalid {} {} in input file - must be a positive number",
-            lineElements[0],
-            lineElements[2]
-        ));
+        throw InputFileException(
+            std::format(
+                "Invalid {} {} in input file - must be a positive number",
+                lineElements[0],
+                lineElements[2]
+            )
+        );
 
     HybridSettings::setLayerRadius(layerRadius);
 
@@ -225,14 +231,16 @@ void HybridInputParser::parseSmoothingRadius(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto smoothingRadius = std::stod(lineElements[2]);
+    const auto smoothingRadius = stringToFiniteDouble(lineElements[2]);
 
     if (smoothingRadius < 0.0)
-        throw InputFileException(std::format(
-            "Invalid {} {} in input file - must be a positive number",
-            lineElements[0],
-            lineElements[2]
-        ));
+        throw InputFileException(
+            std::format(
+                "Invalid {} {} in input file - must be a positive number",
+                lineElements[0],
+                lineElements[2]
+            )
+        );
 
     HybridSettings::setSmoothingRadius(smoothingRadius);
 

--- a/src/input/inputFileParser/manostatInputParser.cpp
+++ b/src/input/inputFileParser/manostatInputParser.cpp
@@ -25,8 +25,10 @@
 #include <cstddef>       // for size_t
 #include <format>        // for format
 #include <functional>    // for _Bind_front_t, bind_front
+#include <limits>        // for numeric_limits
 #include <string_view>   // for string_view
 
+#include "constants/conversionFactors.hpp"
 #include "exceptions.hpp"         // for InputFileException, customException
 #include "manostatSettings.hpp"   // for ManostatSettings
 #include "references.hpp"         // for ReferencesOutput
@@ -39,6 +41,7 @@ using namespace settings;
 using namespace customException;
 using namespace references;
 using namespace utilities;
+using namespace constants;
 
 /**
  * @brief Construct a new Input File Parser Manostat:: Input File Parser
@@ -125,12 +128,15 @@ void ManostatInputParser::parseManostat(
     }
 
     else
-        throw InputFileException(std::format(
-            "Invalid manostat \"{}\" at line {} in input file.\n"
-            "Possible options are: berendsen, stochastic_rescaling and none",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Invalid manostat \"{}\" at line {} in input file.\n"
+                "Possible options are: berendsen, stochastic_rescaling and "
+                "none",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }
 
 /**
@@ -147,7 +153,9 @@ void ManostatInputParser::parsePressure(
 {
     checkCommand(lineElements, lineNumber);
 
-    ManostatSettings::setTargetPressure(stod(lineElements[2]));
+    const auto pressure = stringToFiniteDouble(lineElements[2]);
+
+    ManostatSettings::setTargetPressure(pressure);
 }
 
 /**
@@ -165,11 +173,17 @@ void ManostatInputParser::parseManostatRelaxationTime(
 )
 {
     checkCommand(lineElements, lineNumber);
-    const auto relaxationTime = stod(lineElements[2]);
+    const auto relaxationTime = stringToFiniteDouble(lineElements[2]);
 
-    if (relaxationTime < 0)
+    if (relaxationTime <= 0.0)
         throw InputFileException(
-            "Relaxation time of manostat cannot be negative"
+            "Relaxation time of manostat must be finite and greater than zero"
+        );
+
+    if (relaxationTime > std::numeric_limits<double>::max() / _PS_TO_FS_)
+        throw InputFileException(
+            "Relaxation time of manostat is too large to represent in "
+            "femtoseconds"
         );
 
     ManostatSettings::setTauManostat(relaxationTime);
@@ -191,10 +205,12 @@ void ManostatInputParser::parseCompressibility(
 )
 {
     checkCommand(lineElements, lineNumber);
-    const auto compressibility = stod(lineElements[2]);
+    const auto compressibility = stringToFiniteDouble(lineElements[2]);
 
     if (compressibility < 0.0)
-        throw InputFileException("Compressibility cannot be negative");
+        throw InputFileException(
+            "Compressibility must be finite and non-negative"
+        );
 
     ManostatSettings::setCompressibility(compressibility);
 }
@@ -254,11 +270,13 @@ void ManostatInputParser::parseIsotropy(
         ManostatSettings::setIsotropy(FULL_ANISOTROPIC);
 
     else
-        throw InputFileException(std::format(
-            "Invalid isotropy \"{}\" at line {} in input file.\n"
-            "Possible options are: isotropic, xy, xz, yz, "
-            "anisotropic and full_anisotropic",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Invalid isotropy \"{}\" at line {} in input file.\n"
+                "Possible options are: isotropic, xy, xz, yz, "
+                "anisotropic and full_anisotropic",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }

--- a/src/input/inputFileParser/optInputParser.cpp
+++ b/src/input/inputFileParser/optInputParser.cpp
@@ -118,13 +118,15 @@ void OptInputParser::parseOptimizer(
         OptimizerSettings::setOptimizer(ADAM);
 
     else
-        throw InputFileException(std::format(
-            "Unknown optimizer method \"{}\" in input file "
-            "at line {}.\nPossible options are: steepest-descent, "
-            "adam",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Unknown optimizer method \"{}\" in input file "
+                "at line {}.\nPossible options are: steepest-descent, "
+                "adam",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }
 
 /**
@@ -162,13 +164,16 @@ void OptInputParser::parseLearningRateStrategy(
         OptimizerSettings::setLearningRateStrategy(LINESEARCH_WOLFE);
 
     else
-        throw InputFileException(std::format(
-            "Unknown learning rate strategy \"{}\" in input file "
-            "at line {}.\nPossible options are: constant, "
-            "constant-decay, exponential-decay, linesearch (linesearch-wolfe)",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Unknown learning rate strategy \"{}\" in input file "
+                "at line {}.\nPossible options are: constant, "
+                "constant-decay, exponential-decay, linesearch "
+                "(linesearch-wolfe)",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }
 
 /**
@@ -187,14 +192,16 @@ void OptInputParser::parseInitialLearningRate(
 {
     checkCommandArray(lineElements, lineNumber);
 
-    const auto initialLearningRate = std::stod(lineElements[2]);
+    const auto initialLearningRate = stringToFiniteDouble(lineElements[2]);
 
     if (initialLearningRate <= 0.0)
-        throw InputFileException(std::format(
-            "Initial learning rate must be greater than 0.0 in input file "
-            "at line {}.",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Initial learning rate must be greater than 0.0 in input file "
+                "at line {}.",
+                lineNumber
+            )
+        );
 
     OptimizerSettings::setInitialLearningRate(initialLearningRate);
 }
@@ -215,14 +222,17 @@ void OptInputParser::parseLearningRateUpdateFreq(
 {
     checkCommandArray(lineElements, lineNumber);
 
-    const auto frequency = std::stoi(lineElements[2]);
+    const auto frequency = stringToInt(lineElements[2]);
 
     if (frequency <= 0)
-        throw InputFileException(std::format(
-            "Learning rate update frequency must be greater than 0 in input "
-            "file at line {}.",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Learning rate update frequency must be greater than 0 in "
+                "input "
+                "file at line {}.",
+                lineNumber
+            )
+        );
 
     OptimizerSettings::setLRUpdateFrequency(size_t(frequency));
 }
@@ -243,14 +253,16 @@ void OptInputParser::parseMinLearningRate(
 {
     checkCommandArray(lineElements, lineNumber);
 
-    const auto minLearningRate = std::stod(lineElements[2]);
+    const auto minLearningRate = stringToFiniteDouble(lineElements[2]);
 
     if (minLearningRate <= 0.0)
-        throw InputFileException(std::format(
-            "Minimum learning rate must be greater than 0.0 in input file "
-            "at line {}.",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Minimum learning rate must be greater than 0.0 in input file "
+                "at line {}.",
+                lineNumber
+            )
+        );
 
     OptimizerSettings::setMinLearningRate(minLearningRate);
 }
@@ -271,14 +283,16 @@ void OptInputParser::parseMaxLearningRate(
 {
     checkCommandArray(lineElements, lineNumber);
 
-    const auto maxLearningRate = std::stod(lineElements[2]);
+    const auto maxLearningRate = stringToFiniteDouble(lineElements[2]);
 
     if (maxLearningRate <= 0.0)
-        throw InputFileException(std::format(
-            "Maximum learning rate must be greater than 0.0 in input file "
-            "at line {}.",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Maximum learning rate must be greater than 0.0 in input file "
+                "at line {}.",
+                lineNumber
+            )
+        );
 
     OptimizerSettings::setMaxLearningRate(maxLearningRate);
 }
@@ -299,14 +313,16 @@ void OptInputParser::parseLearningRateDecay(
 {
     checkCommandArray(lineElements, lineNumber);
 
-    const auto decay = std::stod(lineElements[2]);
+    const auto decay = stringToFiniteDouble(lineElements[2]);
 
     if (decay <= 0.0)
-        throw InputFileException(std::format(
-            "Learning rate decay must be greater than 0.0 in input file "
-            "at line {}.",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Learning rate decay must be greater than 0.0 in input file "
+                "at line {}.",
+                lineNumber
+            )
+        );
 
     OptimizerSettings::setLearningRateDecay(decay);
 }

--- a/src/input/inputFileParser/outputInputParser.cpp
+++ b/src/input/inputFileParser/outputInputParser.cpp
@@ -219,7 +219,7 @@ void OutputInputParser::parseOutputFreq(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto outputFrequency = stoi(lineElements[2]);
+    const auto outputFrequency = stringToInt(lineElements[2]);
     if (outputFrequency < 0)
         throw InputFileException(format(
             "Output frequency cannot be negative - \"{}\" at line {} in input "

--- a/src/input/inputFileParser/resetKineticsInputParser.cpp
+++ b/src/input/inputFileParser/resetKineticsInputParser.cpp
@@ -28,6 +28,7 @@
 
 #include "exceptions.hpp"   // for InputFileException, customException
 #include "resetKineticsSettings.hpp"   // for ResetKineticsSettings
+#include "stringUtilities.hpp"         // for stringToInt
 
 using namespace input;
 using namespace engine;
@@ -101,7 +102,7 @@ void ResetKineticsInputParser::parseNScale(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto nScale = stoi(lineElements[2]);
+    const auto nScale = utilities::stringToInt(lineElements[2]);
 
     if (nScale < 0)
         throw InputFileException("Nscale must be positive");
@@ -126,7 +127,7 @@ void ResetKineticsInputParser::parseFScale(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto fScale = stoi(lineElements[2]);
+    const auto fScale = utilities::stringToInt(lineElements[2]);
 
     if (fScale < 0)
         throw InputFileException("Fscale must be positive");
@@ -151,7 +152,7 @@ void ResetKineticsInputParser::parseNReset(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto nReset = stoi(lineElements[2]);
+    const auto nReset = utilities::stringToInt(lineElements[2]);
 
     if (nReset < 0)
         throw InputFileException("Nreset must be positive");
@@ -176,7 +177,7 @@ void ResetKineticsInputParser::parseFReset(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto fReset = stoi(lineElements[2]);
+    const auto fReset = utilities::stringToInt(lineElements[2]);
 
     if (fReset < 0)
         throw InputFileException("Freset must be positive");
@@ -201,7 +202,7 @@ void ResetKineticsInputParser::parseNResetAngular(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto nResetAngular = stoi(lineElements[2]);
+    const auto nResetAngular = utilities::stringToInt(lineElements[2]);
 
     if (nResetAngular < 0)
         throw InputFileException("Nreset_angular must be positive");
@@ -226,7 +227,7 @@ void ResetKineticsInputParser::parseFResetAngular(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto fResetAngular = stoi(lineElements[2]);
+    const auto fResetAngular = utilities::stringToInt(lineElements[2]);
 
     if (fResetAngular < 0)
         throw InputFileException("Freset_angular must be positive");
@@ -251,7 +252,7 @@ void ResetKineticsInputParser::parseFResetForces(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto fResetForces = stoi(lineElements[2]);
+    const auto fResetForces = utilities::stringToInt(lineElements[2]);
 
     if (fResetForces < 0)
         throw InputFileException("Freset_force must be positive");

--- a/src/input/inputFileParser/ringPolymerInputParser.cpp
+++ b/src/input/inputFileParser/ringPolymerInputParser.cpp
@@ -27,6 +27,7 @@
 
 #include "exceptions.hpp"            // for InputFileException, customException
 #include "ringPolymerSettings.hpp"   // for RingPolymerSettings
+#include "stringUtilities.hpp"       // for stringToInt
 
 using namespace input;
 using namespace engine;
@@ -65,13 +66,15 @@ void RingPolymerInputParser::parseNumberOfBeads(
 {
     checkCommand(lineElements, lineNumber);
 
-    auto numberOfBeads = stoi(lineElements[2]);
+    auto numberOfBeads = utilities::stringToInt(lineElements[2]);
 
     if (numberOfBeads < 2)
-        throw InputFileException(std::format(
-            "Number of beads must be at least 2 - in input file in line {}",
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Number of beads must be at least 2 - in input file in line {}",
+                lineNumber
+            )
+        );
 
     RingPolymerSettings::setNumberOfBeads(size_t(numberOfBeads));
 }

--- a/src/input/inputFileParser/simulationBoxInputParser.cpp
+++ b/src/input/inputFileParser/simulationBoxInputParser.cpp
@@ -84,7 +84,7 @@ void SimulationBoxInputParser::parseCoulombRadius(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto cutOff = stod(lineElements[2]);
+    const auto cutOff = stringToFiniteDouble(lineElements[2]);
 
     if (cutOff < 0.0)
         throw InputFileException(format(
@@ -114,9 +114,9 @@ void SimulationBoxInputParser::parseDensity(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto density = stod(lineElements[2]);
+    const auto density = stringToFiniteDouble(lineElements[2]);
 
-    if (density < 0.0)
+    if (density <= 0.0)
         throw InputFileException(
             std::format("Density must be positive - density = {}", density)
         );
@@ -157,11 +157,14 @@ void SimulationBoxInputParser::parseInitializeVelocities(
         SimulationBoxSettings::setInitializeVelocities(FORCE);
 
     else
-        throw InputFileException(std::format(
-            "Invalid value for initialize velocities - \"{}\" at line {} in "
-            "input file.\n"
-            "Possible options are: true, false, force",
-            lineElements[2],
-            lineNumber
-        ));
+        throw InputFileException(
+            std::format(
+                "Invalid value for initialize velocities - \"{}\" at line {} "
+                "in "
+                "input file.\n"
+                "Possible options are: true, false, force",
+                lineElements[2],
+                lineNumber
+            )
+        );
 }

--- a/src/input/inputFileParser/thermostatInputParser.cpp
+++ b/src/input/inputFileParser/thermostatInputParser.cpp
@@ -22,11 +22,14 @@
 
 #include "thermostatInputParser.hpp"
 
+#include <cmath>         // for sqrt
 #include <cstddef>       // for size_t, std
 #include <format>        // for format
 #include <functional>    // for _Bind_front_t, bind_front
+#include <limits>        // for numeric_limits
 #include <string_view>   // for string_view
 
+#include "constants/conversionFactors.hpp"
 #include "exceptions.hpp"           // for InputFileException, customException
 #include "references.hpp"           // for References
 #include "referencesOutput.hpp"     // for ReferencesOutput
@@ -39,6 +42,7 @@ using namespace customException;
 using namespace settings;
 using namespace utilities;
 using namespace references;
+using namespace constants;
 
 /**
  * @brief Construct a new Input File Parser Thermostat:: Input File Parser
@@ -187,10 +191,10 @@ void ThermostatInputParser::parseTemperature(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto temperature = stod(lineElements[2]);
+    const auto temperature = stringToFiniteDouble(lineElements[2]);
 
-    if (temperature < 0)
-        throw InputFileException("Temperature cannot be negative");
+    if (temperature < 0.0)
+        throw InputFileException("Temperature must be finite and non-negative");
 
     ThermostatSettings::setTargetTemperature(temperature);
 }
@@ -211,10 +215,12 @@ void ThermostatInputParser::parseStartTemperature(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto startTemperature = stod(lineElements[2]);
+    const auto startTemperature = stringToFiniteDouble(lineElements[2]);
 
-    if (startTemperature < 0)
-        throw InputFileException("Start temperature cannot be negative");
+    if (startTemperature < 0.0)
+        throw InputFileException(
+            "Start temperature must be finite and non-negative"
+        );
 
     ThermostatSettings::setStartTemperature(startTemperature);
 }
@@ -235,10 +241,12 @@ void ThermostatInputParser::parseEndTemperature(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto endTemperature = stod(lineElements[2]);
+    const auto endTemperature = stringToFiniteDouble(lineElements[2]);
 
-    if (endTemperature < 0)
-        throw InputFileException("End temperature cannot be negative");
+    if (endTemperature < 0.0)
+        throw InputFileException(
+            "End temperature must be finite and non-negative"
+        );
 
     ThermostatSettings::setEndTemperature(endTemperature);
 }
@@ -262,7 +270,7 @@ void ThermostatInputParser::parseTemperatureRampSteps(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto temperatureRampSteps = stoi(lineElements[2]);
+    const auto temperatureRampSteps = stringToInt(lineElements[2]);
 
     if (temperatureRampSteps < 0)
         throw InputFileException("Temperature ramp steps cannot be negative");
@@ -287,10 +295,11 @@ void ThermostatInputParser::parseTemperatureRampFrequency(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto tempRampFreq = stoi(lineElements[2]);
+    const auto tempRampFreq = stringToInt(lineElements[2]);
 
-    if (tempRampFreq < 0)
-        throw InputFileException("Temperature ramp frequency cannot be negative"
+    if (tempRampFreq < 1)
+        throw InputFileException(
+            "Temperature ramp frequency must be greater than zero"
         );
 
     ThermostatSettings::setTemperatureRampFrequency(size_t(tempRampFreq));
@@ -312,11 +321,17 @@ void ThermostatInputParser::parseThermostatRelaxationTime(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto relaxationTime = stod(lineElements[2]);
+    const auto relaxationTime = stringToFiniteDouble(lineElements[2]);
 
-    if (relaxationTime < 0)
+    if (relaxationTime <= 0.0)
         throw InputFileException(
-            "Relaxation time of thermostat cannot be negative"
+            "Relaxation time of thermostat must be finite and greater than zero"
+        );
+
+    if (relaxationTime > std::numeric_limits<double>::max() / _PS_TO_FS_)
+        throw InputFileException(
+            "Relaxation time of thermostat is too large to represent in "
+            "femtoseconds"
         );
 
     ThermostatSettings::setRelaxationTime(relaxationTime);
@@ -338,10 +353,18 @@ void ThermostatInputParser::parseThermostatFriction(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto friction = stod(lineElements[2]);
+    const auto friction = stringToFiniteDouble(lineElements[2]);
 
-    if (friction < 0)
-        throw InputFileException("Friction of thermostat cannot be negative");
+    if (friction < 0.0)
+        throw InputFileException(
+            "Friction of thermostat must be finite and non-negative"
+        );
+
+    if (friction > std::numeric_limits<double>::max() / 1.0e12)
+        throw InputFileException(
+            "Friction of thermostat is too large to represent in inverse "
+            "seconds"
+        );
 
     ThermostatSettings::setFriction(friction * 1.0e12);
 }
@@ -362,10 +385,11 @@ void ThermostatInputParser::parseThermostatChainLength(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto chainLength = stoi(lineElements[2]);
+    const auto chainLength = stringToInt(lineElements[2]);
 
-    if (chainLength < 0)
-        throw InputFileException("Chain length of thermostat cannot be negative"
+    if (chainLength < 1)
+        throw InputFileException(
+            "Chain length of thermostat must be greater than zero"
         );
 
     ThermostatSettings::setNoseHooverChainLength(size_t(chainLength));
@@ -387,11 +411,18 @@ void ThermostatInputParser::parseThermostatCouplingFrequency(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto couplingFrequency = stod(lineElements[2]);
+    const auto couplingFrequency = stringToFiniteDouble(lineElements[2]);
 
-    if (couplingFrequency < 0)
+    if (couplingFrequency < 0.0)
         throw InputFileException(
-            "Coupling frequency of thermostat cannot be negative"
+            "Coupling frequency of thermostat must be finite and non-negative"
+        );
+
+    if (couplingFrequency >
+        std::sqrt(std::numeric_limits<double>::max()) / _PER_CM_TO_HZ_)
+        throw InputFileException(
+            "Coupling frequency of thermostat is too large to represent in "
+            "hertz"
         );
 
     ThermostatSettings::setNoseHooverCouplingFrequency(couplingFrequency);

--- a/src/input/inputFileParser/timingsInputParser.cpp
+++ b/src/input/inputFileParser/timingsInputParser.cpp
@@ -26,12 +26,14 @@
 #include <string_view>   // for string_view
 
 #include "exceptions.hpp"        // for InputFileException
+#include "stringUtilities.hpp"   // for stringToFiniteDouble, stringToInt
 #include "timingsSettings.hpp"   // for TimingsSettings
 
 using namespace input;
 using namespace engine;
 using namespace customException;
 using namespace settings;
+using namespace utilities;
 
 /**
  * @brief Construct a new Input File Parser Timings object
@@ -68,7 +70,14 @@ void TimingsInputParser::parseTimeStep(
 )
 {
     checkCommand(lineElements, lineNumber);
-    TimingsSettings::setTimeStep(stod(lineElements[2]));
+
+    const auto timeStep = stringToFiniteDouble(lineElements[2]);
+    if (timeStep <= 0.0)
+        throw InputFileException(
+            "Time step must be finite and greater than zero"
+        );
+
+    TimingsSettings::setTimeStep(timeStep);
 }
 
 /**
@@ -85,10 +94,10 @@ void TimingsInputParser::parseNumberOfSteps(
 {
     checkCommand(lineElements, lineNumber);
 
-    const auto numberOfSteps = stoi(lineElements[2]);
+    const auto numberOfSteps = stringToInt(lineElements[2]);
 
-    if (numberOfSteps < 0)
-        throw InputFileException("Number of steps cannot be negative");
+    if (numberOfSteps < 1)
+        throw InputFileException("Number of steps must be greater than zero");
 
     TimingsSettings::setNumberOfSteps(size_t(numberOfSteps));
 }

--- a/src/utilities/stringUtilities.cpp
+++ b/src/utilities/stringUtilities.cpp
@@ -24,7 +24,7 @@
 
 #include <algorithm>   // for __for_each_fn
 #include <cctype>      // for isspace
-#include <cmath>       // for isnan, isinf
+#include <cmath>       // for isfinite
 #include <cstdint>     // for uint_fast32_t and UINT32_MAX
 #include <format>      // for format
 #include <fstream>
@@ -318,6 +318,47 @@ std::uint_fast32_t utilities::stringToUintFast32t(const std::string &str)
 }
 
 /**
+ * @brief converts a complete string to an int
+ *
+ * @param str
+ *
+ * @throw invalid_argument if the complete string is not a valid integer
+ * @throw out_of_range if number is out of range for an int
+ */
+int utilities::stringToInt(const std::string &str)
+{
+    size_t parsedCharacters{};
+    int    value{};
+
+    try
+    {
+        value = std::stoi(str, &parsedCharacters);
+    }
+    catch (const std::invalid_argument &)
+    {
+        throw std::invalid_argument(
+            std::format("Invalid integer value '{}' encountered", str)
+        );
+    }
+    catch (const std::out_of_range &)
+    {
+        throw std::out_of_range(
+            std::format(
+                "Integer value '{}' exceeds the representable range for an int",
+                str
+            )
+        );
+    }
+
+    if (parsedCharacters != str.size())
+        throw std::invalid_argument(
+            std::format("Invalid integer value '{}' encountered", str)
+        );
+
+    return value;
+}
+
+/**
  * @brief converts a string to a non-Nan and non-Inf double
  *
  * @param str
@@ -327,11 +368,12 @@ std::uint_fast32_t utilities::stringToUintFast32t(const std::string &str)
  */
 double utilities::stringToFiniteDouble(const std::string &str)
 {
+    size_t parsedCharacters{};
     double value{};
 
     try
     {
-        value = std::stod(str);
+        value = std::stod(str, &parsedCharacters);
     }
     catch (const std::invalid_argument &)
     {
@@ -350,7 +392,7 @@ double utilities::stringToFiniteDouble(const std::string &str)
         );
     }
 
-    if (std::isnan(value) || std::isinf(value))
+    if (parsedCharacters != str.size() || !std::isfinite(value))
         throw std::invalid_argument(
             std::format("Invalid floating-point value '{}' encountered", str)
         );

--- a/tests/src/input/inputFileParsing/CMakeLists.txt
+++ b/tests/src/input/inputFileParsing/CMakeLists.txt
@@ -10,6 +10,7 @@ set(source_files
     testForceFieldParser.cpp
     testGeneralParser.cpp
     testHessianParser.cpp
+    testHybridParser.cpp
     testIntegratorParser.cpp
     testManostatParser.cpp
     testNonCoulombParser.cpp

--- a/tests/src/input/inputFileParsing/testConstraintsParser.cpp
+++ b/tests/src/input/inputFileParsing/testConstraintsParser.cpp
@@ -106,6 +106,13 @@ TEST_F(TestInputFileReader, testParseShakeTolerance)
         customException::InputFileException,
         "Shake tolerance must be positive"
     );
+
+    lineElements = {"shake-tolerance", "=", "0"};
+    EXPECT_THROW_MSG(
+        parser.parseShakeTolerance(lineElements, 0),
+        customException::InputFileException,
+        "Shake tolerance must be positive"
+    );
 }
 
 /**
@@ -122,6 +129,13 @@ TEST_F(TestInputFileReader, testParseShakeIteration)
     EXPECT_EQ(ConstraintSettings::getShakeMaxIter(), 100);
 
     lineElements = {"shake-iter", "=", "-100"};
+    EXPECT_THROW_MSG(
+        parser.parseShakeIteration(lineElements, 0),
+        customException::InputFileException,
+        "Maximum shake iterations must be positive"
+    );
+
+    lineElements = {"shake-iter", "=", "0"};
     EXPECT_THROW_MSG(
         parser.parseShakeIteration(lineElements, 0),
         customException::InputFileException,
@@ -148,6 +162,13 @@ TEST_F(TestInputFileReader, testParseRattleTolerance)
         customException::InputFileException,
         "Rattle tolerance must be positive"
     );
+
+    lineElements = {"rattle-tolerance", "=", "0"};
+    EXPECT_THROW_MSG(
+        parser.parseRattleTolerance(lineElements, 0),
+        customException::InputFileException,
+        "Rattle tolerance must be positive"
+    );
 }
 
 /**
@@ -164,6 +185,13 @@ TEST_F(TestInputFileReader, testParseRattleIteration)
     EXPECT_EQ(ConstraintSettings::getRattleMaxIter(), 100);
 
     lineElements = {"rattle-iter", "=", "-100"};
+    EXPECT_THROW_MSG(
+        parser.parseRattleIteration(lineElements, 0),
+        customException::InputFileException,
+        "Maximum rattle iterations must be positive"
+    );
+
+    lineElements = {"rattle-iter", "=", "0"};
     EXPECT_THROW_MSG(
         parser.parseRattleIteration(lineElements, 0),
         customException::InputFileException,
@@ -190,6 +218,13 @@ TEST_F(TestInputFileReader, testParseMShakeTolerance)
         customException::InputFileException,
         "MShake tolerance must be positive"
     );
+
+    lineElements = {"mshake-tolerance", "=", "0"};
+    EXPECT_THROW_MSG(
+        parser.parseMShakeTolerance(lineElements, 0),
+        customException::InputFileException,
+        "MShake tolerance must be positive"
+    );
 }
 
 /**
@@ -206,6 +241,13 @@ TEST_F(TestInputFileReader, testParseMShakeIteration)
     EXPECT_EQ(ConstraintSettings::getMShakeMaxIter(), 73);
 
     lineElements = {"mshake-iter", "=", "-100"};
+    EXPECT_THROW_MSG(
+        parser.parseMShakeIteration(lineElements, 0),
+        customException::InputFileException,
+        "Maximum MShake iterations must be positive"
+    );
+
+    lineElements = {"mshake-iter", "=", "0"};
     EXPECT_THROW_MSG(
         parser.parseMShakeIteration(lineElements, 0),
         customException::InputFileException,

--- a/tests/src/input/inputFileParsing/testHybridParser.cpp
+++ b/tests/src/input/inputFileParsing/testHybridParser.cpp
@@ -1,0 +1,87 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+#include "exceptions.hpp"
+#include "hybridInputParser.hpp"
+#include "testInputFileReader.hpp"
+#include "throwWithMessage.hpp"
+
+using namespace customException;
+using namespace input;
+
+TEST_F(TestInputFileReader, parseInvalidQMCharges)
+{
+    auto parser = HybridInputParser(*_engine);
+
+    EXPECT_THROW_MSG(
+        parser.parseUseQMCharges({"qm_charges", "=", "invalid"}, 0),
+        InputFileException,
+        "Invalid qm_charges \"invalid\" in input file\n"
+        "Possible values are: qm, mm"
+    );
+}
+
+TEST_F(TestInputFileReader, parseNegativeHybridRadii)
+{
+    auto parser = HybridInputParser(*_engine);
+
+    EXPECT_THROW_MSG(
+        parser.parseCoreRadius({"core_radius", "=", "-1"}, 0),
+        InputFileException,
+        "Invalid core_radius -1 in input file - must be a positive number"
+    );
+    EXPECT_THROW_MSG(
+        parser.parseLayerRadius({"layer_radius", "=", "-1"}, 0),
+        InputFileException,
+        "Invalid layer_radius -1 in input file - must be a positive number"
+    );
+    EXPECT_THROW_MSG(
+        parser.parseSmoothingRadius({"smoothing_radius", "=", "-1"}, 0),
+        InputFileException,
+        "Invalid smoothing_radius -1 in input file - must be a positive number"
+    );
+}
+
+TEST_F(TestInputFileReader, parseNonFiniteHybridRadii)
+{
+    auto parser = HybridInputParser(*_engine);
+
+    EXPECT_THROW_MSG(
+        parser.parseCoreRadius({"core_radius", "=", "nan"}, 0),
+        std::invalid_argument,
+        "Invalid floating-point value 'nan' encountered"
+    );
+    EXPECT_THROW_MSG(
+        parser.parseLayerRadius({"layer_radius", "=", "inf"}, 0),
+        std::invalid_argument,
+        "Invalid floating-point value 'inf' encountered"
+    );
+    EXPECT_THROW_MSG(
+        parser.parseSmoothingRadius({"smoothing_radius", "=", "-inf"}, 0),
+        std::invalid_argument,
+        "Invalid floating-point value '-inf' encountered"
+    );
+}

--- a/tests/src/input/inputFileParsing/testManostatParser.cpp
+++ b/tests/src/input/inputFileParsing/testManostatParser.cpp
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>   // for TestInfo (ptr only), EXPECT_EQ
 
+#include <stdexcept>
 #include <string>   // for string, allocator, basic_string
 #include <vector>   // for vector
 
@@ -45,6 +46,13 @@ TEST_F(TestInputFileReader, ParsePressure)
     parser.parsePressure(lineElements, 0);
 
     EXPECT_EQ(settings::ManostatSettings::getTargetPressure(), 300.0);
+
+    lineElements = {"pressure", "=", "nan"};
+    EXPECT_THROW_MSG(
+        parser.parsePressure(lineElements, 0),
+        std::invalid_argument,
+        "Invalid floating-point value 'nan' encountered"
+    );
 }
 
 /**
@@ -65,7 +73,21 @@ TEST_F(TestInputFileReader, ParseRelaxationTimeManostat)
     EXPECT_THROW_MSG(
         parser.parseManostatRelaxationTime(lineElements, 0),
         customException::InputFileException,
-        "Relaxation time of manostat cannot be negative"
+        "Relaxation time of manostat must be finite and greater than zero"
+    );
+
+    lineElements = {"p_relaxation", "=", "0"};
+    EXPECT_THROW_MSG(
+        parser.parseManostatRelaxationTime(lineElements, 0),
+        customException::InputFileException,
+        "Relaxation time of manostat must be finite and greater than zero"
+    );
+
+    lineElements = {"p_relaxation", "=", "1e308"};
+    EXPECT_THROW_MSG(
+        parser.parseManostatRelaxationTime(lineElements, 0),
+        customException::InputFileException,
+        "Relaxation time of manostat is too large to represent in femtoseconds"
     );
 }
 
@@ -126,7 +148,14 @@ TEST_F(TestInputFileReader, ParseCompressibility)
     EXPECT_THROW_MSG(
         parser.parseCompressibility(lineElements, 0),
         customException::InputFileException,
-        "Compressibility cannot be negative"
+        "Compressibility must be finite and non-negative"
+    );
+
+    lineElements = {"compressibility", "=", "inf"};
+    EXPECT_THROW_MSG(
+        parser.parseCompressibility(lineElements, 0),
+        std::invalid_argument,
+        "Invalid floating-point value 'inf' encountered"
     );
 }
 

--- a/tests/src/input/inputFileParsing/testQMParser.cpp
+++ b/tests/src/input/inputFileParsing/testQMParser.cpp
@@ -405,6 +405,18 @@ TEST_F(TestInputFileReader, parseHubbardDerivs)
         InputFileException,
         "Invalid hubbard_derivs format \"H:1.0,He\" in input file."
     )
+
+    ASSERT_THROW_MSG(
+        parser.parseHubbardDerivs({"hubbard_derivs", "=", "H:0.1junk"}, 0),
+        InputFileException,
+        "Invalid hubbard_derivs format \"H:0.1junk\" in input file."
+    )
+
+    ASSERT_THROW_MSG(
+        parser.parseHubbardDerivs({"hubbard_derivs", "=", "H:nan"}, 0),
+        InputFileException,
+        "Invalid hubbard_derivs format \"H:nan\" in input file."
+    )
 }
 
 TEST_F(TestInputFileReader, parseXtbMethod)

--- a/tests/src/input/inputFileParsing/testSimulationBoxParser.cpp
+++ b/tests/src/input/inputFileParsing/testSimulationBoxParser.cpp
@@ -55,6 +55,13 @@ TEST_F(TestInputFileReader, parseDensity)
         customException::InputFileException,
         "Density must be positive - density = -1"
     );
+
+    const std::vector<std::string> zeroDensity = {"density", "=", "0"};
+    EXPECT_THROW_MSG(
+        parser.parseDensity(zeroDensity, 0),
+        customException::InputFileException,
+        "Density must be positive - density = 0"
+    );
 }
 
 /**

--- a/tests/src/input/inputFileParsing/testThermostatParser.cpp
+++ b/tests/src/input/inputFileParsing/testThermostatParser.cpp
@@ -55,8 +55,11 @@ TEST_F(TestInputFileReader, testParseTemperature)
     EXPECT_THROW_MSG(
         parser.parseTemperature(lineElements, 0),
         customException::InputFileException,
-        "Temperature cannot be negative"
+        "Temperature must be finite and non-negative"
     );
+
+    lineElements = {"temp", "=", "0"};
+    EXPECT_NO_THROW(parser.parseTemperature(lineElements, 0));
 }
 
 /**
@@ -77,7 +80,22 @@ TEST_F(TestInputFileReader, testParseRelaxationTime)
     EXPECT_THROW_MSG(
         parser.parseThermostatRelaxationTime(lineElements, 0),
         customException::InputFileException,
-        "Relaxation time of thermostat cannot be negative"
+        "Relaxation time of thermostat must be finite and greater than zero"
+    );
+
+    lineElements = {"t_relaxation", "=", "1e308"};
+    EXPECT_THROW_MSG(
+        parser.parseThermostatRelaxationTime(lineElements, 0),
+        customException::InputFileException,
+        "Relaxation time of thermostat is too large to represent in "
+        "femtoseconds"
+    );
+
+    lineElements = {"t_relaxation", "=", "0"};
+    EXPECT_THROW_MSG(
+        parser.parseThermostatRelaxationTime(lineElements, 0),
+        customException::InputFileException,
+        "Relaxation time of thermostat must be finite and greater than zero"
     );
 }
 
@@ -158,7 +176,14 @@ TEST_F(TestInputFileReader, testParseFriction)
     EXPECT_THROW_MSG(
         parser.parseThermostatFriction(lineElements, 0),
         customException::InputFileException,
-        "Friction of thermostat cannot be negative"
+        "Friction of thermostat must be finite and non-negative"
+    );
+
+    lineElements = {"friction", "=", "1e308"};
+    EXPECT_THROW_MSG(
+        parser.parseThermostatFriction(lineElements, 0),
+        customException::InputFileException,
+        "Friction of thermostat is too large to represent in inverse seconds"
     );
 }
 
@@ -179,7 +204,14 @@ TEST_F(TestInputFileReader, testParseChainLength)
     EXPECT_THROW_MSG(
         parser.parseThermostatChainLength(lineElements, 0),
         customException::InputFileException,
-        "Chain length of thermostat cannot be negative"
+        "Chain length of thermostat must be greater than zero"
+    );
+
+    lineElements = {"nh-chain-length", "=", "0"};
+    EXPECT_THROW_MSG(
+        parser.parseThermostatChainLength(lineElements, 0),
+        customException::InputFileException,
+        "Chain length of thermostat must be greater than zero"
     );
 }
 
@@ -201,7 +233,14 @@ TEST_F(TestInputFileReader, testParseCouplingFrequency)
     EXPECT_THROW_MSG(
         parser.parseThermostatCouplingFrequency(lineElements, 0),
         customException::InputFileException,
-        "Coupling frequency of thermostat cannot be negative"
+        "Coupling frequency of thermostat must be finite and non-negative"
+    );
+
+    lineElements = {"coupling_frequency", "=", "1e308"};
+    EXPECT_THROW_MSG(
+        parser.parseThermostatCouplingFrequency(lineElements, 0),
+        customException::InputFileException,
+        "Coupling frequency of thermostat is too large to represent in hertz"
     );
 }
 
@@ -243,7 +282,14 @@ TEST_F(TestInputFileReader, testParseTemperatureRampFrequency)
     EXPECT_THROW_MSG(
         parser.parseTemperatureRampFrequency(lineElements, 0),
         customException::InputFileException,
-        "Temperature ramp frequency cannot be negative"
+        "Temperature ramp frequency must be greater than zero"
+    );
+
+    lineElements = {"temp_ramp_frequency", "=", "0"};
+    EXPECT_THROW_MSG(
+        parser.parseTemperatureRampFrequency(lineElements, 0),
+        customException::InputFileException,
+        "Temperature ramp frequency must be greater than zero"
     );
 }
 
@@ -264,8 +310,11 @@ TEST_F(TestInputFileReader, testParseStartTemperature)
     EXPECT_THROW_MSG(
         parser.parseStartTemperature(lineElements, 0),
         customException::InputFileException,
-        "Start temperature cannot be negative"
+        "Start temperature must be finite and non-negative"
     );
+
+    lineElements = {"start_temp", "=", "0"};
+    EXPECT_NO_THROW(parser.parseStartTemperature(lineElements, 0));
 }
 
 /**
@@ -285,6 +334,9 @@ TEST_F(TestInputFileReader, testParseEndTemperature)
     EXPECT_THROW_MSG(
         parser.parseEndTemperature(lineElements, 0),
         customException::InputFileException,
-        "End temperature cannot be negative"
+        "End temperature must be finite and non-negative"
     );
+
+    lineElements = {"end_temp", "=", "0"};
+    EXPECT_NO_THROW(parser.parseEndTemperature(lineElements, 0));
 }

--- a/tests/src/input/inputFileParsing/testTimingsParser.cpp
+++ b/tests/src/input/inputFileParsing/testTimingsParser.cpp
@@ -22,6 +22,8 @@
 
 #include <gtest/gtest.h>   // for TestInfo (ptr only), InitGoogleTest, RUN_ALL_TESTS, EXPECT_EQ
 
+#include <format>   // for format
+#include <stdexcept>
 #include <string>   // for string, allocator, basic_string
 #include <vector>   // for vector
 
@@ -46,6 +48,26 @@ TEST_F(TestInputFileReader, testParseTimestep)
     vector<string>     lineElements = {"timestep", "=", "1"};
     parser.parseTimeStep(lineElements, 0);
     EXPECT_EQ(settings::TimingsSettings::getTimeStep(), 1.0);
+
+    lineElements = {"timestep", "=", "0"};
+    EXPECT_THROW_MSG(
+        parser.parseTimeStep(lineElements, 0),
+        customException::InputFileException,
+        "Time step must be finite and greater than zero"
+    );
+
+    for (const auto &invalid : {"nan", "inf"})
+    {
+        lineElements = {"timestep", "=", invalid};
+        EXPECT_THROW_MSG(
+            parser.parseTimeStep(lineElements, 0),
+            std::invalid_argument,
+            std::format(
+                "Invalid floating-point value '{}' encountered",
+                invalid
+            )
+        );
+    }
 }
 
 /**
@@ -65,6 +87,13 @@ TEST_F(TestInputFileReader, testParseNumberOfSteps)
     EXPECT_THROW_MSG(
         parser.parseNumberOfSteps(lineElements, 0),
         customException::InputFileException,
-        "Number of steps cannot be negative"
+        "Number of steps must be greater than zero"
+    );
+
+    lineElements = {"nsteps", "=", "0"};
+    EXPECT_THROW_MSG(
+        parser.parseNumberOfSteps(lineElements, 0),
+        customException::InputFileException,
+        "Number of steps must be greater than zero"
     );
 }

--- a/tests/src/utilities/testStringUtilities.cpp
+++ b/tests/src/utilities/testStringUtilities.cpp
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>   // for Test, TestInfo (ptr only), EXPECT_EQ
 
+#include <climits>     // for INT_MAX, INT_MIN
 #include <cstdint>     // for UINT32_MAX
 #include <cstdio>      // for remove
 #include <fstream>     // for ofstream
@@ -261,6 +262,36 @@ TEST(TestStringUtilities, stringToUintFast32t)
 }
 
 /**
+ * @brief test stringToInt function
+ *
+ */
+TEST(TestStringUtilities, stringToInt)
+{
+    EXPECT_EQ(0, utilities::stringToInt("0"));
+    EXPECT_EQ(43, utilities::stringToInt("+43"));
+    EXPECT_EQ(-43, utilities::stringToInt("-43"));
+    EXPECT_EQ(INT_MAX, utilities::stringToInt(std::to_string(INT_MAX)));
+    EXPECT_EQ(INT_MIN, utilities::stringToInt(std::to_string(INT_MIN)));
+
+    for (const std::string invalid : {"", "3.14", "12steps", "1e3"})
+        EXPECT_THROW_MSG(
+            utilities::stringToInt(invalid),
+            std::invalid_argument,
+            std::format("Invalid integer value '{}' encountered", invalid)
+        );
+
+    const auto outOfRange = std::to_string(static_cast<long long>(INT_MAX) + 1);
+    EXPECT_THROW_MSG(
+        utilities::stringToInt(outOfRange),
+        std::out_of_range,
+        std::format(
+            "Integer value '{}' exceeds the representable range for an int",
+            outOfRange
+        )
+    );
+}
+
+/**
  * @brief test stringToFiniteDouble function
  *
  */
@@ -284,6 +315,13 @@ TEST(TestStringUtilities, stringToFiniteDouble)
     EXPECT_EQ(-maxValue, utilities::stringToFiniteDouble(str));
 
     str = "abc";
+    EXPECT_THROW_MSG(
+        utilities::stringToFiniteDouble(str),
+        std::invalid_argument,
+        std::format("Invalid floating-point value '{}' encountered", str)
+    );
+
+    str = "1.5fs";
     EXPECT_THROW_MSG(
         utilities::stringToFiniteDouble(str),
         std::invalid_argument,


### PR DESCRIPTION
Closes #331.

- require complete integer and floating-point values
- reject NaN, infinity, and conversion overflow
- enforce scalar parser limits before settings are stored

Cross-field setting relationships remain separate.

Tests:
- testStringUtilities
- 16 affected input parser test suites