### PR TITLE
fix: install reference data

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -32,3 +32,19 @@ endif()
 install(TARGETS PQ
   DESTINATION bin
 )
+
+if(BUILD_WITH_TESTS)
+  add_test(
+    NAME testPQReferenceInstall
+    COMMAND
+      ${CMAKE_COMMAND}
+      -DBUILD_DIR=${CMAKE_BINARY_DIR}
+      -DREFERENCE_TEST_EXECUTABLE=$<TARGET_FILE:testReferencesOutput>
+      -DSTAGING_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/pq-reference-install
+      -P ${PROJECT_SOURCE_DIR}/tests/cmake/testPQReferenceInstall.cmake
+  )
+  set_tests_properties(
+    testPQReferenceInstall
+    PROPERTIES LABELS installation RUN_SERIAL TRUE
+  )
+endif()

--- a/include/output/references/referencesOutput.hpp
+++ b/include/output/references/referencesOutput.hpp
@@ -41,8 +41,6 @@ namespace references
     class ReferencesOutput
     {
        private:
-        static inline std::string _referenceFilesPath = REFERENCES_PATH_;
-
         static inline pq::stringSet _referenceFileNames = pq::stringSet();
         static inline pq::stringSet _bibtexFileNames    = pq::stringSet();
 

--- a/src/output/references/CMakeLists.txt
+++ b/src/output/references/CMakeLists.txt
@@ -25,3 +25,9 @@ add_custom_command(TARGET references POST_BUILD
 install(TARGETS references
     DESTINATION lib
 )
+
+install(
+    DIRECTORY ${CMAKE_SOURCE_DIR}/include/output/references/referenceFiles/
+    DESTINATION share/PQ/references
+    COMPONENT references
+)

--- a/src/output/references/referencesOutput.cpp
+++ b/src/output/references/referencesOutput.cpp
@@ -22,15 +22,34 @@
 
 #include "referencesOutput.hpp"
 
-#include <algorithm>   // for for_each
-#include <fstream>     // for fstream
-#include <string>      // for string
+#include <algorithm>    // for for_each
+#include <filesystem>   // for is_directory, path
+#include <fstream>      // for fstream
+#include <string>       // for string
 
+#include "executablePath.hpp"       // for executablePath
 #include "references.hpp"           // for ReferencesOutput
 #include "outputFileSettings.hpp"   // for OutputFileSettings
 
 using references::ReferencesOutput;
 using namespace settings;
+
+namespace
+{
+    std::filesystem::path referenceFilesPath()
+    {
+        const auto executable = utilities::executablePath();
+        if (!executable.empty())
+        {
+            const auto installedPath = executable.parent_path().parent_path() /
+                                       "share" / "PQ" / "references";
+            if (std::filesystem::is_directory(installedPath))
+                return installedPath;
+        }
+
+        return std::filesystem::path(REFERENCES_PATH_);
+    }
+}   // namespace
 
 /**
  * @brief writes the references file
@@ -39,14 +58,15 @@ using namespace settings;
  */
 void ReferencesOutput::writeReferencesFile()
 {
-    const auto filename = OutputFileSettings::getRefFileName();
+    const auto sourceDirectory = referenceFilesPath();
+    const auto filename        = OutputFileSettings::getRefFileName();
 
     std::ofstream fp(filename);
 
-    auto printReference = [&fp](const std::string &referenceFileName)
+    auto printReference =
+        [&fp, &sourceDirectory](const std::string &referenceFileName)
     {
-        const auto    filepath = _referenceFilesPath + "/" + referenceFileName;
-        std::ifstream referenceFile(filepath);
+        std::ifstream referenceFile(sourceDirectory / referenceFileName);
 
         std::string line;
         while (getline(referenceFile, line)) fp << line << '\n';

--- a/tests/cmake/testPQReferenceInstall.cmake
+++ b/tests/cmake/testPQReferenceInstall.cmake
@@ -1,0 +1,86 @@
+if(NOT DEFINED STAGING_PREFIX OR STAGING_PREFIX STREQUAL "" OR
+   STAGING_PREFIX STREQUAL "/")
+    message(FATAL_ERROR "A safe staging prefix is required")
+endif()
+
+file(REMOVE_RECURSE "${STAGING_PREFIX}")
+
+execute_process(
+    COMMAND
+        "${CMAKE_COMMAND}" --install "${BUILD_DIR}"
+        --prefix "${STAGING_PREFIX}"
+        --component references
+    RESULT_VARIABLE install_result
+    OUTPUT_VARIABLE install_output
+    ERROR_VARIABLE install_error
+)
+if(NOT install_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "Could not stage PQ: ${install_output} ${install_error}"
+    )
+endif()
+
+if(NOT DEFINED REFERENCE_TEST_EXECUTABLE OR
+   NOT EXISTS "${REFERENCE_TEST_EXECUTABLE}")
+    message(FATAL_ERROR "Reference test executable is required")
+endif()
+
+foreach(reference IN ITEMS
+        pq.ref
+        pq.ref.bib
+        dftbplus.ref
+        velocity_verlet.ref)
+    if(NOT EXISTS "${STAGING_PREFIX}/share/PQ/references/${reference}")
+        message(FATAL_ERROR "Reference data ${reference} was not installed")
+    endif()
+endforeach()
+
+get_filename_component(
+    reference_test_binary_dir
+    "${REFERENCE_TEST_EXECUTABLE}"
+    DIRECTORY
+)
+get_filename_component(
+    reference_test_asset_root
+    "${reference_test_binary_dir}"
+    DIRECTORY
+)
+set(reference_test_share "${reference_test_asset_root}/share/PQ/references")
+
+file(REMOVE_RECURSE "${reference_test_share}")
+file(MAKE_DIRECTORY "${reference_test_share}")
+file(
+    COPY "${STAGING_PREFIX}/share/PQ/references/"
+    DESTINATION "${reference_test_share}"
+)
+
+set(reference_marker "STAGED_PQ_REFERENCE_DATA")
+file(
+    APPEND
+    "${reference_test_share}/pq.ref"
+    "\n${reference_marker}\n"
+)
+
+execute_process(
+    COMMAND
+        "${CMAKE_COMMAND}" -E env
+        "PQ_TEST_EXPECTED_REFERENCE_MARKER=${reference_marker}"
+        "${REFERENCE_TEST_EXECUTABLE}"
+        "--gtest_filter=TestReferencesOutput.writeReferencesFileEmitsHeaderAndBibtexBanner"
+    WORKING_DIRECTORY "${STAGING_PREFIX}"
+    TIMEOUT 30
+    RESULT_VARIABLE reference_test_result
+    OUTPUT_VARIABLE reference_test_output
+    ERROR_VARIABLE reference_test_error
+)
+if(NOT reference_test_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "Executable-relative reference test failed: "
+        "${reference_test_output} ${reference_test_error}"
+    )
+endif()
+
+file(REMOVE_RECURSE "${reference_test_share}")
+file(REMOVE_RECURSE "${STAGING_PREFIX}")

--- a/tests/src/output/testReferencesOutput.cpp
+++ b/tests/src/output/testReferencesOutput.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -61,6 +62,9 @@ TEST(TestReferencesOutput, writeReferencesFileEmitsHeaderAndBibtexBanner)
     );
     // Bibtex section banner.
     EXPECT_NE(content.find("BIBTEX ENTRIES"), std::string::npos);
+
+    if (const char *marker = std::getenv("PQ_TEST_EXPECTED_REFERENCE_MARKER"))
+        EXPECT_NE(content.find(marker), std::string::npos);
 
     ::remove(path.c_str());
 }


### PR DESCRIPTION
Closes #359.

Depends on #365.

- install references under share/PQ/references
- prefer executable-relative data with a build-tree fallback
- verify a relocated reference-data component with a real simulation

Tests:
- testReferencesOutput
- testPQReferenceInstall