### PR TITLE
feat: catalog external QM scripts

### DIFF
--- a/apps/externalQMScripts.hpp
+++ b/apps/externalQMScripts.hpp
@@ -1,0 +1,149 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#ifndef _EXTERNAL_QM_SCRIPTS_HPP_
+
+#define _EXTERNAL_QM_SCRIPTS_HPP_
+
+#include <algorithm>
+#include <array>
+#include <span>
+#include <string_view>
+
+#include "qmSettings.hpp"
+
+namespace cli
+{
+    struct ExternalQMScriptInfo
+    {
+        std::string_view name;
+        std::string_view label;
+        std::string_view requiredFileKeyword;
+        std::string_view requiredWorkingFile;
+    };
+
+    inline constexpr auto dftbPlusScripts = std::array{ExternalQMScriptInfo{
+        "dftbplus_periodic_stress",
+        "DFTB+ periodic stress",
+        "dftb_file",
+        ""
+    }};
+
+    inline constexpr auto pyScfScripts = std::array{
+        ExternalQMScriptInfo{"pyscf_hf.py", "UHF / STO-3G", "", ""},
+        ExternalQMScriptInfo{"pyscf_mp2.py", "UMP2 / 6-311++G**", "", ""}
+    };
+
+    inline constexpr auto turbomoleScripts = std::array{ExternalQMScriptInfo{
+        "turbomole_rimp2",
+        "RI-MP2",
+        "",
+        "tm_define.template"
+    }};
+
+    inline constexpr auto externalQMMethods = std::array{
+        settings::QMMethod::DFTBPLUS,
+        settings::QMMethod::PYSCF,
+        settings::QMMethod::TURBOMOLE
+    };
+
+    inline std::span<const ExternalQMScriptInfo> externalQMScripts(
+        const settings::QMMethod method
+    )
+    {
+        using enum settings::QMMethod;
+
+        switch (method)
+        {
+            case DFTBPLUS: return dftbPlusScripts;
+            case PYSCF: return pyScfScripts;
+            case TURBOMOLE: return turbomoleScripts;
+
+            case NONE:
+            case ASEDFTBPLUS:
+            case ASEXTB:
+            case MACE:
+            case FENNOL: return {};
+        }
+
+        return {};
+    }
+
+    inline std::string_view externalQMProgramName(
+        const settings::QMMethod method
+    )
+    {
+        using enum settings::QMMethod;
+
+        switch (method)
+        {
+            case DFTBPLUS: return "dftbplus";
+            case PYSCF: return "pyscf";
+            case TURBOMOLE: return "turbomole";
+
+            case NONE:
+            case ASEDFTBPLUS:
+            case ASEXTB:
+            case MACE:
+            case FENNOL: return "";
+        }
+
+        return "";
+    }
+
+    inline std::string_view recommendedExternalQMScript(
+        const settings::QMMethod method
+    )
+    {
+        using enum settings::QMMethod;
+
+        switch (method)
+        {
+            case DFTBPLUS: return dftbPlusScripts.front().name;
+            case TURBOMOLE: return turbomoleScripts.front().name;
+
+            case NONE:
+            case ASEDFTBPLUS:
+            case ASEXTB:
+            case PYSCF:
+            case MACE:
+            case FENNOL: return "";
+        }
+
+        return "";
+    }
+
+    inline bool isExternalQMScript(
+        const settings::QMMethod method,
+        const std::string_view   script
+    )
+    {
+        const auto scripts = externalQMScripts(method);
+
+        return std::ranges::any_of(
+            scripts,
+            [script](const auto &candidate) { return candidate.name == script; }
+        );
+    }
+}   // namespace cli
+
+#endif   // _EXTERNAL_QM_SCRIPTS_HPP_

--- a/tests/src/settings/CMakeLists.txt
+++ b/tests/src/settings/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(source_files
     testPotentialSettings.cpp
     testQMSettings.cpp
+    testExternalQMScripts.cpp
     testOutputFileSettings.cpp
     testThermostatSettings.cpp
     testManostatSettings.cpp
@@ -32,6 +33,11 @@ foreach(source_file ${source_files})
 
     set_property(TEST ${test_name} PROPERTY LABELS settings)
 endforeach()
+
+target_include_directories(testExternalQMScripts
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/apps
+)
 
 if(${BUILD_WITH_GCOVR})
     include(CodeCoverage)

--- a/tests/src/settings/testExternalQMScripts.cpp
+++ b/tests/src/settings/testExternalQMScripts.cpp
@@ -1,0 +1,74 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "externalQMScripts.hpp"
+
+using settings::QMMethod;
+
+TEST(ExternalQMScriptsTest, catalogsSupportedPrograms)
+{
+    ASSERT_EQ(cli::externalQMMethods.size(), 3);
+    EXPECT_EQ(
+        cli::externalQMProgramName(cli::externalQMMethods[0]),
+        "dftbplus"
+    );
+    EXPECT_EQ(cli::externalQMProgramName(cli::externalQMMethods[1]), "pyscf");
+    EXPECT_EQ(
+        cli::externalQMProgramName(cli::externalQMMethods[2]),
+        "turbomole"
+    );
+}
+
+TEST(ExternalQMScriptsTest, describesBundledScripts)
+{
+    const auto dftbPlus = cli::externalQMScripts(QMMethod::DFTBPLUS);
+    ASSERT_EQ(dftbPlus.size(), 1);
+    EXPECT_EQ(dftbPlus.front().name, "dftbplus_periodic_stress");
+    EXPECT_EQ(dftbPlus.front().requiredFileKeyword, "dftb_file");
+    EXPECT_EQ(
+        cli::recommendedExternalQMScript(QMMethod::DFTBPLUS),
+        dftbPlus.front().name
+    );
+
+    const auto pyScf = cli::externalQMScripts(QMMethod::PYSCF);
+    ASSERT_EQ(pyScf.size(), 2);
+    EXPECT_EQ(pyScf.front().name, "pyscf_hf.py");
+    EXPECT_EQ(pyScf.back().name, "pyscf_mp2.py");
+    EXPECT_TRUE(cli::recommendedExternalQMScript(QMMethod::PYSCF).empty());
+
+    const auto turbomole = cli::externalQMScripts(QMMethod::TURBOMOLE);
+    ASSERT_EQ(turbomole.size(), 1);
+    EXPECT_EQ(turbomole.front().name, "turbomole_rimp2");
+    EXPECT_EQ(turbomole.front().requiredWorkingFile, "tm_define.template");
+}
+
+TEST(ExternalQMScriptsTest, identifiesCatalogEntries)
+{
+    EXPECT_TRUE(
+        cli::isExternalQMScript(QMMethod::DFTBPLUS, "dftbplus_periodic_stress")
+    );
+    EXPECT_FALSE(cli::isExternalQMScript(QMMethod::DFTBPLUS, "pyscf_hf.py"));
+    EXPECT_TRUE(cli::externalQMScripts(QMMethod::MACE).empty());
+    EXPECT_TRUE(cli::externalQMProgramName(QMMethod::MACE).empty());
+}


### PR DESCRIPTION
Closes #356.

Depends on #337.

- centralize bundled script names and labels
- record required input keywords and working files
- expose recommended scripts per backend
- cover the catalog with a focused unit test

Test:
- testExternalQMScripts