### PR TITLE
build: remove test runtime dependencies

### DIFF
--- a/include/input/restartFileReader/atomSection.hpp
+++ b/include/input/restartFileReader/atomSection.hpp
@@ -29,12 +29,8 @@
 #include "restartFileSection.hpp"   // for RestartFileSection
 #include "typeAliases.hpp"          // for strings
 
-#ifdef WITH_TESTS
-#include <gtest/gtest_prod.h>   // for FRIEND_TEST
-
 class TestAtomSection_testProcessAtomLine_Test;     // Friend test class
 class TestAtomSection_testProcessQMAtomLine_Test;   // Friend test class
-#endif
 
 namespace input::restartFile
 {
@@ -54,8 +50,8 @@ namespace input::restartFile
         void setAtomPropertyVectors(pq::strings &, pq::SharedAtom &) const;
 
 #ifdef WITH_TESTS
-        FRIEND_TEST(::TestAtomSection, testProcessAtomLine);
-        FRIEND_TEST(::TestAtomSection, testProcessQMAtomLine);
+        friend class ::TestAtomSection_testProcessAtomLine_Test;
+        friend class ::TestAtomSection_testProcessQMAtomLine_Test;
 #endif
 
        public:

--- a/include/output/output.hpp
+++ b/include/output/output.hpp
@@ -28,10 +28,6 @@
 #include <string>        // for string
 #include <string_view>   // for string_view
 
-#ifdef WITH_TESTS
-#include <gtest/gtest_prod.h>   // for FRIEND_TEST
-#endif
-
 class TestOutput_testSpecialSetFilename_Test;   // Friend test class
 
 namespace output
@@ -58,7 +54,7 @@ namespace output
         void close();
 
 #ifdef WITH_TESTS
-        FRIEND_TEST(::TestOutput, testSpecialSetFilename);
+        friend class ::TestOutput_testSpecialSetFilename_Test;
 #endif
 
         /***************************

--- a/src/input/inputFileParser/CMakeLists.txt
+++ b/src/input/inputFileParser/CMakeLists.txt
@@ -41,13 +41,6 @@ target_link_libraries(inputFileParser
     references
 )
 
-if(BUILD_WITH_TESTS)
-    target_link_libraries(inputFileParser
-        PUBLIC
-        gtest
-    )
-endif()
-
 install(TARGETS inputFileParser
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/
 )

--- a/src/input/restartFileReader/CMakeLists.txt
+++ b/src/input/restartFileReader/CMakeLists.txt
@@ -20,13 +20,6 @@ target_link_libraries(restartFileReader
     linearAlgebra
 )
 
-if(BUILD_WITH_TESTS)
-    target_link_libraries(restartFileReader
-        PUBLIC
-        gtest
-    )
-endif()
-
 install(TARGETS restartFileReader
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/
 )

--- a/src/output/CMakeLists.txt
+++ b/src/output/CMakeLists.txt
@@ -39,13 +39,6 @@ target_link_libraries(output
     thermostat
 )
 
-if(BUILD_WITH_TESTS)
-    target_link_libraries(output
-        PUBLIC
-        gtest
-    )
-endif()
-
 install(TARGETS output
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/
 )

--- a/src/setup/CMakeLists.txt
+++ b/src/setup/CMakeLists.txt
@@ -52,13 +52,6 @@ target_link_libraries(setup
     optimization
 )
 
-if(BUILD_WITH_TESTS)
-    target_link_libraries(setup
-        PUBLIC
-        gtest
-    )
-endif()
-
 if(BUILD_WITH_MPI)
     target_link_libraries(setup
         PRIVATE

--- a/tests/src/main/CMakeLists.txt
+++ b/tests/src/main/CMakeLists.txt
@@ -19,7 +19,3 @@ if(BUILD_WITH_KOKKOS)
         ${Kokkos_INCLUDE_DIRS_RET}
     )
 endif()
-
-install(TARGETS pq_test_main
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/
-)


### PR DESCRIPTION
Closes #352.

- replace GTest friend macros with explicit friend declarations
- remove public GTest links from production libraries
- keep pq_test_main out of install rules

Tests:
- affected production targets
- testAtomSection
- testOutput
- formatting and license checks