### PR TITLE
fix: fail on reference I/O errors

### DIFF
--- a/src/output/references/referencesOutput.cpp
+++ b/src/output/references/referencesOutput.cpp
@@ -23,13 +23,16 @@
 #include "referencesOutput.hpp"
 
 #include <algorithm>    // for for_each
-#include <filesystem>   // for is_directory, path
+#include <filesystem>   // for is_directory, is_regular_file, path
+#include <format>       // for format
 #include <fstream>      // for fstream
+#include <stdexcept>    // for runtime_error
 #include <string>       // for string
+#include <vector>       // for vector
 
 #include "executablePath.hpp"       // for executablePath
-#include "references.hpp"           // for ReferencesOutput
 #include "outputFileSettings.hpp"   // for OutputFileSettings
+#include "references.hpp"           // for ReferencesOutput
 
 using references::ReferencesOutput;
 using namespace settings;
@@ -47,7 +50,11 @@ namespace
                 return installedPath;
         }
 
-        return std::filesystem::path(REFERENCES_PATH_);
+        const auto buildPath = std::filesystem::path(REFERENCES_PATH_);
+        if (std::filesystem::is_directory(buildPath))
+            return buildPath;
+
+        throw std::runtime_error("PQ reference data could not be found");
     }
 }   // namespace
 
@@ -61,15 +68,61 @@ void ReferencesOutput::writeReferencesFile()
     const auto sourceDirectory = referenceFilesPath();
     const auto filename        = OutputFileSettings::getRefFileName();
 
+    auto referenceFileNames = std::vector<std::string>{_PQ_FILE_};
+    referenceFileNames.insert(
+        referenceFileNames.end(),
+        _referenceFileNames.begin(),
+        _referenceFileNames.end()
+    );
+    referenceFileNames.emplace_back(
+        static_cast<std::string>(_PQ_FILE_) + ".bib"
+    );
+    referenceFileNames.insert(
+        referenceFileNames.end(),
+        _bibtexFileNames.begin(),
+        _bibtexFileNames.end()
+    );
+
+    for (const auto &referenceFileName : referenceFileNames)
+    {
+        const auto path = sourceDirectory / referenceFileName;
+        if (!std::filesystem::is_regular_file(path))
+            throw std::runtime_error(
+                std::format(
+                    "PQ reference file \"{}\" could not be found",
+                    path.string()
+                )
+            );
+    }
+
     std::ofstream fp(filename);
+    if (!fp.is_open())
+        throw std::runtime_error(
+            std::format("Could not open reference output file \"{}\"", filename)
+        );
 
     auto printReference =
         [&fp, &sourceDirectory](const std::string &referenceFileName)
     {
         std::ifstream referenceFile(sourceDirectory / referenceFileName);
+        if (!referenceFile.is_open())
+            throw std::runtime_error(
+                std::format(
+                    "Could not open PQ reference file \"{}\"",
+                    (sourceDirectory / referenceFileName).string()
+                )
+            );
 
         std::string line;
         while (getline(referenceFile, line)) fp << line << '\n';
+
+        if (referenceFile.bad())
+            throw std::runtime_error(
+                std::format(
+                    "Could not read PQ reference file \"{}\"",
+                    (sourceDirectory / referenceFileName).string()
+                )
+            );
 
         fp << "\n\n";
         referenceFile.close();
@@ -101,6 +154,13 @@ void ReferencesOutput::writeReferencesFile()
     std::ranges::for_each(_bibtexFileNames, printReference);
 
     fp.close();
+    if (!fp)
+        throw std::runtime_error(
+            std::format(
+                "Could not write reference output file \"{}\"",
+                filename
+            )
+        );
 }
 
 /**

--- a/tests/src/output/testReferencesOutput.cpp
+++ b/tests/src/output/testReferencesOutput.cpp
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 #include "outputFileSettings.hpp"
@@ -69,23 +70,21 @@ TEST(TestReferencesOutput, writeReferencesFileEmitsHeaderAndBibtexBanner)
     ::remove(path.c_str());
 }
 
-TEST(TestReferencesOutput, addReferenceFileExtendsBothReferenceAndBibtexLists)
+TEST(TestReferencesOutput, rejectsUnwritableOutput)
 {
-    // Sanity-check the static accessor is exposed at all; we can only observe
-    // the side effect through the rendered output file, which won't contain
-    // the new entry's body (the .ref file doesn't exist on disk) but the call
-    // itself must not throw and must remain idempotent for duplicates.
+    OutputFileSettings::setRefFileName(".");
+
+    EXPECT_THROW(ReferencesOutput::writeReferencesFile(), std::runtime_error);
+}
+
+TEST(TestReferencesOutput, rejectsMissingReferenceFiles)
+{
     EXPECT_NO_THROW(ReferencesOutput::addReferenceFile("nonexistent.ref"));
     EXPECT_NO_THROW(ReferencesOutput::addReferenceFile("nonexistent.ref"));
 
     const std::string path = "default.refs.test";
     OutputFileSettings::setRefFileName(path);
-    ReferencesOutput::writeReferencesFile();
 
-    // Even with a non-existent reference file in the registered set, the
-    // overall write succeeds and the file exists with at least the headers.
-    const auto content = slurp(path);
-    EXPECT_FALSE(content.empty());
-
-    ::remove(path.c_str());
+    EXPECT_THROW(ReferencesOutput::writeReferencesFile(), std::runtime_error);
+    EXPECT_FALSE(std::ifstream(path).good());
 }


### PR DESCRIPTION
Closes #355.

Depends on #366.

- require every selected reference file before writing
- reject missing installed reference data
- fail when the output cannot be opened, read, or fully written
- avoid leaving a partial file when inputs are missing

Test:
- testReferencesOutput