### PR TITLE
fix: quote external QM paths

### DIFF
--- a/include/QM/external/externalQMRunner.hpp
+++ b/include/QM/external/externalQMRunner.hpp
@@ -43,7 +43,7 @@ namespace QM
         const std::string _singularity = SINGULARITY_;
         const std::string _staticBuild = STATIC_BUILD_;
 
-        void executeCommand(
+        virtual void executeCommand(
             std::string_view command,
             std::string_view program
         ) const;

--- a/include/utilities/stringUtilities.hpp
+++ b/include/utilities/stringUtilities.hpp
@@ -46,6 +46,7 @@ namespace utilities
     std::string toLowerAndReplaceDashesCopy(std::string);
     std::string toLowerAndReplaceDashesCopy(std::string_view);
     std::string firstLetterToUpperCaseCopy(std::string);
+    std::string shellQuote(std::string_view);
 
     void addSpaces(std::string &, const std::string &, const size_t);
 

--- a/src/QM/external/dftbplusRunner.cpp
+++ b/src/QM/external/dftbplusRunner.cpp
@@ -143,9 +143,9 @@ void DFTBPlusRunner::execute()
 
     const auto command = std::format(
         "{} 0 {} 0 0 0 {}",
-        scriptFile,
+        shellQuote(scriptFile),
         reuseCharges,
-        FileSettings::getDFTBFileName()
+        shellQuote(FileSettings::getDFTBFileName())
     );
     executeCommand(command, "DFTB+");
 

--- a/src/QM/external/pyscfRunner.cpp
+++ b/src/QM/external/pyscfRunner.cpp
@@ -83,7 +83,11 @@ void PySCFRunner::execute()
             scriptFileName
         ));
 
-    const auto command = std::format("python {} > pyscf.out", scriptFileName);
+    const auto command = std::format(
+        "python {} > {}",
+        shellQuote(scriptFileName),
+        shellQuote("pyscf.out")
+    );
 
     executeCommand(command, "PySCF");
 }

--- a/src/QM/external/turbomoleRunner.cpp
+++ b/src/QM/external/turbomoleRunner.cpp
@@ -92,7 +92,8 @@ void TurbomoleRunner::execute()
 
     const auto reuseCharges = _isFirstExecution ? 1 : 0;
 
-    const auto command = std::format("{} 0 {} 0 0 0", scriptFile, reuseCharges);
+    const auto command =
+        std::format("{} 0 {} 0 0 0", shellQuote(scriptFile), reuseCharges);
     executeCommand(command, "Turbomole");
 
     _isFirstExecution = false;

--- a/src/utilities/stringUtilities.cpp
+++ b/src/utilities/stringUtilities.cpp
@@ -198,6 +198,29 @@ std::string utilities::firstLetterToUpperCaseCopy(std::string myString)
 }
 
 /**
+ * @brief quotes one argument for a POSIX shell command
+ *
+ * @param argument
+ * @return std::string
+ */
+std::string utilities::shellQuote(const std::string_view argument)
+{
+    std::string quoted{"'"};
+    quoted.reserve(argument.size() + 2);
+
+    for (const auto character : argument)
+    {
+        if (character == '\'')
+            quoted += "'\"'\"'";
+        else
+            quoted += character;
+    }
+
+    quoted += '\'';
+    return quoted;
+}
+
+/**
  * @brief checks if a file exists and can be opened
  *
  * @param filename

--- a/tests/src/QM/testExternalQMRunner.cpp
+++ b/tests/src/QM/testExternalQMRunner.cpp
@@ -36,9 +36,12 @@
 #include "externalQMRunner.hpp"
 #include "fileSettings.hpp"
 #include "physicalData.hpp"
+#include "pyscfRunner.hpp"
 #include "qmSettings.hpp"
 #include "settings.hpp"
 #include "simulationBox.hpp"
+#include "stringUtilities.hpp"
+#include "turbomoleRunner.hpp"
 
 using customException::QMRunnerException;
 using physicalData::PhysicalData;
@@ -94,6 +97,25 @@ namespace
         [[nodiscard]] bool sawStaleResults() const { return _sawStaleResults; }
     };
 
+    template <class Runner>
+    class CommandCaptureRunner : public Runner
+    {
+       private:
+        mutable std::string _command;
+
+       protected:
+        void executeCommand(
+            const std::string_view command,
+            const std::string_view
+        ) const override
+        {
+            _command = command;
+        }
+
+       public:
+        [[nodiscard]] const std::string &getCommand() const { return _command; }
+    };
+
     class ExternalQMRunnerTest : public testing::Test
     {
        protected:
@@ -104,10 +126,12 @@ namespace
         ExternalQMRunnerHarness _runner;
         QM::DFTBPlusRunner      _dftbRunner;
 
-        QMMethod _qmMethod;
-        JobType  _jobType;
-        bool     _removeNetForce;
-        double   _timeLimit;
+        QMMethod    _qmMethod;
+        JobType     _jobType;
+        bool        _removeNetForce;
+        double      _timeLimit;
+        std::string _qmScript;
+        std::string _dftbFile;
 
         void SetUp() override
         {
@@ -115,12 +139,14 @@ namespace
             _jobType        = Settings::getJobtype();
             _removeNetForce = QMSettings::getRemoveNetForce();
             _timeLimit      = QMSettings::getQMLoopTimeLimit();
+            _qmScript       = QMSettings::getQMScript();
+            _dftbFile       = FileSettings::getDFTBFileName();
             _originalPath   = std::filesystem::current_path();
 
             const auto stamp =
                 std::chrono::steady_clock::now().time_since_epoch().count();
             _workPath = std::filesystem::temp_directory_path() /
-                        ("pq-external-qm-" + std::to_string(stamp));
+                        ("pq external qm; " + std::to_string(stamp));
             ASSERT_TRUE(std::filesystem::create_directory(_workPath));
             std::filesystem::current_path(_workPath);
 
@@ -141,12 +167,32 @@ namespace
             QMSettings::setQMMethod(_qmMethod);
             QMSettings::setRemoveNetForce(_removeNetForce);
             QMSettings::setQMLoopTimeLimit(_timeLimit);
+            QMSettings::setQMScript(_qmScript);
+            FileSettings::setDFTBFileName(_dftbFile);
             Settings::setJobtype(_jobType);
 
             std::filesystem::current_path(_originalPath);
             std::error_code error;
             std::filesystem::remove_all(_workPath, error);
             EXPECT_FALSE(error);
+        }
+
+        std::filesystem::path configureQuotedScript(
+            QM::ExternalQMRunner &runner
+        ) const
+        {
+            const auto scriptDirectory =
+                _workPath / "working path; $(touch qm-injected)";
+            std::filesystem::create_directory(scriptDirectory);
+
+            const auto scriptName = "runner's script; touch qm-injected; #";
+            const auto scriptFile = scriptDirectory / scriptName;
+            writeFile(scriptFile.string(), "");
+
+            runner.setScriptPath(scriptDirectory.string() + '/');
+            QMSettings::setQMScript(scriptName);
+
+            return scriptFile;
         }
     };
 }   // namespace
@@ -164,6 +210,58 @@ TEST_F(ExternalQMRunnerTest, propagatesCommandFailure)
     {
         EXPECT_THAT(error.what(), HasSubstr("External QM command failed"));
     }
+}
+
+TEST_F(ExternalQMRunnerTest, quotesDftbCommandArguments)
+{
+    auto       runner    = CommandCaptureRunner<QM::DFTBPlusRunner>();
+    const auto path      = configureQuotedScript(runner);
+    const auto inputFile = std::string("input file; touch qm-injected");
+    FileSettings::setDFTBFileName(inputFile);
+
+    runner.execute();
+
+    EXPECT_EQ(
+        std::format(
+            "{} 0 1 0 0 0 {}",
+            utilities::shellQuote(path.string()),
+            utilities::shellQuote(inputFile)
+        ),
+        runner.getCommand()
+    );
+    EXPECT_FALSE(std::filesystem::exists(_workPath / "qm-injected"));
+}
+
+TEST_F(ExternalQMRunnerTest, quotesPyscfCommandArguments)
+{
+    auto       runner = CommandCaptureRunner<QM::PySCFRunner>();
+    const auto path   = configureQuotedScript(runner);
+
+    runner.execute();
+
+    EXPECT_EQ(
+        std::format(
+            "python {} > {}",
+            utilities::shellQuote(path.string()),
+            utilities::shellQuote("pyscf.out")
+        ),
+        runner.getCommand()
+    );
+    EXPECT_FALSE(std::filesystem::exists(_workPath / "qm-injected"));
+}
+
+TEST_F(ExternalQMRunnerTest, quotesTurbomoleCommandArguments)
+{
+    auto       runner = CommandCaptureRunner<QM::TurbomoleRunner>();
+    const auto path   = configureQuotedScript(runner);
+
+    runner.execute();
+
+    EXPECT_EQ(
+        std::format("{} 0 1 0 0 0", utilities::shellQuote(path.string())),
+        runner.getCommand()
+    );
+    EXPECT_FALSE(std::filesystem::exists(_workPath / "qm-injected"));
 }
 
 TEST_F(ExternalQMRunnerTest, removesStaleResultsBeforeExecution)

--- a/tests/src/utilities/testStringUtilities.cpp
+++ b/tests/src/utilities/testStringUtilities.cpp
@@ -164,6 +164,16 @@ TEST(TestStringUtilities, firstLetterToUpperCaseCopy)
     EXPECT_EQ("Test", utilities::firstLetterToUpperCaseCopy(line));
 }
 
+TEST(TestStringUtilities, shellQuote)
+{
+    EXPECT_EQ("''", utilities::shellQuote(""));
+    EXPECT_EQ("'path with spaces'", utilities::shellQuote("path with spaces"));
+    EXPECT_EQ(
+        "'a'\"'\"'b; touch nope'",
+        utilities::shellQuote("a'b; touch nope")
+    );
+}
+
 /**
  * @brief test check if file exists
  *


### PR DESCRIPTION
Closes #362.

Depends on #335.

- add POSIX-safe shell argument quoting
- quote DFTB+, PySCF, and Turbomole paths
- cover spaces, apostrophes, and shell metacharacters

Tests:
- testExternalQMRunner
- testStringUtilities