### PR TITLE
docs: correct manostat relaxation default

### DIFF
--- a/docs/sphinx/src/userGuide/inputFile.rst
+++ b/docs/sphinx/src/userGuide/inputFile.rst
@@ -959,7 +959,7 @@ This keyword is used in combination with the Berendsen and stochastic cell resca
 .. admonition:: Key
     :class: tip
 
-    p_relaxation = {double} ps -> 0.1 ps
+    p_relaxation = {double} ps -> 1.0 ps
 
 With the ``p_relaxation`` keyword the relaxation time in ``ps`` (*i.e.* :math:`\tau`) of the Berendsen or stochastic cell rescaling manostat is set.
 


### PR DESCRIPTION
Closes #342.

Correct p_relaxation from 0.1 ps to the compiled 1.0 ps default. The thermostat default remains 0.1 ps.