### PR TITLE
feat: warn about disabled control coupling

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -74,4 +74,15 @@ if(BUILD_WITH_TESTS)
       -P ${PROJECT_SOURCE_DIR}/tests/cmake/testPQValidation.cmake
   )
   set_property(TEST testPQValidation PROPERTY LABELS input)
+
+  add_test(
+    NAME testPQValidationWarnings
+    COMMAND
+      ${CMAKE_COMMAND}
+      -DPQ_EXECUTABLE=$<TARGET_FILE:PQ>
+      -DVALIDATION_FIXTURE_DIR=${PROJECT_SOURCE_DIR}/tests/regression/fixtures/mm-md-smoke
+      -DVALIDATION_WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/pq-validation-warnings
+      -P ${PROJECT_SOURCE_DIR}/tests/cmake/testPQValidationWarnings.cmake
+  )
+  set_property(TEST testPQValidationWarnings PROPERTY LABELS input)
 endif()

--- a/apps/validation.cpp
+++ b/apps/validation.cpp
@@ -37,8 +37,10 @@
 #include "fileSettings.hpp"
 #include "forceFieldSettings.hpp"
 #include "inputFileReader.hpp"
+#include "manostatSettings.hpp"
 #include "qmSettings.hpp"
 #include "settings.hpp"
+#include "thermostatSettings.hpp"
 
 namespace
 {
@@ -146,10 +148,42 @@ namespace
         cli::ValidationResult        &result
     )
     {
+        using settings::ManostatSettings;
+        using settings::ManostatType;
+        using settings::ThermostatSettings;
+        using settings::ThermostatType;
+
         if (reader.getKeywordSet("mace_model_size"))
             result.diagnostics.push_back(
                 {cli::ValidationSeverity::WARNING,
                  "\"mace_model_size\" is deprecated; use \"mace_model\"",
+                 std::nullopt}
+            );
+
+        if (ThermostatSettings::getThermostatType() ==
+                ThermostatType::NOSE_HOOVER &&
+            ThermostatSettings::getNoseHooverCouplingFrequency() == 0.0)
+            result.diagnostics.push_back(
+                {cli::ValidationSeverity::WARNING,
+                 "A zero Nose-Hoover coupling frequency disables thermostat "
+                 "coupling",
+                 std::nullopt}
+            );
+
+        if (ThermostatSettings::getThermostatType() ==
+                ThermostatType::LANGEVIN &&
+            ThermostatSettings::getFriction() == 0.0)
+            result.diagnostics.push_back(
+                {cli::ValidationSeverity::WARNING,
+                 "A zero Langevin friction disables thermostat coupling",
+                 std::nullopt}
+            );
+
+        if (ManostatSettings::getManostatType() != ManostatType::NONE &&
+            ManostatSettings::getCompressibility() == 0.0)
+            result.diagnostics.push_back(
+                {cli::ValidationSeverity::WARNING,
+                 "A zero compressibility disables cell response",
                  std::nullopt}
             );
     }

--- a/tests/cmake/testPQValidationWarnings.cmake
+++ b/tests/cmake/testPQValidationWarnings.cmake
@@ -1,0 +1,88 @@
+function(assert_warning input_file scope expected_message)
+    set(arguments --validate "${input_file}" --format=json)
+    if(scope STREQUAL "portable")
+        list(APPEND arguments --scope=portable)
+    endif()
+
+    execute_process(
+        COMMAND "${PQ_EXECUTABLE}" ${arguments}
+        WORKING_DIRECTORY "${VALIDATION_WORK_DIR}"
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE error
+    )
+
+    if(NOT result EQUAL 0 OR NOT error STREQUAL "")
+        message(
+            FATAL_ERROR
+            "Validation rejected ${input_file}: ${output} ${error}"
+        )
+    endif()
+
+    string(JSON valid GET "${output}" valid)
+    string(JSON diagnostic_count LENGTH "${output}" diagnostics)
+    string(JSON severity GET "${output}" diagnostics 0 severity)
+    string(JSON message GET "${output}" diagnostics 0 message)
+
+    if(
+        NOT valid
+        OR NOT diagnostic_count EQUAL 1
+        OR NOT severity STREQUAL "warning"
+        OR NOT message MATCHES "${expected_message}"
+    )
+        message(FATAL_ERROR "Unexpected warning for ${input_file}: ${output}")
+    endif()
+endfunction()
+
+file(REMOVE_RECURSE "${VALIDATION_WORK_DIR}")
+file(MAKE_DIRECTORY "${VALIDATION_WORK_DIR}")
+file(
+    COPY
+    "${VALIDATION_FIXTURE_DIR}/start.rst"
+    "${VALIDATION_FIXTURE_DIR}/moldescriptor.dat"
+    "${VALIDATION_FIXTURE_DIR}/guff.dat"
+    DESTINATION "${VALIDATION_WORK_DIR}"
+)
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/nose-hoover.in"
+    "jobtype = mm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "force-field = off;\n"
+    "thermostat = nh-chain;\n"
+    "temp = 300;\n"
+    "coupling_frequency = 0;\n"
+    "start_file = start.rst;\n"
+)
+assert_warning(
+    "nose-hoover.in"
+    portable
+    "zero Nose-Hoover coupling frequency"
+)
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/langevin.in"
+    "jobtype = mm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "force-field = off;\n"
+    "thermostat = langevin;\n"
+    "temp = 300;\n"
+    "friction = 0;\n"
+    "start_file = start.rst;\n"
+)
+assert_warning("langevin.in" installed "zero Langevin friction")
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/manostat.in"
+    "jobtype = mm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "force-field = off;\n"
+    "manostat = berendsen;\n"
+    "pressure = 1;\n"
+    "compressibility = 0;\n"
+    "start_file = start.rst;\n"
+)
+assert_warning("manostat.in" installed "zero compressibility")


### PR DESCRIPTION
Closes #371.

Depends on #364.

- warn when Nose-Hoover coupling frequency is zero
- warn when Langevin friction is zero
- warn when manostat compressibility is zero
- keep each input valid in portable and installed scopes

Test:
- testPQValidationWarnings