### PR TITLE
fix: reject directories as input files

### DIFF
--- a/src/utilities/stringUtilities.cpp
+++ b/src/utilities/stringUtilities.cpp
@@ -22,11 +22,12 @@
 
 #include "stringUtilities.hpp"
 
-#include <algorithm>   // for __for_each_fn
-#include <cctype>      // for isspace
-#include <cmath>       // for isnan, isinf
-#include <cstdint>     // for uint_fast32_t and UINT32_MAX
-#include <format>      // for format
+#include <algorithm>    // for __for_each_fn
+#include <cctype>       // for isspace
+#include <cmath>        // for isnan, isinf
+#include <cstdint>      // for uint_fast32_t and UINT32_MAX
+#include <filesystem>   // for is_regular_file
+#include <format>       // for format
 #include <fstream>
 #include <ranges>   // for begin, end, operator|, views::split, views::transform
 #include <sstream>
@@ -206,6 +207,9 @@ std::string utilities::firstLetterToUpperCaseCopy(std::string myString)
  */
 bool utilities::fileExists(const std::string &filename)
 {
+    if (!std::filesystem::is_regular_file(filename))
+        return false;
+
     std::ifstream file(filename);
     return file.good();
 }

--- a/tests/src/utilities/testStringUtilities.cpp
+++ b/tests/src/utilities/testStringUtilities.cpp
@@ -22,11 +22,12 @@
 
 #include <gtest/gtest.h>   // for Test, TestInfo (ptr only), EXPECT_EQ
 
-#include <cstdint>     // for UINT32_MAX
-#include <cstdio>      // for remove
-#include <fstream>     // for ofstream
-#include <stdexcept>   // for out_of_range and invalid_argument
-#include <string>      // for string, allocator
+#include <cstdint>      // for UINT32_MAX
+#include <cstdio>       // for remove
+#include <filesystem>   // for create_directory
+#include <fstream>      // for ofstream
+#include <stdexcept>    // for out_of_range and invalid_argument
+#include <string>       // for string, allocator
 
 #include "exceptions.hpp"        // for InputFileException
 #include "gmock/gmock.h"         // for ElementsAre, MakePredicateFormatter
@@ -170,12 +171,16 @@ TEST(TestStringUtilities, firstLetterToUpperCaseCopy)
  */
 TEST(TestStringUtilities, fileExists)
 {
-    std::string   file = "testFile.txt";
+    std::string   file      = "testFile.txt";
+    std::string   directory = "testDirectory";
     std::ofstream out(file);
     out.close();
+    std::filesystem::create_directory(directory);
     EXPECT_TRUE(utilities::fileExists(file));
     EXPECT_FALSE(utilities::fileExists("testFile2.txt"));
+    EXPECT_FALSE(utilities::fileExists(directory));
     std::remove(file.c_str());
+    std::filesystem::remove(directory);
 }
 
 /**


### PR DESCRIPTION
Closes #374.

`fileExists()` now requires a regular file, so directories fail before input parsing or runner setup.

Test: `ctest --test-dir build --output-on-failure -R "^testStringUtilities$"`