### PR TITLE
fix: install bundled QM scripts

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -47,4 +47,18 @@ if(BUILD_WITH_TESTS)
     testPQReferenceInstall
     PROPERTIES LABELS installation RUN_SERIAL TRUE
   )
+
+  add_test(
+    NAME testPQExternalQMScriptInstall
+    COMMAND
+      ${CMAKE_COMMAND}
+      -DBUILD_DIR=${CMAKE_BINARY_DIR}
+      -DSCRIPT_TEST_EXECUTABLE=$<TARGET_FILE:testQMSetup>
+      -DSTAGING_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/pq-qm-script-install
+      -P ${PROJECT_SOURCE_DIR}/tests/cmake/testPQExternalQMScriptInstall.cmake
+  )
+  set_tests_properties(
+    testPQExternalQMScriptInstall
+    PROPERTIES LABELS installation RUN_SERIAL TRUE
+  )
 endif()

--- a/include/QM/external/externalQMRunner.hpp
+++ b/include/QM/external/externalQMRunner.hpp
@@ -24,11 +24,16 @@
 
 #define _EXTERNAL_QM_RUNNER_HPP_
 
+#include <string>
+#include <string_view>
+
 #include "qmRunner.hpp"
 #include "typeAliases.hpp"
 
 namespace QM
 {
+    [[nodiscard]] std::string bundledQMScriptPath(std::string_view script);
+
     /**
      * @brief ExternalQMRunner inherits from QMRunner
      *
@@ -39,6 +44,10 @@ namespace QM
         std::string       _scriptPath  = SCRIPT_PATH_;
         const std::string _singularity = SINGULARITY_;
         const std::string _staticBuild = STATIC_BUILD_;
+
+        [[nodiscard]] std::string resolveScriptPath(
+            std::string_view script
+        ) const;
 
        public:
         ExternalQMRunner()           = default;

--- a/src/QM/external/CMakeLists.txt
+++ b/src/QM/external/CMakeLists.txt
@@ -45,3 +45,10 @@ add_custom_command(TARGET externalQM POST_BUILD
 install(TARGETS externalQM
     DESTINATION lib
 )
+
+install(
+    DIRECTORY ${CMAKE_SOURCE_DIR}/src/QM/scripts/
+    DESTINATION share/PQ/scripts
+    USE_SOURCE_PERMISSIONS
+    COMPONENT qm-scripts
+)

--- a/src/QM/external/dftbplusRunner.cpp
+++ b/src/QM/external/dftbplusRunner.cpp
@@ -132,7 +132,7 @@ void DFTBPlusRunner::writeCoordsFile(SimulationBox &box)
  */
 void DFTBPlusRunner::execute()
 {
-    const auto scriptFile = _scriptPath + QMSettings::getQMScript();
+    const auto scriptFile = resolveScriptPath(QMSettings::getQMScript());
 
     if (!fileExists(scriptFile))
         throw InputFileException(

--- a/src/QM/external/externalQMRunner.cpp
+++ b/src/QM/external/externalQMRunner.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>    // for __for_each_fn, for_each
 #include <cmath>        // for isnan, isinf
+#include <filesystem>   // for is_regular_file, path
 #include <format>       // for format
 #include <fstream>      // for ofstream
 #include <string>       // for string
@@ -31,6 +32,7 @@
 
 #include "constants/conversionFactors.hpp"   // for _HARTREE_PER_BOHR_TO_KCAL_PER_MOL_PER_ANGSTROM_, _HARTREE_TO_KCAL_PER_MOL_
 #include "exceptions.hpp"                    // for InputFileException
+#include "executablePath.hpp"                // for executablePath
 #include "fileSettings.hpp"                  // for FileSettings
 #include "physicalData.hpp"                  // for PhysicalData
 #include "qmSettings.hpp"                    // for QMSettings
@@ -42,6 +44,20 @@ using namespace physicalData;
 using namespace customException;
 using namespace settings;
 using namespace constants;
+
+std::string QM::bundledQMScriptPath(const std::string_view script)
+{
+    const auto executable = utilities::executablePath();
+    if (!executable.empty())
+    {
+        const auto installedPath = executable.parent_path().parent_path() /
+                                   "share" / "PQ" / "scripts" / script;
+        if (std::filesystem::is_regular_file(installedPath))
+            return installedPath.string();
+    }
+
+    return (std::filesystem::path(SCRIPT_PATH_) / script).string();
+}
 
 /**
  * @brief run the qm engine
@@ -64,6 +80,19 @@ void ExternalQMRunner::run(SimulationBox &simBox, PhysicalData &physicalData)
     readChargeFile(simBox);
 
     readStressTensor(simBox.getBox(), physicalData);
+}
+
+std::string ExternalQMRunner::resolveScriptPath(
+    const std::string_view script
+) const
+{
+    if (_scriptPath.empty())
+        return std::string(script);
+
+    if (_scriptPath == SCRIPT_PATH_)
+        return bundledQMScriptPath(script);
+
+    return _scriptPath + std::string(script);
 }
 
 /**

--- a/src/QM/external/pyscfRunner.cpp
+++ b/src/QM/external/pyscfRunner.cpp
@@ -76,7 +76,7 @@ void PySCFRunner::writeCoordsFile(SimulationBox &box)
  */
 void PySCFRunner::execute()
 {
-    const auto scriptFileName = _scriptPath + QMSettings::getQMScript();
+    const auto scriptFileName = resolveScriptPath(QMSettings::getQMScript());
 
     if (!fileExists(scriptFileName))
         throw InputFileException(std::format(

--- a/src/QM/external/turbomoleRunner.cpp
+++ b/src/QM/external/turbomoleRunner.cpp
@@ -83,7 +83,7 @@ void TurbomoleRunner::writeCoordsFile(SimulationBox &simBox)
  */
 void TurbomoleRunner::execute()
 {
-    const auto scriptFile = _scriptPath + QMSettings::getQMScript();
+    const auto scriptFile = resolveScriptPath(QMSettings::getQMScript());
 
     if (!fileExists(scriptFile))
         throw InputFileException(std::format(

--- a/tests/cmake/testPQExternalQMScriptInstall.cmake
+++ b/tests/cmake/testPQExternalQMScriptInstall.cmake
@@ -1,0 +1,62 @@
+if(NOT DEFINED STAGING_PREFIX OR STAGING_PREFIX STREQUAL "" OR
+   STAGING_PREFIX STREQUAL "/")
+    message(FATAL_ERROR "A safe staging prefix is required")
+endif()
+
+file(REMOVE_RECURSE "${STAGING_PREFIX}")
+
+execute_process(
+    COMMAND
+        "${CMAKE_COMMAND}" --install "${BUILD_DIR}"
+        --prefix "${STAGING_PREFIX}"
+        --component qm-scripts
+    RESULT_VARIABLE install_result
+    OUTPUT_VARIABLE install_output
+    ERROR_VARIABLE install_error
+)
+if(NOT install_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "Could not stage PQ: ${install_output} ${install_error}"
+    )
+endif()
+
+foreach(script IN ITEMS
+        dftbplus_periodic_stress
+        pyscf_hf.py
+        pyscf_mp2.py
+        turbomole_rimp2)
+    if(NOT EXISTS "${STAGING_PREFIX}/share/PQ/scripts/${script}")
+        message(FATAL_ERROR "QM script ${script} was not installed")
+    endif()
+endforeach()
+
+get_filename_component(test_binary_dir "${SCRIPT_TEST_EXECUTABLE}" DIRECTORY)
+get_filename_component(test_asset_root "${test_binary_dir}/.." ABSOLUTE)
+set(test_script_dir "${test_asset_root}/share/PQ/scripts")
+file(MAKE_DIRECTORY "${test_script_dir}")
+file(
+    COPY "${STAGING_PREFIX}/share/PQ/scripts/pyscf_hf.py"
+    DESTINATION "${test_script_dir}"
+)
+
+execute_process(
+    COMMAND
+        "${CMAKE_COMMAND}" -E env
+        "PQ_TEST_EXPECTED_SCRIPT_DIR=${test_script_dir}"
+        "${SCRIPT_TEST_EXECUTABLE}"
+        "--gtest_filter=TestQMSetup.resolvesBundledQMScript"
+    RESULT_VARIABLE lookup_result
+    OUTPUT_VARIABLE lookup_output
+    ERROR_VARIABLE lookup_error
+)
+
+file(REMOVE "${test_script_dir}/pyscf_hf.py")
+file(REMOVE_RECURSE "${STAGING_PREFIX}")
+
+if(NOT lookup_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "Installed QM script lookup failed: ${lookup_output} ${lookup_error}"
+    )
+endif()

--- a/tests/src/setup/testQMSetup.cpp
+++ b/tests/src/setup/testQMSetup.cpp
@@ -22,6 +22,8 @@
 
 #include <gtest/gtest.h>   // for Test, TestInfo (ptr only), InitGoogleTest, RUN_ALL_TESTS
 
+#include <cstdlib>
+#include <filesystem>
 #include <string>        // for allocator, basic_string
 #include <string_view>   // for string_view
 
@@ -54,6 +56,20 @@ namespace
             QMSettings::setQMScript("test");
     }
 }   // namespace
+
+TEST(TestQMSetup, resolvesBundledQMScript)
+{
+    const auto script = QM::bundledQMScriptPath("pyscf_hf.py");
+
+    EXPECT_EQ(std::filesystem::path(script).filename(), "pyscf_hf.py");
+    EXPECT_TRUE(std::filesystem::is_regular_file(script));
+
+    if (const auto *expected = std::getenv("PQ_TEST_EXPECTED_SCRIPT_DIR"))
+        EXPECT_EQ(
+            std::filesystem::path(script).parent_path(),
+            std::filesystem::path(expected)
+        );
+}
 
 TEST(TestQMSetup, setupDftbplus)
 {


### PR DESCRIPTION
Closes #360.

Depends on #366.

- install the supported wrappers under share/PQ/scripts
- resolve bundled scripts relative to PQ
- preserve explicit custom paths and the build-tree fallback

Tests:
- testQMSetup
- testPQExternalQMScriptInstall