### PR TITLE
fix: validate input configuration

### DIFF
--- a/docs/sphinx/src/userGuide/inputFile.rst
+++ b/docs/sphinx/src/userGuide/inputFile.rst
@@ -1586,6 +1586,7 @@ ASE-DFTB+ Approach
     slakos = {string}
 
 With the ``slakos`` keyword the user can specify the type of the ``ase-dftbplus`` approach for DFTB+ calculations.
+It is required when ``qm_prog = ase-dftbplus``.
 
 Possible options are:
 

--- a/include/input/inputFileReader.hpp
+++ b/include/input/inputFileReader.hpp
@@ -110,9 +110,11 @@ namespace input
          ******************************/
 
         void validateTimings() const;
+        void validateOptimizer() const;
         void validateQM() const;
         void validateThermostat() const;
         void validateManostat() const;
+        void validateCellList() const;
         void validateReactionFieldCoulomb() const;
         void validateRingPolymer() const;
     };

--- a/include/settings/optimizerSettings.hpp
+++ b/include/settings/optimizerSettings.hpp
@@ -103,6 +103,13 @@ namespace settings
         static void setMaxLearningRate(const double);
         static void setMinLearningRate(const double);
 
+        /******************************
+         * validation helper methods *
+         ******************************/
+
+        static void validateLearningRateStrategy();
+        static void validateLearningRateBounds();
+
         /***************************
          * standard getter methods *
          ***************************/

--- a/src/engine/hessianEngine.cpp
+++ b/src/engine/hessianEngine.cpp
@@ -310,6 +310,8 @@ pq::SharedLearningRate HessianEngine::setupLearningRateStrategy()
     const auto alpha0     = OptimizerSettings::getInitialLearningRate();
     const auto lrStrategy = OptimizerSettings::getLearningRateStrategy();
 
+    OptimizerSettings::validateLearningRateStrategy();
+
     switch (lrStrategy)
     {
         using enum LREnum;
@@ -318,48 +320,27 @@ pq::SharedLearningRate HessianEngine::setupLearningRateStrategy()
 
         case CONSTANT_DECAY:
         {
-            const auto alphaDecay = OptimizerSettings::getLearningRateDecay();
-
-            if (!alphaDecay.has_value())
-                throw UserInputException(
-                    "You need to specify a learning rate decay factor for the "
-                    "constant decay learning rate strategy"
-                );
-
             const auto alphaFreq = OptimizerSettings::getLRUpdateFrequency();
 
             return std::make_shared<ConstantDecayLRStrategy>(
                 alpha0,
-                alphaDecay.value(),
+                OptimizerSettings::getLearningRateDecay().value(),
                 alphaFreq
             );
         }
 
         case EXPONENTIAL_DECAY:
         {
-            const auto alphaDecay = OptimizerSettings::getLearningRateDecay();
-
-            if (!alphaDecay.has_value())
-                throw UserInputException(
-                    "You need to specify a learning rate decay factor for the "
-                    "exponential decay learning rate strategy"
-                );
-
             const auto alphaFreq = OptimizerSettings::getLRUpdateFrequency();
 
             return std::make_shared<ExpDecayLR>(
                 alpha0,
-                alphaDecay.value(),
+                OptimizerSettings::getLearningRateDecay().value(),
                 alphaFreq
             );
         }
 
         case LINESEARCH_WOLFE:
-            throw UserInputException(
-                "The Wolfe line search learning rate strategy is not yet "
-                "implemented"
-            );
-
         case NONE: break;
     }
 
@@ -419,13 +400,7 @@ void HessianEngine::setupMinMaxLearningRate(
     const auto minLR = OptimizerSettings::getMinLearningRate();
     const auto maxLR = OptimizerSettings::getMaxLearningRate();
 
-    if (maxLR.has_value() && minLR >= maxLR.value())
-        throw UserInputException(std::format(
-            "The minimum learning rate {} is greater or equal to the "
-            "maximum learning rate {}, which is not allowed.",
-            minLR,
-            maxLR.value()
-        ));
+    OptimizerSettings::validateLearningRateBounds();
 
     learningRate->setMinLearningRate(minLR);
     learningRate->setMaxLearningRate(maxLR);

--- a/src/input/inputValidation.cpp
+++ b/src/input/inputValidation.cpp
@@ -20,18 +20,23 @@
 <GPL_HEADER>
 ******************************************************************************/
 
+#include <algorithm>   // for max
+#include <cmath>       // for isfinite
+#include <format>      // for format
+
+#include "constants/conversionFactors.hpp"
+#include "engine.hpp"            // for Engine
+#include "exceptions.hpp"        // for InputFileException
+#include "hessianSettings.hpp"   // for HessianSettings
 #include "inputFileReader.hpp"
-
-#include <format>   // for format
-
-#include "exceptions.hpp"            // for InputFileException
-#include "hessianSettings.hpp"       // for HessianSettings
-#include "manostatSettings.hpp"      // for ManostatSettings
-#include "potentialSettings.hpp"     // for PotentialSettings
-#include "qmSettings.hpp"            // for QMSettings
-#include "settings.hpp"              // for Settings
-#include "thermostatSettings.hpp"    // for ThermostatSettings
-#include "timingsSettings.hpp"       // for TimingsSettings
+#include "manostatSettings.hpp"        // for ManostatSettings
+#include "optimizerSettings.hpp"       // for OptimizerSettings
+#include "potentialSettings.hpp"       // for PotentialSettings
+#include "qmSettings.hpp"              // for QMSettings
+#include "settings.hpp"                // for Settings
+#include "simulationBoxSettings.hpp"   // for SimulationBoxSettings
+#include "thermostatSettings.hpp"      // for ThermostatSettings
+#include "timingsSettings.hpp"         // for TimingsSettings
 
 using namespace input;
 using namespace settings;
@@ -46,9 +51,11 @@ using namespace customException;
 void InputFileReader::validateInputConfiguration() const
 {
     validateTimings();
+    validateOptimizer();
     validateQM();
     validateThermostat();
     validateManostat();
+    validateCellList();
     validateReactionFieldCoulomb();
     validateRingPolymer();
 }
@@ -83,6 +90,26 @@ void InputFileReader::validateTimings() const
 }
 
 /**
+ * @brief validates settings used by active optimization jobs
+ *
+ * @throws UserInputException if the learning-rate strategy or bounds are
+ * invalid
+ */
+void InputFileReader::validateOptimizer() const
+{
+    const auto optimizerActive =
+        Settings::isOptJobType() ||
+        (Settings::getJobtype() == JobType::MM_HESSIAN &&
+         HessianSettings::optimizeBeforeHessian());
+
+    if (!optimizerActive)
+        return;
+
+    OptimizerSettings::validateLearningRateStrategy();
+    OptimizerSettings::validateLearningRateBounds();
+}
+
+/**
  * @brief validates QM keyword dependencies
  *
  * @throws InputFileException if selected QM settings require missing or
@@ -93,10 +120,27 @@ void InputFileReader::validateQM() const
     if (!Settings::isQMActivated())
         return;
 
+    if (!getKeywordSet("qm_prog"))
+        throw InputFileException(
+            "QM job selected but the \"qm_prog\" keyword has not been set"
+        );
+
     const auto qmMethod = QMSettings::getQMMethod();
 
     if (qmMethod == QMMethod::ASEDFTBPLUS)
     {
+        if (QMSettings::getSlakosType() == SlakosType::NONE)
+            throw InputFileException(
+                "ASE-DFTB+ requires slakos to be 3ob, matsci, or custom"
+            );
+
+        if (QMSettings::getSlakosType() == SlakosType::CUSTOM &&
+            !getKeywordSet("slakos_path"))
+            throw InputFileException(
+                "Custom Slater-Koster parameters require the "
+                "\"slakos_path\" keyword"
+            );
+
         auto useThirdOrder = QMSettings::useThirdOrderDftb();
 
         if (QMSettings::getSlakosType() == SlakosType::THREEOB &&
@@ -155,13 +199,13 @@ void InputFileReader::validateQM() const
  */
 void InputFileReader::validateThermostat() const
 {
-    const auto thermostatType = ThermostatSettings::getThermostatType();
+    const auto thermostatType    = ThermostatSettings::getThermostatType();
+    const auto targetTempDefined = getKeywordSet("temp");
+    const auto startTempDefined  = getKeywordSet("start_temp");
+    const auto endTempDefined    = getKeywordSet("end_temp");
 
     if (thermostatType != ThermostatType::NONE)
     {
-        const auto targetTempDefined = getKeywordSet("temp");
-        const auto endTempDefined    = getKeywordSet("end_temp");
-
         if (!targetTempDefined && !endTempDefined)
             throw InputFileException(std::format(
                 "Target or end temperature not set for {} thermostat",
@@ -176,7 +220,83 @@ void InputFileReader::validateThermostat() const
             ));
     }
 
-    if (!getKeywordSet("start_temp"))
+    if (SimulationBoxSettings::getInitializeVelocities() !=
+            InitVelocities::FALSE &&
+        !targetTempDefined && !startTempDefined && !endTempDefined)
+        throw InputFileException(
+            "Initializing velocities requires temp, start_temp, or end_temp"
+        );
+
+    if (Settings::isMDJobType() &&
+        (thermostatType == ThermostatType::BERENDSEN ||
+         thermostatType == ThermostatType::VELOCITY_RESCALING))
+    {
+        const auto relaxationTime =
+            ThermostatSettings::getRelaxationTime() * constants::_PS_TO_FS_;
+
+        if (TimingsSettings::getTimeStep() > relaxationTime)
+            throw InputFileException(
+                "The timestep must not exceed the thermostat relaxation time"
+            );
+    }
+
+    if (thermostatType == ThermostatType::LANGEVIN)
+    {
+        auto maxTemperature = 0.0;
+
+        if (targetTempDefined)
+            maxTemperature = std::max(
+                maxTemperature,
+                ThermostatSettings::getTargetTemperature()
+            );
+        if (startTempDefined)
+            maxTemperature = std::max(
+                maxTemperature,
+                ThermostatSettings::getStartTemperature()
+            );
+        if (endTempDefined)
+            maxTemperature = std::max(
+                maxTemperature,
+                ThermostatSettings::getEndTemperature()
+            );
+
+        const auto unitConversion = constants::_M2_TO_ANGSTROM2_ *
+                                    constants::_KG_TO_GRAM_ /
+                                    constants::_FS_TO_S_;
+        const auto conversionFactor =
+            constants::_UNIVERSAL_GAS_CONSTANT_ * unitConversion;
+        const auto sigmaSquared = 4.0 * ThermostatSettings::getFriction() *
+                                  conversionFactor * maxTemperature /
+                                  TimingsSettings::getTimeStep();
+
+        if (!std::isfinite(sigmaSquared))
+            throw InputFileException(
+                "Langevin thermostat parameters produce a non-finite "
+                "random-force scale"
+            );
+    }
+
+    if (thermostatType == ThermostatType::NOSE_HOOVER)
+    {
+        if (targetTempDefined &&
+            ThermostatSettings::getTargetTemperature() <= 0.0)
+            throw InputFileException(
+                "Nose-Hoover target temperature must be greater than zero"
+            );
+
+        if (endTempDefined && ThermostatSettings::getEndTemperature() <= 0.0)
+            throw InputFileException(
+                "Nose-Hoover end temperature must be greater than zero"
+            );
+
+        if (startTempDefined &&
+            ThermostatSettings::getStartTemperature() <= 0.0)
+            throw InputFileException(
+                "Nose-Hoover start temperature must be greater than zero"
+            );
+    }
+
+    if (!startTempDefined)
         return;
 
     const auto totalSteps = TimingsSettings::getNumberOfSteps();
@@ -212,11 +332,44 @@ void InputFileReader::validateManostat() const
 {
     const auto manostatType = ManostatSettings::getManostatType();
 
-    if (manostatType != ManostatType::NONE && !getKeywordSet("pressure"))
+    if (manostatType == ManostatType::NONE)
+        return;
+
+    if (!getKeywordSet("pressure"))
         throw InputFileException(std::format(
             "Pressure not set for {} manostat",
             string(manostatType)
         ));
+
+    const auto relaxationTime =
+        ManostatSettings::getTauManostat() * constants::_PS_TO_FS_;
+
+    if (TimingsSettings::getTimeStep() > relaxationTime)
+        throw InputFileException(
+            "The timestep must not exceed the manostat relaxation time"
+        );
+}
+
+/**
+ * @brief validates cell-list dependencies
+ *
+ * @throws InputFileException if an active cell list is incompatible with the
+ * selected potential
+ */
+void InputFileReader::validateCellList() const
+{
+    if (!_engine.isCellListActivated())
+        return;
+
+    if (Settings::isQMOnlyActivated())
+        throw InputFileException(
+            "Cell lists are not available for pure QM simulations"
+        );
+
+    if (PotentialSettings::getCoulombRadiusCutOff() <= 0.0)
+        throw InputFileException(
+            "An active cell list requires rcoulomb to be greater than zero"
+        );
 }
 
 /**

--- a/src/settings/optimizerSettings.cpp
+++ b/src/settings/optimizerSettings.cpp
@@ -22,10 +22,14 @@
 
 #include "optimizerSettings.hpp"
 
+#include <format>
+
+#include "exceptions.hpp"
 #include "stringUtilities.hpp"   // for toLowerCopy
 
 using namespace settings;
 using namespace utilities;
+using namespace customException;
 
 /**
  * @brief returns the optimizer as string
@@ -202,6 +206,63 @@ void OptimizerSettings::setMinLearningRate(const double minLearningRate)
 void OptimizerSettings::setMaxLearningRate(const double maxLearningRate)
 {
     _maxLearningRate = maxLearningRate;
+}
+
+/*****************************
+ *                           *
+ * validation helper methods *
+ *                           *
+ *****************************/
+
+/**
+ * @brief validates the selected learning-rate strategy
+ */
+void OptimizerSettings::validateLearningRateStrategy()
+{
+    const auto strategy = getLearningRateStrategy();
+
+    if (strategy == LREnum::LINESEARCH_WOLFE)
+        throw UserInputException(
+            "The Wolfe line search learning rate strategy is not yet "
+            "implemented"
+        );
+
+    if (strategy == LREnum::NONE)
+        throw UserInputException(
+            "In order to run the optimizer, you need to specify a learning "
+            "rate strategy."
+        );
+
+    const auto needsDecay = strategy == LREnum::CONSTANT_DECAY ||
+                            strategy == LREnum::EXPONENTIAL_DECAY;
+
+    if (needsDecay && !getLearningRateDecay().has_value())
+        throw UserInputException(
+            std::format(
+                "The {} learning rate strategy requires learning-rate-decay.",
+                strategy == LREnum::CONSTANT_DECAY ? "constant-decay"
+                                                   : "exponential-decay"
+            )
+        );
+}
+
+/**
+ * @brief validates the configured learning-rate bounds
+ */
+void OptimizerSettings::validateLearningRateBounds()
+{
+    const auto minLR = getMinLearningRate();
+    const auto maxLR = getMaxLearningRate();
+
+    if (maxLR.has_value() && minLR >= maxLR.value())
+        throw UserInputException(
+            std::format(
+                "The minimum learning rate {} is greater or equal to the "
+                "maximum learning rate {}, which is not allowed.",
+                minLR,
+                maxLR.value()
+            )
+        );
 }
 
 /***************************

--- a/src/setup/optimizerSetup.cpp
+++ b/src/setup/optimizerSetup.cpp
@@ -154,6 +154,8 @@ pq::SharedLearningRate OptimizerSetup::setupLearningRateStrategy()
     const auto alpha_0    = OptimizerSettings::getInitialLearningRate();
     const auto lrStrategy = OptimizerSettings::getLearningRateStrategy();
 
+    OptimizerSettings::validateLearningRateStrategy();
+
     switch (lrStrategy)
     {
         using enum LREnum;
@@ -162,15 +164,8 @@ pq::SharedLearningRate OptimizerSetup::setupLearningRateStrategy()
 
         case CONSTANT_DECAY:
         {
-            const auto alphaDecay = OptimizerSettings::getLearningRateDecay();
-
-            if (!alphaDecay.has_value())
-                throw UserInputException(
-                    "You need to specify a learning rate decay factor for the "
-                    "constant decay learning rate strategy"
-                );
-
-            const auto alphaDecayValue = alphaDecay.value();
+            const auto alphaDecayValue =
+                OptimizerSettings::getLearningRateDecay().value();
             const auto alphaFreq = OptimizerSettings::getLRUpdateFrequency();
 
             return std::make_shared<ConstantDecayLRStrategy>(
@@ -182,15 +177,8 @@ pq::SharedLearningRate OptimizerSetup::setupLearningRateStrategy()
 
         case EXPONENTIAL_DECAY:
         {
-            const auto alphaDecay = OptimizerSettings::getLearningRateDecay();
-
-            if (!alphaDecay.has_value())
-                throw UserInputException(
-                    "You need to specify a learning rate decay factor for the "
-                    "constant decay learning rate strategy"
-                );
-
-            const auto alphaDecayValue = alphaDecay.value();
+            const auto alphaDecayValue =
+                OptimizerSettings::getLearningRateDecay().value();
             const auto alphaFreq = OptimizerSettings::getLRUpdateFrequency();
 
             return std::make_shared<ExpDecayLR>(
@@ -201,13 +189,6 @@ pq::SharedLearningRate OptimizerSetup::setupLearningRateStrategy()
         }
 
         case LINESEARCH_WOLFE:
-        {
-            throw UserInputException(
-                "The Wolfe line search learning rate strategy is not yet "
-                "implemented"
-            );
-        }
-
         case NONE: break;
     }
 
@@ -227,13 +208,7 @@ void OptimizerSetup::setupMinMaxLR(pq::SharedLearningRate &lrStrategy)
     const auto minLR = OptimizerSettings::getMinLearningRate();
     const auto maxLR = OptimizerSettings::getMaxLearningRate();
 
-    if (maxLR.has_value() && minLR >= maxLR.value())
-        throw UserInputException(std::format(
-            "The minimum learning rate {} is greater or equal to the "
-            "maximum learning rate {}, which is not allowed.",
-            minLR,
-            maxLR.value()
-        ));
+    OptimizerSettings::validateLearningRateBounds();
 
     lrStrategy->setMinLearningRate(minLR);
     lrStrategy->setMaxLearningRate(maxLR);

--- a/tests/src/input/testInputValidation.cpp
+++ b/tests/src/input/testInputValidation.cpp
@@ -22,17 +22,22 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>   // for numeric_limits
 #include <memory>   // for make_unique, unique_ptr
 #include <string>   // for string
 
+#include "celllist.hpp"              // for CellList
+#include "defaults.hpp"              // for default settings
 #include "exceptions.hpp"            // for InputFileException
 #include "hessianSettings.hpp"       // for HessianSettings
 #include "inputFileReader.hpp"       // for InputFileReader
 #include "manostatSettings.hpp"      // for ManostatSettings
 #include "optEngine.hpp"             // for OptEngine
+#include "optimizerSettings.hpp"     // for OptimizerSettings
 #include "potentialSettings.hpp"     // for PotentialSettings
 #include "qmSettings.hpp"            // for QMSettings
 #include "settings.hpp"              // for Settings
+#include "simulationBoxSettings.hpp"   // for SimulationBoxSettings
 #include "thermostatSettings.hpp"    // for ThermostatSettings
 #include "throwWithMessage.hpp"      // for ASSERT_THROW_MSG
 #include "timingsSettings.hpp"       // for TimingsSettings
@@ -49,18 +54,39 @@ class TestInputValidation : public ::testing::Test
         Settings::setJobtype(JobType::NONE);
         HessianSettings::setOptimizeBeforeHessian(false);
 
+        OptimizerSettings::setLearningRateStrategy(LREnum::CONSTANT);
+        OptimizerSettings::setMinLearningRate(1.0e-15);
+        OptimizerSettings::setMaxLearningRate(1.0);
+
         ManostatSettings::setManostatType(ManostatType::NONE);
+        ManostatSettings::setTauManostat(
+            defaults::_BERENDSEN_MANOSTAT_RELAX_TIME_
+        );
 
         ThermostatSettings::setThermostatType(ThermostatType::NONE);
+        ThermostatSettings::setTargetTemperature(0.0);
+        ThermostatSettings::setStartTemperature(0.0);
+        ThermostatSettings::setEndTemperature(0.0);
         ThermostatSettings::setTemperatureSet(false);
         ThermostatSettings::setStartTemperatureSet(false);
         ThermostatSettings::setEndTemperatureSet(false);
         ThermostatSettings::setTemperatureRampSteps(0);
         ThermostatSettings::setTemperatureRampFrequency(1);
+        ThermostatSettings::setRelaxationTime(
+            defaults::_BERENDSEN_THERMOSTAT_RELAX_TIME_
+        );
+        ThermostatSettings::setFriction(
+            defaults::_LANGEVIN_THERMOSTAT_FRICTION_
+        );
+        SimulationBoxSettings::setInitializeVelocities(InitVelocities::FALSE);
 
         PotentialSettings::setCoulombLongRangeType(
             CoulombLongRangeType::SHIFTED
         );
+        PotentialSettings::setCoulombRadiusCutOff(
+            defaults::_COULOMB_CUT_OFF_DEFAULT_
+        );
+        TimingsSettings::setTimeStep(0.5);
 
         QMSettings::setQMMethod(QMMethod::NONE);
         QMSettings::setMaceModel(MaceModel::MEDIUM);
@@ -87,6 +113,8 @@ class TestInputValidation : public ::testing::Test
         TimingsSettings::setNumberOfSteps(100);
         setKeyword("nstep");
         setKeyword("timestep");
+        if (jobType == JobType::QM_MD || jobType == JobType::RING_POLYMER_QM_MD)
+            setKeyword("qm_prog");
     }
 
     std::unique_ptr<engine::OptEngine> _engine;
@@ -159,6 +187,33 @@ TEST_F(TestInputValidation, requiresPressureForManostat)
     );
 }
 
+TEST_F(TestInputValidation, rejectsUnstableManostatRelaxationTime)
+{
+    configureMDJob(JobType::MM_MD);
+    ManostatSettings::setManostatType(ManostatType::BERENDSEN);
+    ManostatSettings::setTauManostat(0.0001);
+    setKeyword("pressure");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "The timestep must not exceed the manostat relaxation time"
+    );
+}
+
+TEST_F(TestInputValidation, requiresQMProgramForQMJob)
+{
+    Settings::setJobtype(JobType::QM_MD);
+    setKeyword("nstep");
+    setKeyword("timestep");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "QM job selected but the \"qm_prog\" keyword has not been set"
+    );
+}
+
 TEST_F(TestInputValidation, requiresTemperatureForThermostat)
 {
     ThermostatSettings::setThermostatType(ThermostatType::BERENDSEN);
@@ -188,7 +243,118 @@ TEST_F(TestInputValidation, acceptsEndTemperatureForThermostat)
 {
     configureMDJob(JobType::MM_MD);
     ThermostatSettings::setThermostatType(ThermostatType::BERENDSEN);
+    ThermostatSettings::setEndTemperature(300.0);
     setKeyword("end_temp");
+
+    EXPECT_NO_THROW(_reader->validateInputConfiguration());
+    EXPECT_DOUBLE_EQ(ThermostatSettings::getTargetTemperature(), 0.0);
+    EXPECT_DOUBLE_EQ(ThermostatSettings::getActualTargetTemperature(), 0.0);
+}
+
+TEST_F(TestInputValidation, requiresTemperatureForVelocityInitialization)
+{
+    configureMDJob(JobType::MM_MD);
+    SimulationBoxSettings::setInitializeVelocities(InitVelocities::FORCE);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Initializing velocities requires temp, start_temp, or end_temp"
+    );
+}
+
+TEST_F(TestInputValidation, rejectsUnstableThermostatRelaxationTime)
+{
+    configureMDJob(JobType::MM_MD);
+    ThermostatSettings::setThermostatType(ThermostatType::VELOCITY_RESCALING);
+    ThermostatSettings::setTargetTemperature(300.0);
+    ThermostatSettings::setRelaxationTime(0.0001);
+    setKeyword("temp");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "The timestep must not exceed the thermostat relaxation time"
+    );
+}
+
+TEST_F(TestInputValidation, rejectsNonFiniteLangevinScale)
+{
+    configureMDJob(JobType::MM_MD);
+    ThermostatSettings::setThermostatType(ThermostatType::LANGEVIN);
+    ThermostatSettings::setTargetTemperature(300.0);
+    ThermostatSettings::setFriction(std::numeric_limits<double>::max());
+    setKeyword("temp");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Langevin thermostat parameters produce a non-finite random-force "
+        "scale"
+    );
+}
+
+TEST_F(TestInputValidation, rejectsNonFiniteLangevinRampScale)
+{
+    configureMDJob(JobType::MM_MD);
+    ThermostatSettings::setThermostatType(ThermostatType::LANGEVIN);
+    ThermostatSettings::setTargetTemperature(300.0);
+    ThermostatSettings::setStartTemperature(std::numeric_limits<double>::max());
+    setKeyword("temp");
+    setKeyword("start_temp");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Langevin thermostat parameters produce a non-finite random-force "
+        "scale"
+    );
+}
+
+TEST_F(TestInputValidation, rejectsCellListWithoutCoulombCutoff)
+{
+    configureMDJob(JobType::MM_MD);
+    _engine->getCellList().activate();
+    PotentialSettings::setCoulombRadiusCutOff(0.0);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "An active cell list requires rcoulomb to be greater than zero"
+    );
+}
+
+TEST_F(TestInputValidation, rejectsCellListForPureQM)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::DFTBPLUS);
+    _engine->getCellList().activate();
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Cell lists are not available for pure QM simulations"
+    );
+}
+
+TEST_F(TestInputValidation, rejectsZeroTemperatureForNoseHoover)
+{
+    ThermostatSettings::setThermostatType(ThermostatType::NOSE_HOOVER);
+    ThermostatSettings::setTargetTemperature(0.0);
+    setKeyword("temp");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Nose-Hoover target temperature must be greater than zero"
+    );
+}
+
+TEST_F(TestInputValidation, acceptsZeroTemperatureForBerendsen)
+{
+    ThermostatSettings::setThermostatType(ThermostatType::BERENDSEN);
+    ThermostatSettings::setTargetTemperature(0.0);
+    setKeyword("temp");
 
     EXPECT_NO_THROW(_reader->validateInputConfiguration());
 }
@@ -256,12 +422,39 @@ TEST_F(TestInputValidation, acceptsReplicaCountForRingPolymer)
     EXPECT_NO_THROW(_reader->validateInputConfiguration());
 }
 
+TEST_F(TestInputValidation, requiresSlaterKosterSetForAseDftbPlus)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::ASEDFTBPLUS);
+    QMSettings::setSlakosType(SlakosType::NONE);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "ASE-DFTB+ requires slakos to be 3ob, matsci, or custom"
+    );
+}
+
+TEST_F(TestInputValidation, requiresPathForCustomSlaterKosterParameters)
+{
+    configureMDJob(JobType::QM_MD);
+    QMSettings::setQMMethod(QMMethod::ASEDFTBPLUS);
+    QMSettings::setSlakosType(SlakosType::CUSTOM);
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        InputFileException,
+        "Custom Slater-Koster parameters require the \"slakos_path\" keyword"
+    );
+}
+
 TEST_F(TestInputValidation, rejectsHubbardDerivativesWithoutThirdOrder)
 {
     configureMDJob(JobType::QM_MD);
     QMSettings::setQMMethod(QMMethod::ASEDFTBPLUS);
     QMSettings::setSlakosType(SlakosType::CUSTOM);
     QMSettings::setUseThirdOrderDftb(false);
+    setKeyword("slakos_path");
     setKeyword("third_order");
     setKeyword("hubbard_derivs");
 
@@ -279,6 +472,7 @@ TEST_F(TestInputValidation, acceptsHubbardDerivativesWithThirdOrder)
     QMSettings::setQMMethod(QMMethod::ASEDFTBPLUS);
     QMSettings::setSlakosType(SlakosType::CUSTOM);
     QMSettings::setUseThirdOrderDftb(true);
+    setKeyword("slakos_path");
     setKeyword("third_order");
     setKeyword("hubbard_derivs");
 
@@ -403,4 +597,90 @@ TEST_F(TestInputValidation, acceptsValidConditionalKeywords)
     setKeyword("temp");
 
     EXPECT_NO_THROW(_reader->validateInputConfiguration());
+}
+
+TEST_F(TestInputValidation, requiresDecayForConstantDecayOptimization)
+{
+    Settings::setJobtype(JobType::MM_OPT);
+    TimingsSettings::setNumberOfSteps(100);
+    OptimizerSettings::setLearningRateStrategy(LREnum::CONSTANT_DECAY);
+    setKeyword("nstep");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        UserInputException,
+        "The constant-decay learning rate strategy requires "
+        "learning-rate-decay."
+    );
+}
+
+TEST_F(TestInputValidation, requiresDecayForExponentialDecayOptimization)
+{
+    Settings::setJobtype(JobType::MM_OPT);
+    TimingsSettings::setNumberOfSteps(100);
+    OptimizerSettings::setLearningRateStrategy(LREnum::EXPONENTIAL_DECAY);
+    setKeyword("nstep");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        UserInputException,
+        "The exponential-decay learning rate strategy requires "
+        "learning-rate-decay."
+    );
+}
+
+TEST_F(TestInputValidation, acceptsConstantOptimizationWithoutDecay)
+{
+    Settings::setJobtype(JobType::MM_OPT);
+    TimingsSettings::setNumberOfSteps(100);
+    OptimizerSettings::setLearningRateStrategy(LREnum::CONSTANT);
+    setKeyword("nstep");
+
+    EXPECT_NO_THROW(_reader->validateInputConfiguration());
+}
+
+TEST_F(TestInputValidation, rejectsUnimplementedLineSearchOptimization)
+{
+    Settings::setJobtype(JobType::MM_OPT);
+    TimingsSettings::setNumberOfSteps(100);
+    OptimizerSettings::setLearningRateStrategy(LREnum::LINESEARCH_WOLFE);
+    setKeyword("nstep");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        UserInputException,
+        "The Wolfe line search learning rate strategy is not yet implemented"
+    );
+}
+
+TEST_F(TestInputValidation, rejectsMissingLearningRateStrategy)
+{
+    Settings::setJobtype(JobType::MM_OPT);
+    TimingsSettings::setNumberOfSteps(100);
+    OptimizerSettings::setLearningRateStrategy(LREnum::NONE);
+    setKeyword("nstep");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        UserInputException,
+        "In order to run the optimizer, you need to specify a learning rate "
+        "strategy."
+    );
+}
+
+TEST_F(TestInputValidation, rejectsOverlappingLearningRateBounds)
+{
+    Settings::setJobtype(JobType::MM_OPT);
+    TimingsSettings::setNumberOfSteps(100);
+    OptimizerSettings::setLearningRateStrategy(LREnum::CONSTANT);
+    OptimizerSettings::setMinLearningRate(0.5);
+    OptimizerSettings::setMaxLearningRate(0.5);
+    setKeyword("nstep");
+
+    ASSERT_THROW_MSG(
+        _reader->validateInputConfiguration(),
+        UserInputException,
+        "The minimum learning rate 0.5 is greater or equal to the maximum "
+        "learning rate 0.5, which is not allowed."
+    );
 }

--- a/tests/src/setup/testOptimizerSetup.cpp
+++ b/tests/src/setup/testOptimizerSetup.cpp
@@ -26,6 +26,8 @@
 #include "convergence.hpp"
 #include "convergenceSettings.hpp"
 #include "exceptions.hpp"
+#include "hessianEngine.hpp"
+#include "hessianSettings.hpp"
 #include "optEngine.hpp"
 #include "optimizerSettings.hpp"
 #include "optimizerSetup.hpp"
@@ -47,6 +49,7 @@ namespace
         OptimizerSettings::setLearningRateStrategy(LREnum::CONSTANT);
         OptimizerSettings::setInitialLearningRate(0.01);
         OptimizerSettings::setMinLearningRate(0.0);
+        OptimizerSettings::setMaxLearningRate(1.0);
         OptimizerSettings::setLRUpdateFrequency(1);
     }
 }   // namespace
@@ -250,4 +253,33 @@ TEST_F(TestSetup, setupWiresOptimizerAndLearningRateAndEvaluator)
 
     OptimizerSetup s(dynamic_cast<engine::OptEngine &>(*_engine));
     EXPECT_NO_THROW(s.setup());
+}
+
+/* ---------- Hessian optimization ---------- */
+
+TEST_F(TestSetup, hessianOptimizationValidatesLearningRateStrategy)
+{
+    resetOptimizerSettings();
+    Settings::setJobtype(JobType::MM_HESSIAN);
+    HessianSettings::setOptimizeBeforeHessian(true);
+    OptimizerSettings::setLearningRateStrategy(LREnum::NONE);
+
+    engine::HessianEngine hessianEngine;
+    EXPECT_THROW(hessianEngine.run(), UserInputException);
+
+    HessianSettings::setOptimizeBeforeHessian(false);
+}
+
+TEST_F(TestSetup, hessianOptimizationValidatesLearningRateBounds)
+{
+    resetOptimizerSettings();
+    Settings::setJobtype(JobType::MM_HESSIAN);
+    HessianSettings::setOptimizeBeforeHessian(true);
+    OptimizerSettings::setMinLearningRate(0.5);
+    OptimizerSettings::setMaxLearningRate(0.5);
+
+    engine::HessianEngine hessianEngine;
+    EXPECT_THROW(hessianEngine.run(), UserInputException);
+
+    HessianSettings::setOptimizeBeforeHessian(false);
 }


### PR DESCRIPTION
Closes #338.

Depends on #336.

- validate thermostat, manostat, QM, velocity, and cell-list relationships
- reject non-finite Langevin parameters without mutating temperature settings
- centralize optimizer validation for standard and Hessian workflows
- document the ASE-DFTB+ slakos requirement

Tests:
- testInputValidation
- testOptimizerSetup
- five shuffled repeats