### PR TITLE
fix: port external QM safeguards to qmmm-dev

### DIFF
--- a/changes/external-qm-robustness.user.bugfix.md
+++ b/changes/external-qm-robustness.user.bugfix.md
@@ -1,0 +1,1 @@
+- External-QM calculations now fail cleanly on process errors or incomplete result files, including when paths contain spaces.

--- a/include/QM/external/externalQMRunner.hpp
+++ b/include/QM/external/externalQMRunner.hpp
@@ -49,6 +49,11 @@ namespace QM
             std::string_view script
         ) const;
 
+        virtual void executeCommand(
+            std::string_view command,
+            std::string_view program
+        ) const;
+
        public:
         ExternalQMRunner()           = default;
         ~ExternalQMRunner() override = default;

--- a/include/utilities/stringUtilities.hpp
+++ b/include/utilities/stringUtilities.hpp
@@ -46,7 +46,9 @@ namespace utilities
     std::string toLowerAndReplaceDashesCopy(std::string);
     std::string toLowerAndReplaceDashesCopy(std::string_view);
     std::string firstLetterToUpperCaseCopy(std::string);
-    void        addSpaces(std::string &, const std::string &, const size_t);
+    std::string shellQuote(std::string_view);
+
+    void addSpaces(std::string &, const std::string &, const size_t);
 
     std::uint_fast32_t stringToUintFast32t(const std::string &);
     unsigned long long stringToULL(const std::string &str);

--- a/src/QM/external/dftbplusRunner.cpp
+++ b/src/QM/external/dftbplusRunner.cpp
@@ -23,8 +23,8 @@
 #include "dftbplusRunner.hpp"
 
 #include <algorithm>    // for std::ranges:find
+#include <cmath>        // for isfinite
 #include <cstddef>      // for size_t
-#include <cstdlib>      // for system
 #include <filesystem>   // for remove
 #include <format>       // for format
 #include <fstream>      // for ofstream
@@ -208,7 +208,7 @@ void DFTBPlusRunner::execute(SimulationBox &box)
         FileSettings::getDFTBFileName(),
         FileSettings::getPointChargeFileName()
     );
-    ::system(command.c_str());
+    executeCommand(command, "DFTB+");
 
     // set for next execution
     _isFirstExecution = false;
@@ -238,9 +238,27 @@ void DFTBPlusRunner::readStressTensor(Box &box, PhysicalData &data)
 
     StaticMatrix3x3<double> stress;
 
-    stressFile >> stress[0][0] >> stress[0][1] >> stress[0][2];
-    stressFile >> stress[1][0] >> stress[1][1] >> stress[1][2];
-    stressFile >> stress[2][0] >> stress[2][1] >> stress[2][2];
+    if (!(stressFile >> stress[0][0] >> stress[0][1] >> stress[0][2] >>
+          stress[1][0] >> stress[1][1] >> stress[1][2] >> stress[2][0] >>
+          stress[2][1] >> stress[2][2]))
+        throw QMRunnerException(
+            std::format(
+                "Incomplete {} stress tensor \"{}\"",
+                string(QMSettings::getQMMethod()),
+                stressFileName
+            )
+        );
+
+    for (size_t row = 0; row < 3; ++row)
+        for (size_t column = 0; column < 3; ++column)
+            if (!std::isfinite(stress[row][column]))
+                throw QMRunnerException(
+                    std::format(
+                        "Invalid value in {} stress tensor \"{}\"",
+                        string(QMSettings::getQMMethod()),
+                        stressFileName
+                    )
+                );
 
     const auto conversion = HARTREE_PER_BOHR3_TO_KCAL_PER_MOL_PER_ANGSTROM3;
     stress                = stress * conversion;

--- a/src/QM/external/dftbplusRunner.cpp
+++ b/src/QM/external/dftbplusRunner.cpp
@@ -201,12 +201,12 @@ void DFTBPlusRunner::execute(SimulationBox &box)
 
     const auto command = std::format(
         "{} {} {} {} {} {}",
-        scriptFile,
+        shellQuote(scriptFile),
         charge,
         readChargesBin,
         usePointCharges,
-        FileSettings::getDFTBFileName(),
-        FileSettings::getPointChargeFileName()
+        shellQuote(FileSettings::getDFTBFileName()),
+        shellQuote(FileSettings::getPointChargeFileName())
     );
     executeCommand(command, "DFTB+");
 

--- a/src/QM/external/externalQMRunner.cpp
+++ b/src/QM/external/externalQMRunner.cpp
@@ -142,11 +142,18 @@ void ExternalQMRunner::executeCommand(
     const std::string_view program
 ) const
 {
+#if defined(_WIN32)
+    static_cast<void>(command);
+    throw QMRunnerException(
+        std::format("{} command execution is not supported on Windows", program)
+    );
+#else
     const auto status = std::system(std::string(command).c_str());
     if (status != EXIT_SUCCESS)
         throw QMRunnerException(
             std::format("{} command failed with status {}", program, status)
         );
+#endif
 }
 
 /**

--- a/src/QM/external/externalQMRunner.cpp
+++ b/src/QM/external/externalQMRunner.cpp
@@ -23,8 +23,10 @@
 #include "externalQMRunner.hpp"
 
 #include <algorithm>    // for __for_each_fn, for_each
-#include <cmath>        // for isnan, isinf
-#include <filesystem>   // for is_regular_file, path
+#include <array>        // for array
+#include <cmath>        // for isfinite
+#include <cstdlib>      // for system
+#include <filesystem>   // for is_regular_file, path, remove
 #include <format>       // for format
 #include <fstream>      // for ofstream
 #include <string>       // for string
@@ -90,6 +92,13 @@ void ExternalQMRunner::run(
         stopTimingsSection("Write Pointcharges");
     }
 
+    const auto resultFiles = std::array{
+        FileSettings::getQMForcesTempFileName(),
+        FileSettings::getQMChargesTempFileName(),
+        FileSettings::getStressTensorTempFileName()
+    };
+    for (const auto &file : resultFiles) std::filesystem::remove(file);
+
     std::jthread timeoutThread{[this](const std::stop_token stopToken)
                                { throwAfterTimeout(stopToken); }};
 
@@ -126,6 +135,18 @@ std::string ExternalQMRunner::resolveScriptPath(
         return bundledQMScriptPath(script);
 
     return _scriptPath + std::string(script);
+}
+
+void ExternalQMRunner::executeCommand(
+    const std::string_view command,
+    const std::string_view program
+) const
+{
+    const auto status = std::system(std::string(command).c_str());
+    if (status != EXIT_SUCCESS)
+        throw QMRunnerException(
+            std::format("{} command failed with status {}", program, status)
+        );
 }
 
 /**
@@ -168,9 +189,16 @@ void ExternalQMRunner::readForceFile(
 
     double energy = 0.0;
 
-    forceFile >> energy;
+    if (!(forceFile >> energy))
+        throw QMRunnerException(
+            std::format(
+                "Cannot read QM energy from {} force file \"{}\"",
+                string(QMSettings::getQMMethod()),
+                forceFileName
+            )
+        );
 
-    if (std::isnan(energy) || std::isinf(energy))
+    if (!std::isfinite(energy))
         throw QMRunnerException(
             std::format(
                 "Invalid QM energy (NaN/Inf) in {} force file \"{}\"",
@@ -185,10 +213,17 @@ void ExternalQMRunner::readForceFile(
     {
         auto grad = linearAlgebra::Vec3D();
 
-        forceFile >> grad[0] >> grad[1] >> grad[2];
+        if (!(forceFile >> grad[0] >> grad[1] >> grad[2]))
+            throw QMRunnerException(
+                std::format(
+                    "Incomplete {} force file \"{}\"",
+                    string(QMSettings::getQMMethod()),
+                    forceFileName
+                )
+            );
 
         for (size_t i = 0; i < 3; ++i)
-            if (std::isnan(grad[i]) || std::isinf(grad[i]))
+            if (!std::isfinite(grad[i]))
                 throw QMRunnerException(
                     std::format(
                         "Invalid QM force component (NaN/Inf) in {} force file "
@@ -244,11 +279,26 @@ void ExternalQMRunner::readChargeFile(SimulationBox &box)
 
     box.resetQMCharges();
 
-    auto readCharges = [&chargeFile](auto &atom)
+    auto readCharges = [&chargeFile, &chargeFileName](auto &atom)
     {
         auto charge = 0.0;
 
-        chargeFile >> charge;
+        if (!(chargeFile >> charge))
+            throw QMRunnerException(
+                std::format(
+                    "Incomplete {} charge file \"{}\"",
+                    string(QMSettings::getQMMethod()),
+                    chargeFileName
+                )
+            );
+        if (!std::isfinite(charge))
+            throw QMRunnerException(
+                std::format(
+                    "Invalid value in {} charge file \"{}\"",
+                    string(QMSettings::getQMMethod()),
+                    chargeFileName
+                )
+            );
 
         atom->setQMCharge(charge);
     };

--- a/src/QM/external/pyscfRunner.cpp
+++ b/src/QM/external/pyscfRunner.cpp
@@ -80,7 +80,11 @@ void PySCFRunner::execute(SimulationBox &)
             )
         );
 
-    const auto command = std::format("python {} > pyscf.out", scriptFileName);
+    const auto command = std::format(
+        "python {} > {}",
+        shellQuote(scriptFileName),
+        shellQuote("pyscf.out")
+    );
 
     executeCommand(command, "PySCF");
 }

--- a/src/QM/external/pyscfRunner.cpp
+++ b/src/QM/external/pyscfRunner.cpp
@@ -22,8 +22,7 @@
 
 #include "pyscfRunner.hpp"
 
-#include <stdlib.h>   // for system, size_t
-
+#include <cstddef>   // for size_t
 #include <format>    // for format
 #include <fstream>   // for ofstream, operator<<, basic_ostream
 #include <string>    // for allocator, string, operator+, operator<<
@@ -83,5 +82,5 @@ void PySCFRunner::execute(SimulationBox &)
 
     const auto command = std::format("python {} > pyscf.out", scriptFileName);
 
-    ::system(command.c_str());
+    executeCommand(command, "PySCF");
 }

--- a/src/QM/external/turbomoleRunner.cpp
+++ b/src/QM/external/turbomoleRunner.cpp
@@ -135,12 +135,12 @@ void TurbomoleRunner::execute(SimulationBox &box)
 
     const auto command = std::format(
         "{} {} {} {} {} {}",
-        scriptFile,
+        shellQuote(scriptFile),
         charge,
         runTMDefine,
         usePointCharges,
-        FileSettings::getTMFileName(),
-        FileSettings::getPointChargeFileName()
+        shellQuote(FileSettings::getTMFileName()),
+        shellQuote(FileSettings::getPointChargeFileName())
     );
     executeCommand(command, "Turbomole");
 

--- a/src/QM/external/turbomoleRunner.cpp
+++ b/src/QM/external/turbomoleRunner.cpp
@@ -22,7 +22,6 @@
 
 #include "turbomoleRunner.hpp"
 
-#include <cstdlib>      // for system
 #include <filesystem>   // for remove
 #include <format>       // for format
 #include <fstream>      // for ofstream
@@ -143,7 +142,7 @@ void TurbomoleRunner::execute(SimulationBox &box)
         FileSettings::getTMFileName(),
         FileSettings::getPointChargeFileName()
     );
-    ::system(command.c_str());
+    executeCommand(command, "Turbomole");
 
     _isFirstExecution = false;
     _usePointCharges  = false;

--- a/src/settings/waterModelSettings.cpp
+++ b/src/settings/waterModelSettings.cpp
@@ -22,6 +22,8 @@
 
 #include "waterModelSettings.hpp"
 
+#include <format>
+
 #include "exceptions.hpp"        // for customException
 #include "stringUtilities.hpp"   // for toLowerCopy
 

--- a/src/utilities/stringUtilities.cpp
+++ b/src/utilities/stringUtilities.cpp
@@ -203,6 +203,29 @@ std::string utilities::firstLetterToUpperCaseCopy(std::string myString)
 }
 
 /**
+ * @brief quotes one argument for a POSIX shell command
+ *
+ * @param argument
+ * @return std::string
+ */
+std::string utilities::shellQuote(const std::string_view argument)
+{
+    std::string quoted{"'"};
+    quoted.reserve(argument.size() + 2);
+
+    for (const auto character : argument)
+    {
+        if (character == '\'')
+            quoted += "'\"'\"'";
+        else
+            quoted += character;
+    }
+
+    quoted += '\'';
+    return quoted;
+}
+
+/**
  * @brief checks if a file exists and can be opened
  *
  * @param filename

--- a/tests/src/CMakeLists.txt
+++ b/tests/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(setup)
+add_subdirectory(QM)
 add_subdirectory(simulationBox)
 add_subdirectory(linearAlgebra)
 add_subdirectory(manostat)

--- a/tests/src/QM/CMakeLists.txt
+++ b/tests/src/QM/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_executable(testExternalQMRunner
+    testExternalQMRunner.cpp
+)
+
+target_include_directories(testExternalQMRunner
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/tests/include/macros
+)
+
+target_link_libraries(testExternalQMRunner
+    PRIVATE
+    externalQM
+    gtest
+    gmock
+    pq_test_main
+)
+
+target_precompile_headers(testExternalQMRunner REUSE_FROM pq_test_pch)
+target_link_libraries(testExternalQMRunner PRIVATE pq_test_pch)
+
+add_test(
+    NAME testExternalQMRunner
+    COMMAND testExternalQMRunner
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests
+)
+
+set_property(TEST testExternalQMRunner PROPERTY LABELS QM)

--- a/tests/src/QM/testExternalQMRunner.cpp
+++ b/tests/src/QM/testExternalQMRunner.cpp
@@ -200,6 +200,17 @@ namespace
 
 TEST_F(ExternalQMRunnerTest, propagatesCommandFailure)
 {
+#if defined(_WIN32)
+    try
+    {
+        _runner.runCommand("true", "External QM");
+        FAIL() << "Expected command execution to be rejected on Windows";
+    }
+    catch (const QMRunnerException &error)
+    {
+        EXPECT_THAT(error.what(), HasSubstr("not supported on Windows"));
+    }
+#else
     EXPECT_NO_THROW(_runner.runCommand("true", "External QM"));
 
     try
@@ -211,6 +222,7 @@ TEST_F(ExternalQMRunnerTest, propagatesCommandFailure)
     {
         EXPECT_THAT(error.what(), HasSubstr("External QM command failed"));
     }
+#endif
 }
 
 TEST_F(ExternalQMRunnerTest, quotesDftbCommandArguments)

--- a/tests/src/QM/testExternalQMRunner.cpp
+++ b/tests/src/QM/testExternalQMRunner.cpp
@@ -25,6 +25,7 @@
 
 #include <chrono>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -36,9 +37,12 @@
 #include "externalQMRunner.hpp"
 #include "fileSettings.hpp"
 #include "physicalData.hpp"
+#include "pyscfRunner.hpp"
 #include "qmSettings.hpp"
 #include "settings.hpp"
 #include "simulationBox.hpp"
+#include "stringUtilities.hpp"
+#include "turbomoleRunner.hpp"
 
 using customException::QMRunnerException;
 using physicalData::PhysicalData;
@@ -94,6 +98,25 @@ namespace
         [[nodiscard]] bool sawStaleResults() const { return _sawStaleResults; }
     };
 
+    template <class Runner>
+    class CommandCaptureRunner : public Runner
+    {
+       private:
+        mutable std::string _command;
+
+       protected:
+        void executeCommand(
+            const std::string_view command,
+            const std::string_view
+        ) const override
+        {
+            _command = command;
+        }
+
+       public:
+        [[nodiscard]] const std::string &getCommand() const { return _command; }
+    };
+
     class ExternalQMRunnerTest : public testing::Test
     {
        protected:
@@ -104,10 +127,12 @@ namespace
         ExternalQMRunnerHarness _runner;
         QM::DFTBPlusRunner      _dftbRunner;
 
-        QMMethod _qmMethod;
-        JobType  _jobType;
-        bool     _removeNetForce;
-        double   _timeLimit;
+        QMMethod    _qmMethod;
+        JobType     _jobType;
+        bool        _removeNetForce;
+        double      _timeLimit;
+        std::string _qmScript;
+        std::string _dftbFile;
 
         void SetUp() override
         {
@@ -115,12 +140,14 @@ namespace
             _jobType        = Settings::getJobtype();
             _removeNetForce = QMSettings::getRemoveNetForce();
             _timeLimit      = QMSettings::getQMLoopTimeLimit();
+            _qmScript       = QMSettings::getQMScript();
+            _dftbFile       = FileSettings::getDFTBFileName();
             _originalPath   = std::filesystem::current_path();
 
             const auto stamp =
                 std::chrono::steady_clock::now().time_since_epoch().count();
             _workPath = std::filesystem::temp_directory_path() /
-                        ("pq-external-qm-" + std::to_string(stamp));
+                        ("pq external qm; " + std::to_string(stamp));
             ASSERT_TRUE(std::filesystem::create_directory(_workPath));
             std::filesystem::current_path(_workPath);
 
@@ -141,12 +168,32 @@ namespace
             QMSettings::setQMMethod(_qmMethod);
             QMSettings::setRemoveNetForce(_removeNetForce);
             QMSettings::setQMLoopTimeLimit(_timeLimit);
+            QMSettings::setQMScript(_qmScript);
+            FileSettings::setDFTBFileName(_dftbFile);
             Settings::setJobtype(_jobType);
 
             std::filesystem::current_path(_originalPath);
             std::error_code error;
             std::filesystem::remove_all(_workPath, error);
             EXPECT_FALSE(error);
+        }
+
+        std::filesystem::path configureQuotedScript(
+            QM::ExternalQMRunner &runner
+        ) const
+        {
+            const auto scriptDirectory =
+                _workPath / "working path; $(touch qm-injected)";
+            std::filesystem::create_directory(scriptDirectory);
+
+            const auto scriptName = "runner's script; touch qm-injected; #";
+            const auto scriptFile = scriptDirectory / scriptName;
+            writeFile(scriptFile.string(), "");
+
+            runner.setScriptPath(scriptDirectory.string() + '/');
+            QMSettings::setQMScript(scriptName);
+
+            return scriptFile;
         }
     };
 }   // namespace
@@ -164,6 +211,66 @@ TEST_F(ExternalQMRunnerTest, propagatesCommandFailure)
     {
         EXPECT_THAT(error.what(), HasSubstr("External QM command failed"));
     }
+}
+
+TEST_F(ExternalQMRunnerTest, quotesDftbCommandArguments)
+{
+    auto       runner    = CommandCaptureRunner<QM::DFTBPlusRunner>();
+    const auto path      = configureQuotedScript(runner);
+    const auto inputFile = std::string("input file; touch qm-injected");
+    FileSettings::setDFTBFileName(inputFile);
+
+    runner.execute(_simulationBox);
+
+    EXPECT_EQ(
+        std::format(
+            "{} {} 0 0 {} {}",
+            utilities::shellQuote(path.string()),
+            _simulationBox.calcActiveMolCharge(),
+            utilities::shellQuote(inputFile),
+            utilities::shellQuote(FileSettings::getPointChargeFileName())
+        ),
+        runner.getCommand()
+    );
+    EXPECT_FALSE(std::filesystem::exists(_workPath / "qm-injected"));
+}
+
+TEST_F(ExternalQMRunnerTest, quotesPyscfCommandArguments)
+{
+    auto       runner = CommandCaptureRunner<QM::PySCFRunner>();
+    const auto path   = configureQuotedScript(runner);
+
+    runner.execute(_simulationBox);
+
+    EXPECT_EQ(
+        std::format(
+            "python {} > {}",
+            utilities::shellQuote(path.string()),
+            utilities::shellQuote("pyscf.out")
+        ),
+        runner.getCommand()
+    );
+    EXPECT_FALSE(std::filesystem::exists(_workPath / "qm-injected"));
+}
+
+TEST_F(ExternalQMRunnerTest, quotesTurbomoleCommandArguments)
+{
+    auto       runner = CommandCaptureRunner<QM::TurbomoleRunner>();
+    const auto path   = configureQuotedScript(runner);
+
+    runner.execute(_simulationBox);
+
+    EXPECT_EQ(
+        std::format(
+            "{} {} 1 0 {} {}",
+            utilities::shellQuote(path.string()),
+            _simulationBox.calcActiveMolCharge(),
+            utilities::shellQuote(FileSettings::getTMFileName()),
+            utilities::shellQuote(FileSettings::getPointChargeFileName())
+        ),
+        runner.getCommand()
+    );
+    EXPECT_FALSE(std::filesystem::exists(_workPath / "qm-injected"));
 }
 
 TEST_F(ExternalQMRunnerTest, removesStaleResultsBeforeExecution)
@@ -219,7 +326,7 @@ TEST_F(ExternalQMRunnerTest, rejectsIncompleteCharges)
 
 TEST_F(ExternalQMRunnerTest, rejectsNonFiniteCharges)
 {
-    writeFile(FileSettings::getQMChargesTempFileName(), "1 nan\n");
+    writeFile(FileSettings::getQMChargesTempFileName(), "nan\n");
 
     EXPECT_THROW(_runner.readChargeFile(_simulationBox), QMRunnerException);
 }

--- a/tests/src/QM/testExternalQMRunner.cpp
+++ b/tests/src/QM/testExternalQMRunner.cpp
@@ -1,0 +1,248 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "atom.hpp"
+#include "dftbplusRunner.hpp"
+#include "exceptions.hpp"
+#include "externalQMRunner.hpp"
+#include "fileSettings.hpp"
+#include "physicalData.hpp"
+#include "qmSettings.hpp"
+#include "settings.hpp"
+#include "simulationBox.hpp"
+
+using customException::QMRunnerException;
+using physicalData::PhysicalData;
+using settings::FileSettings;
+using settings::JobType;
+using settings::QMMethod;
+using settings::QMSettings;
+using settings::Settings;
+using simulationBox::Atom;
+using simulationBox::SimulationBox;
+using testing::HasSubstr;
+
+namespace
+{
+    void writeFile(const std::string_view fileName, const std::string_view text)
+    {
+        auto file = std::ofstream(std::string(fileName));
+        file << text;
+    }
+
+    class ExternalQMRunnerHarness : public QM::ExternalQMRunner
+    {
+       private:
+        bool _sawStaleResults = false;
+
+       public:
+        void writeCoordsFile(SimulationBox &) override {}
+
+        void execute(SimulationBox &) override
+        {
+            _sawStaleResults = std::filesystem::exists(
+                                   FileSettings::getQMForcesTempFileName()
+                               ) ||
+                               std::filesystem::exists(
+                                   FileSettings::getQMChargesTempFileName()
+                               ) ||
+                               std::filesystem::exists(
+                                   FileSettings::getStressTensorTempFileName()
+                               );
+
+            writeFile(FileSettings::getQMForcesTempFileName(), "0\n0 0 0\n");
+            writeFile(FileSettings::getQMChargesTempFileName(), "0\n");
+        }
+
+        void runCommand(
+            const std::string_view command,
+            const std::string_view program
+        ) const
+        {
+            executeCommand(command, program);
+        }
+
+        [[nodiscard]] bool sawStaleResults() const { return _sawStaleResults; }
+    };
+
+    class ExternalQMRunnerTest : public testing::Test
+    {
+       protected:
+        std::filesystem::path   _originalPath;
+        std::filesystem::path   _workPath;
+        SimulationBox           _simulationBox;
+        PhysicalData            _physicalData;
+        ExternalQMRunnerHarness _runner;
+        QM::DFTBPlusRunner      _dftbRunner;
+
+        QMMethod _qmMethod;
+        JobType  _jobType;
+        bool     _removeNetForce;
+        double   _timeLimit;
+
+        void SetUp() override
+        {
+            _qmMethod       = QMSettings::getQMMethod();
+            _jobType        = Settings::getJobtype();
+            _removeNetForce = QMSettings::getRemoveNetForce();
+            _timeLimit      = QMSettings::getQMLoopTimeLimit();
+            _originalPath   = std::filesystem::current_path();
+
+            const auto stamp =
+                std::chrono::steady_clock::now().time_since_epoch().count();
+            _workPath = std::filesystem::temp_directory_path() /
+                        ("pq-external-qm-" + std::to_string(stamp));
+            ASSERT_TRUE(std::filesystem::create_directory(_workPath));
+            std::filesystem::current_path(_workPath);
+
+            QMSettings::setQMMethod(QMMethod::DFTBPLUS);
+            QMSettings::setRemoveNetForce(false);
+            QMSettings::setQMLoopTimeLimit(0.0);
+            Settings::setJobtype(JobType::QM_MD);
+
+            auto atom = std::make_shared<Atom>();
+            atom->setName("H");
+            _simulationBox.addAtom(atom);
+            _simulationBox.addQMAtom(atom);
+            _simulationBox.setBoxDimensions({10.0, 10.0, 10.0});
+        }
+
+        void TearDown() override
+        {
+            QMSettings::setQMMethod(_qmMethod);
+            QMSettings::setRemoveNetForce(_removeNetForce);
+            QMSettings::setQMLoopTimeLimit(_timeLimit);
+            Settings::setJobtype(_jobType);
+
+            std::filesystem::current_path(_originalPath);
+            std::error_code error;
+            std::filesystem::remove_all(_workPath, error);
+            EXPECT_FALSE(error);
+        }
+    };
+}   // namespace
+
+TEST_F(ExternalQMRunnerTest, propagatesCommandFailure)
+{
+    EXPECT_NO_THROW(_runner.runCommand("true", "External QM"));
+
+    try
+    {
+        _runner.runCommand("false", "External QM");
+        FAIL() << "Expected the failed command to throw";
+    }
+    catch (const QMRunnerException &error)
+    {
+        EXPECT_THAT(error.what(), HasSubstr("External QM command failed"));
+    }
+}
+
+TEST_F(ExternalQMRunnerTest, removesStaleResultsBeforeExecution)
+{
+    writeFile(FileSettings::getQMForcesTempFileName(), "stale");
+    writeFile(FileSettings::getQMChargesTempFileName(), "stale");
+    writeFile(FileSettings::getStressTensorTempFileName(), "stale");
+
+    EXPECT_NO_THROW(
+        _runner.run(
+            _simulationBox,
+            _physicalData,
+            simulationBox::Periodicity::NON_PERIODIC
+        )
+    );
+    EXPECT_FALSE(_runner.sawStaleResults());
+    EXPECT_FALSE(
+        std::filesystem::exists(FileSettings::getStressTensorTempFileName())
+    );
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsIncompleteForces)
+{
+    writeFile(FileSettings::getQMForcesTempFileName(), "0\n0 0\n");
+
+    EXPECT_THROW(
+        _runner.readForceFile(_simulationBox, _physicalData),
+        QMRunnerException
+    );
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsNonFiniteForces)
+{
+    writeFile(FileSettings::getQMForcesTempFileName(), "0\nnan 0 0\n");
+
+    EXPECT_THROW(
+        _runner.readForceFile(_simulationBox, _physicalData),
+        QMRunnerException
+    );
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsIncompleteCharges)
+{
+    auto atom = std::make_shared<Atom>();
+    atom->setName("H");
+    _simulationBox.addAtom(atom);
+    _simulationBox.addQMAtom(atom);
+
+    writeFile(FileSettings::getQMChargesTempFileName(), "0\n");
+
+    EXPECT_THROW(_runner.readChargeFile(_simulationBox), QMRunnerException);
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsNonFiniteCharges)
+{
+    writeFile(FileSettings::getQMChargesTempFileName(), "1 nan\n");
+
+    EXPECT_THROW(_runner.readChargeFile(_simulationBox), QMRunnerException);
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsIncompleteStressTensor)
+{
+    writeFile(FileSettings::getStressTensorTempFileName(), "0 0 0\n0 0 0\n");
+
+    EXPECT_THROW(
+        _dftbRunner.readStressTensor(_simulationBox.getBox(), _physicalData),
+        QMRunnerException
+    );
+}
+
+TEST_F(ExternalQMRunnerTest, rejectsNonFiniteStressTensor)
+{
+    writeFile(
+        FileSettings::getStressTensorTempFileName(),
+        "nan 0 0\n0 0 0\n0 0 0\n"
+    );
+
+    EXPECT_THROW(
+        _dftbRunner.readStressTensor(_simulationBox.getBox(), _physicalData),
+        QMRunnerException
+    );
+}

--- a/tests/src/QM/testExternalQMRunner.cpp
+++ b/tests/src/QM/testExternalQMRunner.cpp
@@ -159,7 +159,6 @@ namespace
             auto atom = std::make_shared<Atom>();
             atom->setName("H");
             _simulationBox.addAtom(atom);
-            _simulationBox.addQMAtom(atom);
             _simulationBox.setBoxDimensions({10.0, 10.0, 10.0});
         }
 
@@ -329,7 +328,6 @@ TEST_F(ExternalQMRunnerTest, rejectsIncompleteCharges)
     auto atom = std::make_shared<Atom>();
     atom->setName("H");
     _simulationBox.addAtom(atom);
-    _simulationBox.addQMAtom(atom);
 
     writeFile(FileSettings::getQMChargesTempFileName(), "0\n");
 

--- a/tests/src/utilities/testStringUtilities.cpp
+++ b/tests/src/utilities/testStringUtilities.cpp
@@ -167,6 +167,16 @@ TEST(TestStringUtilities, firstLetterToUpperCaseCopy)
     EXPECT_EQ("Test", utilities::firstLetterToUpperCaseCopy(line));
 }
 
+TEST(TestStringUtilities, shellQuote)
+{
+    EXPECT_EQ("''", utilities::shellQuote(""));
+    EXPECT_EQ("'path with spaces'", utilities::shellQuote("path with spaces"));
+    EXPECT_EQ(
+        "'a'\"'\"'b; touch nope'",
+        utilities::shellQuote("a'b; touch nope")
+    );
+}
+
 /**
  * @brief test check if file exists
  *


### PR DESCRIPTION
Port #384's external-QM safeguards to `qmmm-dev`.

Tests: `testExternalQMRunner`; `testStringUtilities`.