### PR TITLE
fix: install bundled Slakos data

### DIFF
--- a/.cmake/slakos.cmake
+++ b/.cmake/slakos.cmake
@@ -1,28 +1,165 @@
-include(FetchContent)
+set(
+    PQ_SLAKOS_SOURCE_DIR
+    ""
+    CACHE PATH
+    "Path to preseeded 3ob and matsci directories for offline builds"
+)
 
-function(CloneRepository repositoryURL sourceDir)
-    #Commands are left empty so that we only checkout the source and no not perform any kind of build
-    if (EXISTS ${sourceDir})
-        message("Directory ${sourceDir} already exists. Skipping cloning of ${repositoryURL}")
-        return()
-    endif()
-
-    message("Starting to clone ${repositoryURL} into ${sourceDir}")
-    execute_process(
-        COMMAND git clone ${repositoryURL} ${sourceDir}
-        RESULT_VARIABLE result
+function(ValidateSlakosSet source_dir set_name)
+    foreach(required_path IN ITEMS
+        LICENSE
+        README
+        RELEASE.md
+        CHANGELOG.md
     )
+        if(NOT EXISTS "${source_dir}/${required_path}")
+            message(
+                FATAL_ERROR
+                "${set_name} data is missing ${source_dir}/${required_path}"
+            )
+        endif()
+    endforeach()
 
-    if(NOT ${result} EQUAL 0)
-        message(FATAL_ERROR "Failed to clone from ${repositoryURL}")
+    if(NOT IS_DIRECTORY "${source_dir}/skfiles")
+        message(
+            FATAL_ERROR
+            "${set_name} data is missing ${source_dir}/skfiles"
+        )
     endif()
-endfunction(CloneRepository)
 
-# fetch 3ob slakos files
-CloneRepository("https://github.com/dftbparams/3ob.git" "${CMAKE_BINARY_DIR}/external/slakos/3ob")
+    file(GLOB slakos_files "${source_dir}/skfiles/*.skf")
+    if(NOT slakos_files)
+        message(FATAL_ERROR "${set_name} contains no Slater-Koster files")
+    endif()
+endfunction()
 
-# fetch matsci files
-CloneRepository("https://github.com/dftbparams/matsci.git" "${CMAKE_BINARY_DIR}/external/slakos/matsci")
+function(CheckoutRepository repository_url source_dir revision)
+    if(NOT EXISTS "${source_dir}/.git")
+        if(EXISTS "${source_dir}")
+            message(
+                FATAL_ERROR
+                "${source_dir} exists but is not a Git checkout"
+            )
+        endif()
 
-# define directory for 3ob and matsci for preprocessor
-add_compile_definitions(__SLAKOS_DIR__="${CMAKE_BINARY_DIR}/external/slakos/")
+        execute_process(
+            COMMAND
+                "${GIT_EXECUTABLE}" clone --no-checkout
+                "${repository_url}" "${source_dir}"
+            RESULT_VARIABLE clone_result
+        )
+        if(NOT clone_result EQUAL 0)
+            message(FATAL_ERROR "Failed to clone ${repository_url}")
+        endif()
+    endif()
+
+    execute_process(
+        COMMAND
+            "${GIT_EXECUTABLE}" -C "${source_dir}"
+            cat-file -e "${revision}^{commit}"
+        RESULT_VARIABLE revision_available
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+    if(NOT revision_available EQUAL 0)
+        execute_process(
+            COMMAND
+                "${GIT_EXECUTABLE}" -C "${source_dir}"
+                fetch --depth 1 origin "${revision}"
+            RESULT_VARIABLE fetch_result
+        )
+        if(NOT fetch_result EQUAL 0)
+            message(
+                FATAL_ERROR
+                "Failed to fetch ${revision} from ${repository_url}"
+            )
+        endif()
+    endif()
+
+    execute_process(
+        COMMAND
+            "${GIT_EXECUTABLE}" -C "${source_dir}"
+            checkout --detach "${revision}"
+        RESULT_VARIABLE checkout_result
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+    if(NOT checkout_result EQUAL 0)
+        message(FATAL_ERROR "Failed to checkout ${revision} in ${source_dir}")
+    endif()
+
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" -C "${source_dir}" rev-parse HEAD
+        RESULT_VARIABLE revision_result
+        OUTPUT_VARIABLE actual_revision
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT revision_result EQUAL 0 OR
+       NOT "${actual_revision}" STREQUAL "${revision}")
+        message(
+            FATAL_ERROR
+            "Expected ${revision} in ${source_dir}, found ${actual_revision}"
+        )
+    endif()
+
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" -C "${source_dir}" status --porcelain
+        RESULT_VARIABLE status_result
+        OUTPUT_VARIABLE checkout_status
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT status_result EQUAL 0 OR NOT "${checkout_status}" STREQUAL "")
+        message(
+            FATAL_ERROR
+            "${source_dir} contains uncommitted or untracked files"
+        )
+    endif()
+endfunction()
+
+set(SLAKOS_3OB_REVISION "c5e165cb65f80f6b4e054c99e3f770ac3b8a4ecc")
+set(SLAKOS_MATSCI_REVISION "57016b4363fd6180f6edff662e5fbaa95276b4bd")
+
+if(PQ_SLAKOS_SOURCE_DIR)
+    get_filename_component(
+        SLAKOS_SOURCE_DIR
+        "${PQ_SLAKOS_SOURCE_DIR}"
+        ABSOLUTE
+        BASE_DIR "${CMAKE_SOURCE_DIR}"
+    )
+    message(STATUS "Using preseeded Slater-Koster data: ${SLAKOS_SOURCE_DIR}")
+else()
+    find_package(Git REQUIRED)
+    set(SLAKOS_SOURCE_DIR "${CMAKE_BINARY_DIR}/external/slakos")
+    CheckoutRepository(
+        "https://github.com/dftbparams/3ob.git"
+        "${SLAKOS_SOURCE_DIR}/3ob"
+        "${SLAKOS_3OB_REVISION}"
+    )
+    CheckoutRepository(
+        "https://github.com/dftbparams/matsci.git"
+        "${SLAKOS_SOURCE_DIR}/matsci"
+        "${SLAKOS_MATSCI_REVISION}"
+    )
+endif()
+
+ValidateSlakosSet("${SLAKOS_SOURCE_DIR}/3ob" "3ob")
+ValidateSlakosSet("${SLAKOS_SOURCE_DIR}/matsci" "matsci")
+
+add_compile_definitions(__SLAKOS_DIR__="${SLAKOS_SOURCE_DIR}/")
+
+foreach(slakos_set IN ITEMS 3ob matsci)
+    install(
+        DIRECTORY "${SLAKOS_SOURCE_DIR}/${slakos_set}/skfiles"
+        DESTINATION "share/PQ/slakos/${slakos_set}"
+        COMPONENT slakos
+    )
+    install(
+        FILES
+            "${SLAKOS_SOURCE_DIR}/${slakos_set}/LICENSE"
+            "${SLAKOS_SOURCE_DIR}/${slakos_set}/README"
+            "${SLAKOS_SOURCE_DIR}/${slakos_set}/RELEASE.md"
+            "${SLAKOS_SOURCE_DIR}/${slakos_set}/CHANGELOG.md"
+        DESTINATION "share/PQ/slakos/${slakos_set}"
+        COMPONENT slakos
+    )
+endforeach()

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -61,4 +61,21 @@ if(BUILD_WITH_TESTS)
     testPQExternalQMScriptInstall
     PROPERTIES LABELS installation RUN_SERIAL TRUE
   )
+
+  if(BUILD_WITH_ASE)
+    add_test(
+      NAME testPQSlakosInstall
+      COMMAND
+        ${CMAKE_COMMAND}
+        -DBUILD_DIR=${CMAKE_BINARY_DIR}
+        -DSLAKOS_SOURCE_DIR=${SLAKOS_SOURCE_DIR}
+        -DSLAKOS_TEST_EXECUTABLE=$<TARGET_FILE:testQMSettings>
+        -DSTAGING_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/pq-slakos-install
+        -P ${PROJECT_SOURCE_DIR}/tests/cmake/testPQSlakosInstall.cmake
+    )
+    set_tests_properties(
+      testPQSlakosInstall
+      PROPERTIES LABELS installation RUN_SERIAL TRUE
+    )
+  endif()
 endif()

--- a/docs/sphinx/src/installation/installation.rst
+++ b/docs/sphinx/src/installation/installation.rst
@@ -69,6 +69,9 @@ Common CMake options are listed below. Boolean options are set with ``On`` or
     * - ``BUILD_WITH_ASE``
       - ``On``
       - Build ASE-based QM runners and built-in Slater-Koster setup.
+    * - ``PQ_SLAKOS_SOURCE_DIR``
+      - unset
+      - Use preseeded ``3ob`` and ``matsci`` directories instead of cloning them.
     * - ``BUILD_WITH_PYTHON_BINDINGS``
       - ``Off``
       - Build Python bindings.
@@ -84,6 +87,14 @@ Example MPI build:
 .. code-block:: bash
 
     $ cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_WITH_MPI=On
+
+For a network-restricted ASE build, prepare a directory containing ``3ob`` and
+``matsci`` checkouts, then configure with:
+
+.. code-block:: bash
+
+    $ cmake ../ -DCMAKE_BUILD_TYPE=Release \
+        -DPQ_SLAKOS_SOURCE_DIR=/path/to/slakos
 
 .. _singularity:
 

--- a/include/output/references/referenceFiles/3ob.ref
+++ b/include/output/references/referenceFiles/3ob.ref
@@ -1,0 +1,26 @@
+3ob Slater-Koster Parameter Set (3ob-3-1)
+    © 2017 Marcus Elstner, Karlsruhe Institute of Technology.
+    Licensed under CC BY-SA 4.0.
+
+    M. Gaus, A. Goez, and M. Elstner
+    Parametrization and Benchmark of DFTB3 for Organic Molecules.
+    J. Chem. Theory Comput. 2013, 9, 338-354.
+    https://doi.org/10.1021/ct300849w
+
+    M. Gaus, X. Lu, M. Elstner, and Q. Cui
+    Parameterization of DFTB3/3OB for Sulfur and Phosphorus for
+    Chemical and Biological Applications.
+    J. Chem. Theory Comput. 2014, 10, 1518-1537.
+    https://doi.org/10.1021/ct401002w
+
+    X. Lu, M. Gaus, M. Elstner, and Q. Cui
+    Parametrization of DFTB3/3OB for Magnesium and Zinc for
+    Chemical and Biological Applications.
+    J. Phys. Chem. B 2015, 119, 1062-1082.
+    https://doi.org/10.1021/jp506557r
+
+    M. Kubillus, T. Kubař, M. Gaus, J. Řezáč, and M. Elstner
+    Parameterization of the DFTB3 Method for Br, Ca, Cl, F, I, K,
+    and Na in Organic and Biological Systems.
+    J. Chem. Theory Comput. 2015, 11, 332-342.
+    https://doi.org/10.1021/ct5009137

--- a/include/output/references/referenceFiles/3ob.ref.bib
+++ b/include/output/references/referenceFiles/3ob.ref.bib
@@ -1,0 +1,51 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% 3ob Slater-Koster parameters %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@article{Gaus2013ThreeOB,
+    author = {Gaus, Michael and Goez, Albrecht and Elstner, Marcus},
+    title = {Parametrization and Benchmark of DFTB3 for Organic Molecules},
+    journal = {Journal of Chemical Theory and Computation},
+    volume = {9},
+    number = {1},
+    pages = {338-354},
+    year = {2013},
+    doi = {10.1021/ct300849w},
+    url = {https://doi.org/10.1021/ct300849w},
+}
+
+@article{Gaus2014ThreeOB,
+    author = {Gaus, Michael and Lu, Xiya and Elstner, Marcus and Cui, Qiang},
+    title = {Parameterization of DFTB3/3OB for Sulfur and Phosphorus for Chemical and Biological Applications},
+    journal = {Journal of Chemical Theory and Computation},
+    volume = {10},
+    number = {4},
+    pages = {1518-1537},
+    year = {2014},
+    doi = {10.1021/ct401002w},
+    url = {https://doi.org/10.1021/ct401002w},
+}
+
+@article{Lu2015ThreeOB,
+    author = {Lu, Xiya and Gaus, Michael and Elstner, Marcus and Cui, Qiang},
+    title = {Parametrization of DFTB3/3OB for Magnesium and Zinc for Chemical and Biological Applications},
+    journal = {The Journal of Physical Chemistry B},
+    volume = {119},
+    number = {3},
+    pages = {1062-1082},
+    year = {2015},
+    doi = {10.1021/jp506557r},
+    url = {https://doi.org/10.1021/jp506557r},
+}
+
+@article{Kubillus2015ThreeOB,
+    author = {Kubillus, Maximilian and Kubař, Tomáš and Gaus, Michael and Řezáč, Jan and Elstner, Marcus},
+    title = {Parameterization of the DFTB3 Method for Br, Ca, Cl, F, I, K, and Na in Organic and Biological Systems},
+    journal = {Journal of Chemical Theory and Computation},
+    volume = {11},
+    number = {1},
+    pages = {332-342},
+    year = {2015},
+    doi = {10.1021/ct5009137},
+    url = {https://doi.org/10.1021/ct5009137},
+}

--- a/include/output/references/referenceFiles/matsci.ref
+++ b/include/output/references/referenceFiles/matsci.ref
@@ -1,0 +1,40 @@
+matsci Slater-Koster Parameter Set (matsci-0-3)
+    © 2016 Gotthard Seifert, TU Dresden.
+    Licensed under CC BY-SA 4.0.
+
+    J. Frenzel, A. F. Oliveira, N. Jardillier, T. Heine, and G. Seifert
+    Semi-relativistic, self-consistent charge Slater-Koster tables for
+    density-functional based tight-binding (DFTB) for materials science
+    simulations.
+    TU Dresden, 2004-2009.
+
+    J. Frenzel, A. F. Oliveira, H. A. Duarte, T. Heine, and G. Seifert
+    Structural and Electronic Properties of Bulk Gibbsite and Gibbsite
+    Surfaces. Z. Anorg. Allg. Chem. 2005, 631, 1267-1271.
+    https://doi.org/10.1002/zaac.200500051
+
+    L. Guimarães, A. N. Enyashin, J. Frenzel, T. Heine, H. A. Duarte,
+    and G. Seifert
+    Imogolite Nanotubes: Stability, Electronic, and Mechanical Properties.
+    ACS Nano 2007, 1, 362-368.
+    https://doi.org/10.1021/nn700184k
+
+    R. Luschtinetz, A. F. Oliveira, J. Frenzel, J.-O. Joswig,
+    G. Seifert, and H. A. Duarte
+    Adsorption of phosphonic and ethylphosphonic acid on aluminum oxide
+    surfaces. Surf. Sci. 2008, 602, 1347-1359.
+    https://doi.org/10.1016/j.susc.2008.01.035
+
+    R. Luschtinetz, J. Frenzel, T. Milek, and G. Seifert
+    Adsorption of Phosphonic Acid at the TiO2 Anatase (101) and
+    Rutile (110) Surfaces. J. Phys. Chem. C 2009, 113, 5730-5740.
+    https://doi.org/10.1021/jp8110343
+
+    S. Gemming, A. N. Enyashin, J. Frenzel, and G. Seifert
+    Adsorption of nucleotides on the rutile (110) surface.
+    Int. J. Mater. Res. 2010, 101, 758-764.
+    https://doi.org/10.3139/146.110337
+
+    N. Jardillier
+    PhD thesis, Université Montpellier II, 2006.
+    http://nicolas.jardillier.free.fr

--- a/include/output/references/referenceFiles/matsci.ref.bib
+++ b/include/output/references/referenceFiles/matsci.ref.bib
@@ -1,0 +1,78 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% matsci Slater-Koster parameters %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@misc{Frenzel2009Matsci,
+    author = {Frenzel, Johannes and Oliveira, Augusto F. and Jardillier, Nicolas and Heine, Thomas and Seifert, Gotthard},
+    title = {Semi-relativistic, self-consistent charge Slater-Koster tables for density-functional based tight-binding (DFTB) for materials science simulations},
+    institution = {TU Dresden},
+    year = {2009},
+}
+
+@article{Frenzel2005Matsci,
+    author = {Frenzel, Johannes and Oliveira, Augusto F. and Duarte, Helio A. and Heine, Thomas and Seifert, Gotthard},
+    title = {Structural and Electronic Properties of Bulk Gibbsite and Gibbsite Surfaces},
+    journal = {Zeitschrift für anorganische und allgemeine Chemie},
+    volume = {631},
+    number = {6-7},
+    pages = {1267-1271},
+    year = {2005},
+    doi = {10.1002/zaac.200500051},
+    url = {https://doi.org/10.1002/zaac.200500051},
+}
+
+@article{Guimaraes2007Matsci,
+    author = {Guimarães, Luciana and Enyashin, Andrey N. and Frenzel, Johannes and Heine, Thomas and Duarte, Hélio A. and Seifert, Gotthard},
+    title = {Imogolite Nanotubes: Stability, Electronic, and Mechanical Properties},
+    journal = {ACS Nano},
+    volume = {1},
+    number = {4},
+    pages = {362-368},
+    year = {2007},
+    doi = {10.1021/nn700184k},
+    url = {https://doi.org/10.1021/nn700184k},
+}
+
+@article{Luschtinetz2008Matsci,
+    author = {Luschtinetz, Regina and Oliveira, Augusto F. and Frenzel, Johannes and Joswig, Jan-Ole and Seifert, Gotthard and Duarte, Helio A.},
+    title = {Adsorption of phosphonic and ethylphosphonic acid on aluminum oxide surfaces},
+    journal = {Surface Science},
+    volume = {602},
+    number = {7},
+    pages = {1347-1359},
+    year = {2008},
+    doi = {10.1016/j.susc.2008.01.035},
+    url = {https://doi.org/10.1016/j.susc.2008.01.035},
+}
+
+@article{Luschtinetz2009Matsci,
+    author = {Luschtinetz, Regina and Frenzel, Johannes and Milek, Theodor and Seifert, Gotthard},
+    title = {Adsorption of Phosphonic Acid at the TiO2 Anatase (101) and Rutile (110) Surfaces},
+    journal = {The Journal of Physical Chemistry C},
+    volume = {113},
+    number = {14},
+    pages = {5730-5740},
+    year = {2009},
+    doi = {10.1021/jp8110343},
+    url = {https://doi.org/10.1021/jp8110343},
+}
+
+@article{Gemming2010Matsci,
+    author = {Gemming, Sibylle and Enyashin, Andrey N. and Frenzel, Johannes and Seifert, Gotthard},
+    title = {Adsorption of nucleotides on the rutile (110) surface},
+    journal = {International Journal of Materials Research},
+    volume = {101},
+    number = {6},
+    pages = {758-764},
+    year = {2010},
+    doi = {10.3139/146.110337},
+    url = {https://doi.org/10.3139/146.110337},
+}
+
+@phdthesis{Jardillier2006Matsci,
+    author = {Jardillier, Nicolas},
+    title = {PhD thesis},
+    school = {Université Montpellier II},
+    year = {2006},
+    url = {http://nicolas.jardillier.free.fr},
+}

--- a/include/output/references/references.hpp
+++ b/include/output/references/references.hpp
@@ -42,6 +42,8 @@ namespace references
 
     // QM Programs
     static constexpr char _DFTBPLUS_FILE_[]  = "dftbplus.ref";
+    static constexpr char _THREEOB_FILE_[]   = "3ob.ref";
+    static constexpr char _MATSCI_FILE_[]    = "matsci.ref";
     static constexpr char _GFN1_FILE_[]      = "gfn1.ref";
     static constexpr char _GFN2_FILE_[]      = "gfn2.ref";
     static constexpr char _IPEA1_FILE_[]     = "ipea1.ref";

--- a/src/input/inputFileParser/QMInputParser.cpp
+++ b/src/input/inputFileParser/QMInputParser.cpp
@@ -477,11 +477,13 @@ void QMInputParser::parseSlakosType(
     {
         QMSettings::setSlakosType(THREEOB);
         QMSettings::setHubbardDerivs(hubbardDerivMap3ob);
+        ReferencesOutput::addReferenceFile(_THREEOB_FILE_);
     }
 
     else if ("matsci" == slakos)
     {
         QMSettings::setSlakosType(MATSCI);
+        ReferencesOutput::addReferenceFile(_MATSCI_FILE_);
     }
 
     else if ("custom" == slakos)

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -22,9 +22,11 @@
 
 #include "qmSettings.hpp"
 
+#include <filesystem>
 #include <format>   // for std::format
 
 #include "exceptions.hpp"        // for customException
+#include "executablePath.hpp"
 #include "stringUtilities.hpp"   // for toLowerCopy
 
 using settings::MaceMode;
@@ -156,14 +158,26 @@ std::string settings::string(const SlakosType slakos)
 /**
  * @brief builds the file path for a built-in SLAKOS set (3ob/matsci)
  *
- * @details __SLAKOS_DIR__ is only defined when building with ASE support (see
- * .cmake/slakos.cmake). In a build without ASE, requesting a built-in set is
- * reported as a user input error instead of failing to compile.
+ * @details installed data next to the executable is preferred. The fetched
+ * build-tree data is used while running an uninstalled ASE build.
  */
 static std::string builtinSlakosPath([[maybe_unused]] const SlakosType type)
 {
 #ifdef __SLAKOS_DIR__
-    return __SLAKOS_DIR__ + settings::string(type) + "/skfiles/";
+    const auto executable = utilities::executablePath();
+    if (!executable.empty())
+    {
+        const auto installedPath = executable.parent_path().parent_path() /
+                                   "share" / "PQ" / "slakos" /
+                                   settings::string(type) / "skfiles";
+        if (std::filesystem::is_directory(installedPath))
+            return installedPath.string() +
+                   std::filesystem::path::preferred_separator;
+    }
+
+    const auto buildPath = std::filesystem::path(__SLAKOS_DIR__) /
+                           settings::string(type) / "skfiles";
+    return buildPath.string() + std::filesystem::path::preferred_separator;
 #else
     throw InputFileException(
         "Built-in SLAKOS sets (3ob/matsci) require building PQ with "

--- a/tests/cmake/testPQSlakosInstall.cmake
+++ b/tests/cmake/testPQSlakosInstall.cmake
@@ -1,0 +1,111 @@
+if(NOT DEFINED STAGING_PREFIX OR STAGING_PREFIX STREQUAL "" OR
+   STAGING_PREFIX STREQUAL "/")
+    message(FATAL_ERROR "A safe staging prefix is required")
+endif()
+
+file(REMOVE_RECURSE "${STAGING_PREFIX}")
+
+execute_process(
+    COMMAND
+        "${CMAKE_COMMAND}" --install "${BUILD_DIR}"
+        --prefix "${STAGING_PREFIX}"
+        --component slakos
+    RESULT_VARIABLE install_result
+    OUTPUT_VARIABLE install_output
+    ERROR_VARIABLE install_error
+)
+if(NOT install_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "Could not stage PQ: ${install_output} ${install_error}"
+    )
+endif()
+
+execute_process(
+    COMMAND
+        "${CMAKE_COMMAND}" --install "${BUILD_DIR}"
+        --prefix "${STAGING_PREFIX}"
+        --component references
+    RESULT_VARIABLE reference_install_result
+    OUTPUT_VARIABLE reference_install_output
+    ERROR_VARIABLE reference_install_error
+)
+if(NOT reference_install_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "Could not stage reference data: "
+        "${reference_install_output} ${reference_install_error}"
+    )
+endif()
+
+foreach(slakos_set IN ITEMS 3ob matsci)
+    set(slakos_root "${STAGING_PREFIX}/share/PQ/slakos/${slakos_set}")
+    foreach(metadata IN ITEMS LICENSE README RELEASE.md CHANGELOG.md)
+        if(NOT EXISTS "${slakos_root}/${metadata}")
+            message(
+                FATAL_ERROR
+                "${slakos_set} metadata ${metadata} was not installed"
+            )
+        endif()
+    endforeach()
+
+    file(
+        GLOB source_parameters
+        "${SLAKOS_SOURCE_DIR}/${slakos_set}/skfiles/*.skf"
+    )
+    file(GLOB installed_parameters "${slakos_root}/skfiles/*.skf")
+    list(LENGTH source_parameters source_parameter_count)
+    list(LENGTH installed_parameters installed_parameter_count)
+    if(NOT installed_parameter_count EQUAL source_parameter_count)
+        message(
+            FATAL_ERROR
+            "${slakos_set} installed ${installed_parameter_count} of "
+            "${source_parameter_count} parameter files"
+        )
+    endif()
+endforeach()
+
+foreach(reference IN ITEMS 3ob.ref 3ob.ref.bib matsci.ref matsci.ref.bib)
+    if(NOT EXISTS "${STAGING_PREFIX}/share/PQ/references/${reference}")
+        message(FATAL_ERROR "Reference data ${reference} was not installed")
+    endif()
+endforeach()
+
+file(READ "${STAGING_PREFIX}/share/PQ/references/3ob.ref" threeob_references)
+if(NOT threeob_references MATCHES "10.1021/ct300849w")
+    message(FATAL_ERROR "3ob reference data is incomplete")
+endif()
+
+file(READ "${STAGING_PREFIX}/share/PQ/references/matsci.ref" matsci_references)
+if(NOT matsci_references MATCHES "10.1002/zaac.200500051")
+    message(FATAL_ERROR "matsci reference data is incomplete")
+endif()
+
+get_filename_component(test_binary_dir "${SLAKOS_TEST_EXECUTABLE}" DIRECTORY)
+get_filename_component(test_asset_root "${test_binary_dir}/.." ABSOLUTE)
+set(test_slakos_root "${test_asset_root}/share/PQ/slakos")
+file(MAKE_DIRECTORY
+    "${test_slakos_root}/3ob/skfiles"
+    "${test_slakos_root}/matsci/skfiles"
+)
+
+execute_process(
+    COMMAND
+        "${CMAKE_COMMAND}" -E env
+        "PQ_TEST_EXPECTED_SLAKOS_ROOT=${test_slakos_root}"
+        "${SLAKOS_TEST_EXECUTABLE}"
+        "--gtest_filter=QMSettingsTest.ResolvesBundledSlakos"
+    RESULT_VARIABLE lookup_result
+    OUTPUT_VARIABLE lookup_output
+    ERROR_VARIABLE lookup_error
+)
+
+file(REMOVE_RECURSE "${test_slakos_root}")
+file(REMOVE_RECURSE "${STAGING_PREFIX}")
+
+if(NOT lookup_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "Installed Slakos lookup failed: ${lookup_output} ${lookup_error}"
+    )
+endif()

--- a/tests/src/settings/testQMSettings.cpp
+++ b/tests/src/settings/testQMSettings.cpp
@@ -22,6 +22,9 @@
 
 #include <gtest/gtest.h>   // for Test, InitGoogleTest, RUN_ALL_TESTS, EXPECT_EQ
 
+#include <cstdlib>
+#include <filesystem>
+
 #include "exceptions.hpp"         // for UserInputException
 #include "gtest/gtest.h"          // for Message, TestPartResult
 #include "qmSettings.hpp"         // for QMSettings, QMMethod
@@ -175,6 +178,29 @@ TEST(QMSettingsTest, SetSlakosTypeTest)
         "Slakos notASlakosType not recognized"
     );
 }
+
+#ifdef WITH_ASE
+TEST(QMSettingsTest, ResolvesBundledSlakos)
+{
+    const auto *expectedRoot = std::getenv("PQ_TEST_EXPECTED_SLAKOS_ROOT");
+
+    for (const auto *slakos : {"3ob", "matsci"})
+    {
+        QMSettings::setSlakosType(slakos);
+        const auto path =
+            std::filesystem::weakly_canonical(QMSettings::getSlakosPath());
+
+        EXPECT_TRUE(std::filesystem::is_directory(path));
+        if (expectedRoot)
+            EXPECT_EQ(
+                path,
+                std::filesystem::weakly_canonical(
+                    std::filesystem::path(expectedRoot) / slakos / "skfiles"
+                )
+            );
+    }
+}
+#endif
 
 #ifndef WITH_ASE
 TEST(QMSettingsTest, SetBuiltInSlakosTypeRequiresAse)


### PR DESCRIPTION
Closes #361.

Depends on #367.

- pin and validate 3ob and matsci inputs
- support preseeded data for offline builds
- install parameters, licenses, and citations under share/PQ/slakos
- resolve installed datasets at runtime

Tests:
- testQMSettings
- testQMParser
- testPQSlakosInstall