### PR TITLE
feat: validate installed input resources

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -19,6 +19,11 @@ target_compile_definitions(PQ
   PQ_BUILD_WITH_KOKKOS=$<BOOL:${BUILD_WITH_KOKKOS}>
   PQ_BUILD_WITH_PYTHON_BINDINGS=$<BOOL:${BUILD_WITH_PYTHON_BINDINGS}>
   PQ_BUILD_WITH_PYTHON_EMBEDDING=$<BOOL:${BUILD_WITH_PYBIND11}>
+  PQ_BUILD_STATIC=$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>
+  PQ_BUILD_WITH_SINGULARITY=$<BOOL:${BUILD_WITH_SINGULARITY}>
+  PQ_BUILD_EXECUTABLE_DIR="${PROJECT_BINARY_DIR}/apps"
+  PQ_BUILD_QM_SCRIPT_DIR="${PROJECT_BINARY_DIR}/src/QM/scripts"
+  PQ_BUILD_SLAKOS_DIR="${PROJECT_BINARY_DIR}/external/slakos"
 )
 
 target_link_libraries(PQ
@@ -74,4 +79,19 @@ if(BUILD_WITH_TESTS)
       -P ${PROJECT_SOURCE_DIR}/tests/cmake/testPQValidation.cmake
   )
   set_property(TEST testPQValidation PROPERTY LABELS input)
+
+  add_test(
+    NAME testPQValidationEnvironment
+    COMMAND
+      ${CMAKE_COMMAND}
+      -DPQ_EXECUTABLE=$<TARGET_FILE:PQ>
+      -DEXPECTED_ASE=${BUILD_WITH_ASE}
+      -DEXPECTED_SHARED=${BUILD_SHARED_LIBS}
+      -DEXPECTED_SINGULARITY=${BUILD_WITH_SINGULARITY}
+      -DBUNDLED_SCRIPT_SOURCE_DIR=${PROJECT_SOURCE_DIR}/src/QM/scripts
+      -DVALIDATION_FIXTURE_DIR=${PROJECT_SOURCE_DIR}/tests/regression/fixtures/mm-md-smoke
+      -DVALIDATION_WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/pq-validation-environment
+      -P ${PROJECT_SOURCE_DIR}/tests/cmake/testPQValidationEnvironment.cmake
+  )
+  set_property(TEST testPQValidationEnvironment PROPERTY LABELS input)
 endif()

--- a/apps/validation.cpp
+++ b/apps/validation.cpp
@@ -22,6 +22,9 @@
 
 #include "validation.hpp"
 
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
 #include <format>
 #include <iomanip>
 #include <iostream>
@@ -31,12 +34,23 @@
 #include <streambuf>
 #include <string>
 #include <string_view>
+#include <vector>
+
+#if defined(_WIN32)
+#include <windows.h>
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h>
+#elif defined(__linux__)
+#include <unistd.h>
+#endif
 
 #include "engine.hpp"
 #include "exceptions.hpp"
+#include "externalQMScripts.hpp"
 #include "fileSettings.hpp"
 #include "forceFieldSettings.hpp"
 #include "inputFileReader.hpp"
+#include "manostatSettings.hpp"
 #include "qmSettings.hpp"
 #include "settings.hpp"
 
@@ -76,12 +90,201 @@ namespace
         };
     }
 
+    void requireFile(
+        const std::filesystem::path &fileName,
+        const std::string_view       description
+    )
+    {
+        if (!std::filesystem::is_regular_file(fileName))
+            throw customException::InputFileException(
+                std::format(
+                    "{} \"{}\" does not exist or is not a regular file",
+                    description,
+                    fileName.string()
+                )
+            );
+    }
+
+    void requireDirectory(
+        const std::filesystem::path &directoryName,
+        const std::string_view       description
+    )
+    {
+        if (!std::filesystem::is_directory(directoryName))
+            throw customException::InputFileException(
+                std::format(
+                    "{} \"{}\" does not exist or is not a directory",
+                    description,
+                    directoryName.string()
+                )
+            );
+    }
+
+    bool isRemoteResource(const std::string_view value)
+    {
+        return value.starts_with("https://") || value.starts_with("http://");
+    }
+
+    std::filesystem::path executablePath()
+    {
+#if defined(_WIN32)
+        auto buffer = std::vector<wchar_t>(1024);
+        while (true)
+        {
+            const auto length = GetModuleFileNameW(
+                nullptr,
+                buffer.data(),
+                static_cast<DWORD>(buffer.size())
+            );
+            if (length == 0)
+                break;
+            if (length < buffer.size() - 1)
+                return std::filesystem::weakly_canonical(buffer.data());
+            buffer.resize(buffer.size() * 2);
+        }
+#elif defined(__APPLE__)
+        auto size = uint32_t{0};
+        _NSGetExecutablePath(nullptr, &size);
+        auto buffer = std::vector<char>(size);
+        if (_NSGetExecutablePath(buffer.data(), &size) == 0)
+            return std::filesystem::weakly_canonical(buffer.data());
+#elif defined(__linux__)
+        auto buffer = std::vector<char>(1024);
+        while (true)
+        {
+            const auto length =
+                readlink("/proc/self/exe", buffer.data(), buffer.size());
+            if (length < 0)
+                break;
+            if (static_cast<size_t>(length) < buffer.size())
+                return std::filesystem::weakly_canonical(
+                    std::filesystem::path(
+                        std::string(buffer.data(), static_cast<size_t>(length))
+                    )
+                );
+            buffer.resize(buffer.size() * 2);
+        }
+#endif
+
+        return {};
+    }
+
+    std::filesystem::path runtimeAssetPath(
+        const std::filesystem::path &installedRelativePath,
+        const std::filesystem::path &buildPath
+    )
+    {
+        const auto executable = executablePath();
+        if (executable.empty())
+            return buildPath;
+
+        std::error_code error;
+        const auto      buildExecutableDirectory =
+            std::filesystem::weakly_canonical(PQ_BUILD_EXECUTABLE_DIR, error);
+
+        if (!error && executable.parent_path() == buildExecutableDirectory)
+            return buildPath;
+
+        return executable.parent_path().parent_path() / "share" / "PQ" /
+               installedRelativePath;
+    }
+
+    std::filesystem::path bundledQMScriptPath(const std::string_view script)
+    {
+        return runtimeAssetPath(
+            std::filesystem::path("scripts") / script,
+            std::filesystem::path(PQ_BUILD_QM_SCRIPT_DIR) / script
+        );
+    }
+
+    std::filesystem::path bundledSlakosPath(const settings::SlakosType type)
+    {
+        const auto name = settings::string(type);
+
+        return runtimeAssetPath(
+            std::filesystem::path("slakos") / name / "skfiles",
+            std::filesystem::path(PQ_BUILD_SLAKOS_DIR) / name / "skfiles"
+        );
+    }
+
+    void validateExternalQMScriptSelection()
+    {
+        using settings::QMSettings;
+        using settings::Settings;
+
+        if (!Settings::isQMActivated() || !QMSettings::isExternalQMRunner())
+            return;
+
+        const auto script         = QMSettings::getQMScript();
+        const auto fullPathScript = QMSettings::getQMScriptFullPath();
+
+        if (script.empty() && fullPathScript.empty())
+            throw customException::InputFileException(
+                "No qm_script provided. Please provide a qm_script in the "
+                "input file."
+            );
+
+        if (!script.empty() && !fullPathScript.empty())
+            throw customException::InputFileException(
+                "\"qm_script\" and \"qm_script_full_path\" are mutually "
+                "exclusive"
+            );
+
+        if (!script.empty() &&
+            !cli::isExternalQMScript(QMSettings::getQMMethod(), script))
+            throw customException::InputFileException(
+                std::format(
+                    "Bundled QM script \"{}\" is not available for {}",
+                    script,
+                    cli::externalQMProgramName(QMSettings::getQMMethod())
+                )
+            );
+    }
+
+    void validateInstalledExternalQMScript()
+    {
+        using settings::QMSettings;
+        using settings::Settings;
+
+        if (!Settings::isQMActivated() || !QMSettings::isExternalQMRunner())
+            return;
+
+        const auto script         = QMSettings::getQMScript();
+        const auto fullPathScript = QMSettings::getQMScriptFullPath();
+
+        if ((PQ_BUILD_STATIC || PQ_BUILD_WITH_SINGULARITY) &&
+            fullPathScript.empty())
+            throw customException::InputFileException(
+                "This PQ build requires \"qm_script_full_path\" for "
+                "external QM programs"
+            );
+
+        if (!fullPathScript.empty())
+        {
+            requireFile(fullPathScript, "QM script");
+            return;
+        }
+
+        requireFile(bundledQMScriptPath(script), "Bundled QM script");
+
+        const auto scripts  = cli::externalQMScripts(QMSettings::getQMMethod());
+        const auto selected = std::ranges::find_if(
+            scripts,
+            [&script](const auto &candidate)
+            { return candidate.name == script; }
+        );
+
+        if (selected != scripts.end() && !selected->requiredWorkingFile.empty())
+            requireFile(
+                selected->requiredWorkingFile,
+                "Required QM working file"
+            );
+    }
+
     void validateInputDependencies(engine::Engine &engine)
     {
         using settings::FileSettings;
         using settings::ForceFieldSettings;
-        using settings::QMSettings;
-        using settings::Settings;
 
         if (engine.isConstraintsActivated() || ForceFieldSettings::isActive())
         {
@@ -103,23 +306,90 @@ namespace
                 "M-SHAKE file needed for requested simulation setup"
             );
 
-        if (!Settings::isQMActivated() || !QMSettings::isExternalQMRunner())
+        validateExternalQMScriptSelection();
+    }
+
+    void validateEffectiveFiles(engine::Engine &engine)
+    {
+        using settings::FileSettings;
+        using settings::ForceFieldSettings;
+        using settings::ManostatSettings;
+        using settings::ManostatType;
+        using settings::QMMethod;
+        using settings::QMSettings;
+        using settings::Settings;
+        using settings::SlakosType;
+
+        requireFile(FileSettings::getStartFileName(), "Start file");
+
+        if (FileSettings::isRingPolymerStartFileNameSet())
+            requireFile(
+                FileSettings::getRingPolymerStartFileName(),
+                "Ring-polymer start file"
+            );
+
+        if (FileSettings::isIntraNonBondedFileNameSet())
+            requireFile(
+                FileSettings::getIntraNonBondedFileName(),
+                "Intra non-bonded file"
+            );
+
+        if (Settings::isMMActivated() ||
+            ManostatSettings::getManostatType() != ManostatType::NONE)
+            requireFile(
+                FileSettings::getMolDescriptorFileName(),
+                "Moldescriptor file"
+            );
+
+        if (Settings::isMMActivated() &&
+            !engine.isForceFieldNonCoulombicsActivated())
+            requireFile(FileSettings::getGuffDatFileName(), "Guff file");
+
+        if (engine.isConstraintsActivated() || ForceFieldSettings::isActive())
+            requireFile(FileSettings::getTopologyFileName(), "Topology file");
+
+        if (ForceFieldSettings::isActive())
+            requireFile(FileSettings::getParameterFilename(), "Parameter file");
+
+        if (FileSettings::isMShakeFileNameSet())
+            requireFile(FileSettings::getMShakeFileName(), "M-SHAKE file");
+
+        if (!Settings::isQMActivated())
             return;
 
-        const auto script         = QMSettings::getQMScript();
-        const auto fullPathScript = QMSettings::getQMScriptFullPath();
+        const auto method = QMSettings::getQMMethod();
 
-        if (script.empty() && fullPathScript.empty())
-            throw customException::InputFileException(
-                "No qm_script provided. Please provide a qm_script in the "
-                "input file."
-            );
+        if (method == QMMethod::DFTBPLUS)
+            requireFile(FileSettings::getDFTBFileName(), "DFTB setup file");
 
-        if (!script.empty() && !fullPathScript.empty())
-            throw customException::InputFileException(
-                "\"qm_script\" and \"qm_script_full_path\" are mutually "
-                "exclusive"
-            );
+        if (method == QMMethod::ASEDFTBPLUS &&
+            QMSettings::getSlakosType() != SlakosType::NONE)
+        {
+            const auto slakosType = QMSettings::getSlakosType();
+            if (slakosType == SlakosType::CUSTOM)
+                requireDirectory(
+                    QMSettings::getSlakosPath(),
+                    "Slater-Koster directory"
+                );
+            else
+                requireDirectory(
+                    bundledSlakosPath(slakosType),
+                    "Built-in Slater-Koster directory"
+                );
+        }
+
+        if (method == QMMethod::FENNOL)
+            requireFile(QMSettings::getFennolModelPath(), "FeNNol model file");
+
+        if (method == QMMethod::MACE &&
+            QMSettings::getMaceModel() == settings::MaceModel::CUSTOM)
+        {
+            const auto modelPath = QMSettings::getMaceModelPath();
+            if (!isRemoteResource(modelPath))
+                requireFile(modelPath, "MACE model file");
+        }
+
+        validateInstalledExternalQMScript();
     }
 
     void validateCompiledCapabilities()
@@ -219,14 +489,18 @@ cli::ValidationResult cli::validateInputFile(
         input::InputFileReader reader(
             inputFile,
             *engine,
-            scope == ValidationScope::INSTALLED
+            scope == ValidationScope::INSTALLED,
+            false
         );
         reader.read();
         reader.postProcess();
         reader.validateInputConfiguration();
         validateInputDependencies(*engine);
         if (scope == ValidationScope::INSTALLED)
+        {
             validateCompiledCapabilities();
+            validateEffectiveFiles(*engine);
+        }
 
         auto result = ValidationResult{
             .valid     = true,

--- a/include/input/inputFileParser/QMInputParser.hpp
+++ b/include/input/inputFileParser/QMInputParser.hpp
@@ -39,8 +39,14 @@ namespace input
      */
     class QMInputParser : public InputFileParser
     {
+       private:
+        bool _resolveBuiltInSlakosPath;
+
        public:
-        explicit QMInputParser(pq::Engine &);
+        explicit QMInputParser(
+            pq::Engine &,
+            bool resolveBuiltInSlakosPath = true
+        );
 
         void parseQMMethod(const pq::strings &, const size_t);
         void parseQMScript(const pq::strings &, const size_t);

--- a/include/input/inputFileReader.hpp
+++ b/include/input/inputFileReader.hpp
@@ -77,7 +77,8 @@ namespace input
         explicit InputFileReader(
             const std::string_view &,
             engine::Engine &,
-            bool validateFilePaths = true
+            bool validateFilePaths        = true,
+            bool resolveBuiltInSlakosPath = true
         );
 
         void read();

--- a/include/settings/qmSettings.hpp
+++ b/include/settings/qmSettings.hpp
@@ -178,7 +178,10 @@ namespace settings
         static void setQMScriptFullPath(const std::string_view &script);
 
         static void setSlakosType(const std::string_view &slakos);
-        static void setSlakosType(const SlakosType slakos);
+        static void setSlakosType(
+            const SlakosType slakos,
+            bool             resolveBuiltInPath = true
+        );
         static void setSlakosPath(const std::string_view &path);
 
         static void setUseDispersionCorrection(const bool use);

--- a/src/input/inputFileParser/QMInputParser.cpp
+++ b/src/input/inputFileParser/QMInputParser.cpp
@@ -50,8 +50,14 @@ using namespace constants;
  * <string>
  *
  * @param engine
+ * @param resolveBuiltInSlakosPath
  */
-QMInputParser::QMInputParser(Engine &engine) : InputFileParser(engine)
+QMInputParser::QMInputParser(
+    Engine    &engine,
+    const bool resolveBuiltInSlakosPath
+)
+    : InputFileParser(engine),
+      _resolveBuiltInSlakosPath(resolveBuiltInSlakosPath)
 {
     addKeyword(
         std::string("qm_prog"),
@@ -475,13 +481,13 @@ void QMInputParser::parseSlakosType(
 
     if ("3ob" == slakos)
     {
-        QMSettings::setSlakosType(THREEOB);
+        QMSettings::setSlakosType(THREEOB, _resolveBuiltInSlakosPath);
         QMSettings::setHubbardDerivs(hubbardDerivMap3ob);
     }
 
     else if ("matsci" == slakos)
     {
-        QMSettings::setSlakosType(MATSCI);
+        QMSettings::setSlakosType(MATSCI, _resolveBuiltInSlakosPath);
     }
 
     else if ("custom" == slakos)

--- a/src/input/inputFileReader.cpp
+++ b/src/input/inputFileReader.cpp
@@ -69,11 +69,14 @@ using std::make_unique;
  *
  * @param fileName
  * @param engine
+ * @param validateFilePaths
+ * @param resolveBuiltInSlakosPath
  */
 InputFileReader::InputFileReader(
     const std::string_view &fileName,
     engine::Engine         &engine,
-    const bool              validateFilePaths
+    const bool              validateFilePaths,
+    const bool              resolveBuiltInSlakosPath
 )
     : _fileName(fileName), _engine(engine)
 {
@@ -100,7 +103,9 @@ InputFileReader::InputFileReader(
 
     _parsers.push_back(make_unique<ConvInputParser>(_engine));
     _parsers.push_back(make_unique<OptInputParser>(_engine));
-    _parsers.push_back(make_unique<QMInputParser>(_engine));
+    _parsers.push_back(
+        make_unique<QMInputParser>(_engine, resolveBuiltInSlakosPath)
+    );
 
     addKeywords();
 }

--- a/src/settings/qmSettings.cpp
+++ b/src/settings/qmSettings.cpp
@@ -507,10 +507,22 @@ void QMSettings::setSlakosType(const std::string_view &slakos)
 /**
  * @brief sets the slakosType to enum in settings
  *
- * @param model
+ * @param slakos
+ * @param resolveBuiltInPath
  */
-void QMSettings::setSlakosType(const SlakosType slakos)
+void QMSettings::setSlakosType(
+    const SlakosType slakos,
+    const bool       resolveBuiltInPath
+)
 {
+    if (!resolveBuiltInPath &&
+        (slakos == SlakosType::THREEOB || slakos == SlakosType::MATSCI))
+    {
+        _slakosType = slakos;
+        _slakosPath.clear();
+        return;
+    }
+
     setSlakosType(string(slakos));
 }
 

--- a/tests/cmake/testPQValidationEnvironment.cmake
+++ b/tests/cmake/testPQValidationEnvironment.cmake
@@ -1,0 +1,341 @@
+function(run_validation input_file scope output_var result_var)
+    set(arguments --validate "${input_file}" --format=json)
+    if(scope STREQUAL "portable")
+        list(APPEND arguments --scope=portable)
+    endif()
+
+    execute_process(
+        COMMAND "${PQ_EXECUTABLE}" ${arguments}
+        WORKING_DIRECTORY "${VALIDATION_WORK_DIR}"
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE error
+    )
+
+    if(NOT error STREQUAL "")
+        message(FATAL_ERROR "Validation wrote to stderr: ${error}")
+    endif()
+
+    set(${output_var} "${output}" PARENT_SCOPE)
+    set(${result_var} "${result}" PARENT_SCOPE)
+endfunction()
+
+function(assert_valid input_file scope)
+    run_validation("${input_file}" "${scope}" output result)
+    if(NOT result EQUAL 0)
+        message(
+            FATAL_ERROR
+            "${scope} validation rejected ${input_file}: ${output}"
+        )
+    endif()
+
+    string(JSON valid GET "${output}" valid)
+    if(NOT valid)
+        message(FATAL_ERROR "${input_file} was not reported valid: ${output}")
+    endif()
+endfunction()
+
+function(assert_invalid input_file scope expected_message)
+    run_validation("${input_file}" "${scope}" output result)
+    if(NOT result EQUAL 1)
+        message(
+            FATAL_ERROR
+            "${scope} validation accepted ${input_file}: ${output}"
+        )
+    endif()
+
+    string(JSON message GET "${output}" diagnostics 0 message)
+    if(NOT message MATCHES "${expected_message}")
+        message(
+            FATAL_ERROR
+            "Unexpected diagnostic for ${input_file}: ${output}"
+        )
+    endif()
+endfunction()
+
+file(REMOVE_RECURSE "${VALIDATION_WORK_DIR}")
+file(MAKE_DIRECTORY "${VALIDATION_WORK_DIR}")
+file(
+    COPY "${VALIDATION_FIXTURE_DIR}/start.rst"
+    DESTINATION "${VALIDATION_WORK_DIR}"
+)
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/mm.in"
+    "jobtype = mm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "force-field = off;\n"
+    "start_file = start.rst;\n"
+)
+assert_invalid("mm.in" installed "Moldescriptor file.*does not exist")
+file(WRITE "${VALIDATION_WORK_DIR}/moldescriptor.dat" "")
+assert_invalid("mm.in" installed "Guff file.*does not exist")
+file(WRITE "${VALIDATION_WORK_DIR}/guff.dat" "")
+assert_valid("mm.in" installed)
+
+file(MAKE_DIRECTORY "${VALIDATION_WORK_DIR}/start-directory")
+file(
+    WRITE "${VALIDATION_WORK_DIR}/directory-reference.in"
+    "jobtype = mm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "force-field = off;\n"
+    "start_file = start-directory;\n"
+)
+assert_invalid(
+    "directory-reference.in"
+    installed
+    "Start file.*not a regular file"
+)
+
+file(MAKE_DIRECTORY "${VALIDATION_WORK_DIR}/topology-directory")
+file(MAKE_DIRECTORY "${VALIDATION_WORK_DIR}/parameter-directory")
+file(
+    WRITE "${VALIDATION_WORK_DIR}/force-field.in"
+    "jobtype = mm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "force-field = on;\n"
+    "topology_file = topology-directory;\n"
+    "parameter_file = parameter-directory;\n"
+    "start_file = start.rst;\n"
+)
+assert_invalid(
+    "force-field.in"
+    installed
+    "Topology file.*not a regular file"
+)
+file(REMOVE_RECURSE "${VALIDATION_WORK_DIR}/topology-directory")
+file(WRITE "${VALIDATION_WORK_DIR}/topology-directory" "")
+assert_invalid(
+    "force-field.in"
+    installed
+    "Parameter file.*not a regular file"
+)
+file(REMOVE_RECURSE "${VALIDATION_WORK_DIR}/parameter-directory")
+file(WRITE "${VALIDATION_WORK_DIR}/parameter-directory" "")
+assert_valid("force-field.in" installed)
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/dftb.in"
+    "jobtype = qm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "qm_prog = dftbplus;\n"
+    "qm_script = dftbplus_periodic_stress;\n"
+    "start_file = start.rst;\n"
+)
+assert_valid("dftb.in" portable)
+assert_invalid("dftb.in" installed "DFTB setup file.*does not exist")
+file(WRITE "${VALIDATION_WORK_DIR}/dftb_in.template" "")
+
+if(EXPECTED_SHARED AND NOT EXPECTED_SINGULARITY)
+    assert_valid("dftb.in" installed)
+
+    set(relocated_prefix "${VALIDATION_WORK_DIR}/relocated")
+    file(MAKE_DIRECTORY "${relocated_prefix}/bin")
+    file(MAKE_DIRECTORY "${relocated_prefix}/share/PQ/scripts")
+    file(
+        COPY "${PQ_EXECUTABLE}"
+        DESTINATION "${relocated_prefix}/bin"
+        FILE_PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+    )
+    file(
+        COPY "${BUNDLED_SCRIPT_SOURCE_DIR}/dftbplus_periodic_stress"
+        DESTINATION "${relocated_prefix}/share/PQ/scripts"
+    )
+
+    get_filename_component(pq_executable_name "${PQ_EXECUTABLE}" NAME)
+    set(build_tree_pq "${PQ_EXECUTABLE}")
+    set(PQ_EXECUTABLE "${relocated_prefix}/bin/${pq_executable_name}")
+    assert_valid("dftb.in" installed)
+    file(
+        REMOVE
+        "${relocated_prefix}/share/PQ/scripts/dftbplus_periodic_stress"
+    )
+    assert_invalid(
+        "dftb.in"
+        installed
+        "Bundled QM script.*does not exist"
+    )
+    set(PQ_EXECUTABLE "${build_tree_pq}")
+else()
+    assert_invalid(
+        "dftb.in"
+        installed
+        "requires.*qm_script_full_path"
+    )
+endif()
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/wrong-script.in"
+    "jobtype = qm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "qm_prog = pyscf;\n"
+    "qm_script = dftbplus_periodic_stress;\n"
+    "start_file = start.rst;\n"
+)
+assert_invalid(
+    "wrong-script.in"
+    portable
+    "not available for pyscf"
+)
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/two-scripts.in"
+    "jobtype = qm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "qm_prog = dftbplus;\n"
+    "qm_script = dftbplus_periodic_stress;\n"
+    "qm_script_full_path = runner;\n"
+    "start_file = start.rst;\n"
+)
+assert_invalid("two-scripts.in" portable "mutually exclusive")
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/missing-script.in"
+    "jobtype = qm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "qm_prog = dftbplus;\n"
+    "start_file = start.rst;\n"
+)
+assert_invalid("missing-script.in" portable "No qm_script provided")
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/full-path.in"
+    "jobtype = qm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "qm_prog = dftbplus;\n"
+    "qm_script_full_path = runner;\n"
+    "dftb_file = dftb_in.template;\n"
+    "start_file = start.rst;\n"
+)
+assert_valid("full-path.in" portable)
+assert_invalid("full-path.in" installed "QM script.*does not exist")
+file(MAKE_DIRECTORY "${VALIDATION_WORK_DIR}/runner")
+assert_invalid("full-path.in" installed "QM script.*not a regular file")
+file(REMOVE_RECURSE "${VALIDATION_WORK_DIR}/runner")
+file(WRITE "${VALIDATION_WORK_DIR}/runner" "")
+assert_valid("full-path.in" installed)
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/turbomole.in"
+    "jobtype = qm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "qm_prog = turbomole;\n"
+    "qm_script = turbomole_rimp2;\n"
+    "start_file = start.rst;\n"
+)
+assert_valid("turbomole.in" portable)
+if(EXPECTED_SHARED AND NOT EXPECTED_SINGULARITY)
+    assert_invalid(
+        "turbomole.in"
+        installed
+        "Required QM working file.*tm_define.template"
+    )
+    file(WRITE "${VALIDATION_WORK_DIR}/tm_define.template" "")
+    assert_valid("turbomole.in" installed)
+endif()
+
+foreach(slakos IN ITEMS 3ob matsci)
+    file(
+        WRITE "${VALIDATION_WORK_DIR}/${slakos}.in"
+        "jobtype = qm-md;\n"
+        "nstep = 1;\n"
+        "timestep = 0.5;\n"
+        "qm_prog = ase-dftbplus;\n"
+        "slakos = ${slakos};\n"
+        "start_file = start.rst;\n"
+    )
+    assert_valid("${slakos}.in" portable)
+
+    if(EXPECTED_ASE)
+        assert_valid("${slakos}.in" installed)
+    else()
+        assert_invalid("${slakos}.in" installed "requires ASE support")
+    endif()
+endforeach()
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/custom-slakos.in"
+    "jobtype = qm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "qm_prog = ase-dftbplus;\n"
+    "slakos = custom;\n"
+    "slakos_path = custom-sk;\n"
+    "start_file = start.rst;\n"
+)
+assert_valid("custom-slakos.in" portable)
+if(EXPECTED_ASE)
+    assert_invalid(
+        "custom-slakos.in"
+        installed
+        "Slater-Koster directory.*does not exist"
+    )
+else()
+    assert_invalid("custom-slakos.in" installed "requires ASE support")
+endif()
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/fennol.in"
+    "jobtype = qm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "qm_prog = fennol;\n"
+    "fennol_model_path = missing.fnx;\n"
+    "start_file = start.rst;\n"
+)
+assert_valid("fennol.in" portable)
+if(EXPECTED_ASE)
+    assert_invalid("fennol.in" installed "FeNNol model file.*does not exist")
+else()
+    assert_invalid("fennol.in" installed "requires ASE support")
+endif()
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/mace-local.in"
+    "jobtype = qm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "qm_prog = mace;\n"
+    "mace_model = custom;\n"
+    "mace_model_path = missing.model;\n"
+    "start_file = start.rst;\n"
+)
+assert_valid("mace-local.in" portable)
+if(EXPECTED_ASE)
+    assert_invalid(
+        "mace-local.in"
+        installed
+        "MACE model file.*does not exist"
+    )
+else()
+    assert_invalid("mace-local.in" installed "requires ASE support")
+endif()
+
+file(
+    WRITE "${VALIDATION_WORK_DIR}/mace-remote.in"
+    "jobtype = qm-md;\n"
+    "nstep = 1;\n"
+    "timestep = 0.5;\n"
+    "qm_prog = mace;\n"
+    "mace_model = custom;\n"
+    "mace_model_path = https://example.org/model.model;\n"
+    "start_file = start.rst;\n"
+)
+assert_valid("mace-remote.in" portable)
+if(EXPECTED_ASE)
+    assert_valid("mace-remote.in" installed)
+else()
+    assert_invalid("mace-remote.in" installed "requires ASE support")
+endif()


### PR DESCRIPTION
Closes #357.

Depends on #337, #364, #365, #367, and #368.

- validate effective input, topology, parameter, and model files
- validate bundled or explicit external-QM scripts and companion files
- validate built-in and custom Slater-Koster directories
- keep portable validation independent of local installation state
- verify relocated binaries do not fall back to missing build-tree assets

Stack note: executable discovery remains local until #365 lands, then it will use the shared utility before merge.

Tests:
- testPQCli
- testPQValidation
- testPQValidationEnvironment in shared, static, and Singularity builds
- testCommandLineArgs