### PR TITLE
build: restore qmmm-dev compilation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,4 +77,19 @@ jobs:
 
       - name: Run clangd-tidy
         run: |
-          clangd-tidy $(find src/ apps/ include/ -name "*.cpp" -o -name "*.hpp" -o -name "*.tpp" 2>/dev/null) -p=build
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base=HEAD^1
+          else
+            base=HEAD^
+          fi
+
+          mapfile -t files < <(
+            git diff --name-only "$base" HEAD -- src apps include |
+              grep -E '\.(cpp|hpp|tpp)$' || true
+          )
+
+          if ((${#files[@]})); then
+            clangd-tidy "${files[@]}" -p=build
+          else
+            echo "No C++ files changed."
+          fi

--- a/apps/externalQMScripts.hpp
+++ b/apps/externalQMScripts.hpp
@@ -54,7 +54,7 @@ namespace cli
     };
 
     inline constexpr auto turbomoleScripts = std::array{ExternalQMScriptInfo{
-        "turbomole_rimp2",
+        "turbomole_ricc2",
         "RI-MP2",
         "",
         "tm_define.template"

--- a/changes/developer/bugfix.qmmm-settings-compilation.md
+++ b/changes/developer/bugfix.qmmm-settings-compilation.md
@@ -1,0 +1,1 @@
+- Restore builds after the smoothing-method enum update.

--- a/changes/developer/ci.changed-file-lint.md
+++ b/changes/developer/ci.changed-file-lint.md
@@ -1,0 +1,1 @@
+- Limit pull-request linting to changed C++ source files.

--- a/changes/user/bugfix.turbomole-script-catalog.md
+++ b/changes/user/bugfix.turbomole-script-catalog.md
@@ -1,0 +1,1 @@
+- Fix the bundled Turbomole script name offered by validation and setup tools.

--- a/src/settings/hybridSettings.cpp
+++ b/src/settings/hybridSettings.cpp
@@ -39,7 +39,6 @@ std::string settings::string(const SmoothingMethod method)
 
         case HOTSPOT: return "Hotspot";
         case EXACT: return "Exact";
-        case NONE: break;
     }
 
     return "NONE";

--- a/src/settings/waterModelSettings.cpp
+++ b/src/settings/waterModelSettings.cpp
@@ -22,6 +22,8 @@
 
 #include "waterModelSettings.hpp"
 
+#include <format>
+
 #include "exceptions.hpp"        // for customException
 #include "stringUtilities.hpp"   // for toLowerCopy
 

--- a/tests/cmake/testPQCli.cmake
+++ b/tests/cmake/testPQCli.cmake
@@ -268,7 +268,7 @@ if(
 )
     message(FATAL_ERROR "Unexpected PySCF script catalog")
 endif()
-if(NOT turbomole_script STREQUAL "turbomole_rimp2")
+if(NOT turbomole_script STREQUAL "turbomole_ricc2")
     message(FATAL_ERROR "Unexpected Turbomole script: ${turbomole_script}")
 endif()
 if(NOT turbomole_required_file STREQUAL "tm_define.template")

--- a/tests/cmake/testPQValidationEnvironment.cmake
+++ b/tests/cmake/testPQValidationEnvironment.cmake
@@ -232,7 +232,7 @@ file(
     "nstep = 1;\n"
     "timestep = 0.5;\n"
     "qm_prog = turbomole;\n"
-    "qm_script = turbomole_rimp2;\n"
+    "qm_script = turbomole_ricc2;\n"
     "start_file = start.rst;\n"
 )
 assert_valid("turbomole.in" portable)

--- a/tests/src/settings/testExternalQMScripts.cpp
+++ b/tests/src/settings/testExternalQMScripts.cpp
@@ -59,7 +59,7 @@ TEST(ExternalQMScriptsTest, describesBundledScripts)
 
     const auto turbomole = cli::externalQMScripts(QMMethod::TURBOMOLE);
     ASSERT_EQ(turbomole.size(), 1);
-    EXPECT_EQ(turbomole.front().name, "turbomole_rimp2");
+    EXPECT_EQ(turbomole.front().name, "turbomole_ricc2");
     EXPECT_EQ(turbomole.front().requiredWorkingFile, "tm_define.template");
 }
 


### PR DESCRIPTION
Restore qmmm-dev builds, validate the shipped Turbomole script, and lint only changed source files.

Tests: benchmark build + smoke tests; focused script validation.