### PR TITLE
fix: initialize kinetic energy accumulators

### DIFF
--- a/changes/developer/internal.compilation.md
+++ b/changes/developer/internal.compilation.md
@@ -4,3 +4,4 @@
 - remove `matrix.hpp` dependency from `ForceFieldNonCoulomb` class as it was again included transitively in many many TUs
 - remove some useless public API functions from `ForceFieldNonCoulomb` class for easier maintainance as they were only used for testing
 - add pre-compiled-headers (pchs) to speedup compilation time ~20%
+- zero-initialize kinetic-energy accumulator tensors exposed by PCH-enabled builds

--- a/src/physicalData/physicalData.cpp
+++ b/src/physicalData/physicalData.cpp
@@ -59,8 +59,8 @@ void PhysicalData::calculateKinetics(SimulationBox &simulationBox)
     startTimingsSection("Calc Kinetics");
 
     _momentum = Vec3D();
-    tensor3D kineticEnergyAtomicTensor;
-    tensor3D kineticEnergyMolecularTensor;
+    tensor3D kineticEnergyAtomicTensor{};
+    tensor3D kineticEnergyMolecularTensor{};
 
     auto kinEnergyAndMomOfMol = [&kineticEnergyAtomicTensor,
                                  &kineticEnergyMolecularTensor,

--- a/tests/src/setup/CMakeLists.txt
+++ b/tests/src/setup/CMakeLists.txt
@@ -40,7 +40,7 @@ foreach(source_file ${source_files})
         COMMAND ${test_name}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests
     )
-    target_precompile_headers(${test_name} 
+    target_precompile_headers(${test_name}
         REUSE_FROM pq_test_pch
     )
 


### PR DESCRIPTION
Value-initialize the kinetic-energy accumulator tensors before use. PCH changed the stack layout and exposed the existing undefined behavior in `testPhysicalData` and the post-merge `dev` build.

Also removes the trailing whitespace in the PCH test setup.

Validation: GCC 13 x86 Release focused test and full serial suite (149/149).