### PR TITLE
Release-0.7.0 changelog finalization

### DIFF
--- a/.github/workflows/check-pr-for-release-version.yml
+++ b/.github/workflows/check-pr-for-release-version.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check PR Title or Description
+        id: release_version
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -25,18 +26,24 @@ jobs:
           echo "Checking PR body: $body"
 
           # Regex: Release-x.y.z (case-insensitive, numeric x, y, z of variable length)
-          regex='[Rr][Ee][Ll][Ee][Aa][Ss][Ee]-[0-9]+\.[0-9]+\.[0-9]+'
+          regex='[Rr][Ee][Ll][Ee][Aa][Ss][Ee]-([0-9]+\.[0-9]+\.[0-9]+)'
 
-          if [[ "$title" =~ $regex ]] || [[ "$body" =~ $regex ]]; then
-            echo "✅ Found valid Release pattern in title or description."
-            exit 0
+          if [[ "$title" =~ $regex ]]; then
+            version="v${BASH_REMATCH[1]}"
+          elif [[ "$body" =~ $regex ]]; then
+            version="v${BASH_REMATCH[1]}"
           else
             echo "❌ Invalid PR. Title or description must contain: Release-x.y.z (e.g., Release-1.2.3)"
             exit 1
           fi
 
+          echo "✅ Found release version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Test changelog tooling
         run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
 
-      - name: Check release changelog entries
-        run: python3 scripts/update_changelog.py --check
+      - name: Check prepared release changelogs
+        run: >-
+          python3 scripts/update_changelog.py --check-prepared
+          "${{ steps.release_version.outputs.version }}"

--- a/.github/workflows/check-pr-for-release-version.yml
+++ b/.github/workflows/check-pr-for-release-version.yml
@@ -6,13 +6,26 @@ on:
       - main
     types: [opened, edited, reopened, synchronize]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: prepare-release-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-release-pattern:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
 
       - name: Check PR Title or Description
         id: release_version
@@ -43,7 +56,59 @@ jobs:
       - name: Test changelog tooling
         run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
 
-      - name: Check prepared release changelogs
+      - name: Check whether release changelogs are prepared
+        id: changelogs
+        continue-on-error: true
         run: >-
           python3 scripts/update_changelog.py --check-prepared
           "${{ steps.release_version.outputs.version }}"
+
+      - name: Mint repository App token
+        id: app-token
+        if: >-
+          steps.changelogs.outcome == 'failure' &&
+          github.event.action != 'synchronize'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PQ_PERF_BOT_APP_ID }}
+          private-key: ${{ secrets.PQ_PERF_BOT_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Prepare release changelogs
+        if: steps.app-token.outcome == 'success'
+        run: >-
+          python3 scripts/update_changelog.py
+          "${{ steps.release_version.outputs.version }}"
+
+      - name: Verify prepared release changelogs
+        run: >-
+          python3 scripts/update_changelog.py --check-prepared
+          "${{ steps.release_version.outputs.version }}"
+
+      - name: Get repository App user ID
+        id: app-user
+        if: steps.app-token.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          app_user="${{ steps.app-token.outputs.app-slug }}[bot]"
+          user_id="$(gh api "/users/$app_user" --jq .id)"
+          echo "name=$app_user" >> "$GITHUB_OUTPUT"
+          echo "id=$user_id" >> "$GITHUB_OUTPUT"
+
+      - name: Commit prepared release changelogs
+        if: steps.app-token.outcome == 'success'
+        env:
+          APP_USER_ID: ${{ steps.app-user.outputs.id }}
+          APP_USER_NAME: ${{ steps.app-user.outputs.name }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
+        run: |
+          git config user.name "$APP_USER_NAME"
+          git config user.email \
+            "$APP_USER_ID+$APP_USER_NAME@users.noreply.github.com"
+          git add CHANGELOG.md DEV-CHANGELOG.md changes/
+          git commit -m "docs: prepare changelogs for $RELEASE_VERSION"
+          gh auth setup-git
+          git push origin "HEAD:$HEAD_REF"

--- a/.github/workflows/check-pr-for-release-version.yml
+++ b/.github/workflows/check-pr-for-release-version.yml
@@ -6,26 +6,13 @@ on:
       - main
     types: [opened, edited, reopened, synchronize]
 
-permissions:
-  contents: read
-
-concurrency:
-  group: prepare-release-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   check-release-pattern:
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-          submodules: recursive
-          persist-credentials: false
 
       - name: Check PR Title or Description
         id: release_version
@@ -41,9 +28,7 @@ jobs:
           # Regex: Release-x.y.z (case-insensitive, numeric x, y, z of variable length)
           regex='[Rr][Ee][Ll][Ee][Aa][Ss][Ee]-([0-9]+\.[0-9]+\.[0-9]+)'
 
-          if [[ "$title" =~ $regex ]]; then
-            version="v${BASH_REMATCH[1]}"
-          elif [[ "$body" =~ $regex ]]; then
+          if [[ "$title" =~ $regex ]] || [[ "$body" =~ $regex ]]; then
             version="v${BASH_REMATCH[1]}"
           else
             echo "❌ Invalid PR. Title or description must contain: Release-x.y.z (e.g., Release-1.2.3)"
@@ -56,59 +41,7 @@ jobs:
       - name: Test changelog tooling
         run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
 
-      - name: Check whether release changelogs are prepared
-        id: changelogs
-        continue-on-error: true
+      - name: Check prepared release changelogs
         run: >-
           python3 scripts/update_changelog.py --check-prepared
           "${{ steps.release_version.outputs.version }}"
-
-      - name: Mint repository App token
-        id: app-token
-        if: >-
-          steps.changelogs.outcome == 'failure' &&
-          github.event.action != 'synchronize'
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.PQ_PERF_BOT_APP_ID }}
-          private-key: ${{ secrets.PQ_PERF_BOT_PRIVATE_KEY }}
-          permission-contents: write
-
-      - name: Prepare release changelogs
-        if: steps.app-token.outcome == 'success'
-        run: >-
-          python3 scripts/update_changelog.py
-          "${{ steps.release_version.outputs.version }}"
-
-      - name: Verify prepared release changelogs
-        run: >-
-          python3 scripts/update_changelog.py --check-prepared
-          "${{ steps.release_version.outputs.version }}"
-
-      - name: Get repository App user ID
-        id: app-user
-        if: steps.app-token.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          app_user="${{ steps.app-token.outputs.app-slug }}[bot]"
-          user_id="$(gh api "/users/$app_user" --jq .id)"
-          echo "name=$app_user" >> "$GITHUB_OUTPUT"
-          echo "id=$user_id" >> "$GITHUB_OUTPUT"
-
-      - name: Commit prepared release changelogs
-        if: steps.app-token.outcome == 'success'
-        env:
-          APP_USER_ID: ${{ steps.app-user.outputs.id }}
-          APP_USER_NAME: ${{ steps.app-user.outputs.name }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
-        run: |
-          git config user.name "$APP_USER_NAME"
-          git config user.email \
-            "$APP_USER_ID+$APP_USER_NAME@users.noreply.github.com"
-          git add CHANGELOG.md DEV-CHANGELOG.md changes/
-          git commit -m "docs: prepare changelogs for $RELEASE_VERSION"
-          gh auth setup-git
-          git push origin "HEAD:$HEAD_REF"

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -45,25 +45,10 @@ jobs:
           echo "✅ Found release version: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
-      - name: Update changelogs
-        run: |
-          version="${{ steps.extract_version.outputs.version }}"
-          python3 scripts/update_changelog.py "$version"
-
-      - name: Commit and push changelog updates
-        run: |
-          version="${{ steps.extract_version.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git add CHANGELOG.md DEV-CHANGELOG.md changes/
-
-          if git diff --cached --quiet; then
-            echo "ℹ️ No changelog changes to commit."
-          else
-            git commit -m "docs: update changelogs for $version"
-            git push origin HEAD:main
-          fi
+      - name: Verify release changelogs
+        run: >-
+          python3 scripts/update_changelog.py --check-prepared
+          "${{ steps.extract_version.outputs.version }}"
 
       - name: Create Git tag
         id: create_tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ implementation changes are documented in
 ## Next Release
 
 <!-- insertion marker -->
+## [v0.7.0](https://github.com/MolarVerse/PQ/releases/tag/v0.7.0) - 2026-08-06
+
+### New Features
+
+- Add FeNNol as an ASE-based QM runner.
+- Add `mace_mode` to choose between accurate and accelerated MACE execution; accelerated mode requires matching cuequivariance packages.
+- Add the `mm-hessian` job for molecular-mechanics Hessian calculations, with optional geometry optimization.
+- Add `mshake-iter` and `mshake-tolerance` for controlling M-SHAKE convergence.
+- Add `remove_net_force` for removing the total net force from imported QM forces.
+- Add Reaction Field as a long-range electrostatics method.
+- The `PQ` executable now exposes version, help, and compiled capabilities for setup tools.
+- PQ setup tools now expose bundled external-QM scripts and validate input ranges, setting constraints, resource paths, and disabled couplings.
+- Trajectory comments can include the effective simulation step when `include_output_metadata` is enabled.
+
+### Changes
+
+- Clean include directives with IWYU.
+- Rename `mace_model_size` to `mace_model`; the old keyword remains available with a deprecation warning.
+
+### Bug Fixes
+
+- Count non-adjacent duplicate atom types correctly.
+- Prevent the Berendsen thermostat from producing invalid velocities when the kinetic energy is zero.
+- Reject periodic cell-list layouts in which neighbor offsets refer to the same cell more than once.
+- Prevent undefined forces for collinear angle configurations, including linear equilibrium geometries such as CO2.
+- Reject non-finite energies and forces from external QM calculations instead of propagating them into a trajectory.
+- J-coupling topology references now remain valid throughout a simulation, preventing incorrect molecule data.
+- Correct kinetic-virial handling when physical data is copied, including molecular virial calculations.
+- Recompute Langevin noise when the friction setting changes.
+- Fix M-SHAKE convergence, iteration limits, previous-position handling, and velocity corrections for constrained molecules.
+- Reference output is validated before writing, preventing partial files when a referenced file cannot be read.
+- Single-step simulations now complete their progress indicator without dividing by zero.
+- Preserve molecular geometry and wrap positions correctly during stochastic cell rescaling.
+- Display subsection percentages of total time correctly in the `.timings` output file.
+
+### Performance
+
+- Skip inactive terms in Guff pair-potential calculations.
+
+### Build and Compatibility
+
+- Allow builds without ASE even when built-in SLAKOS data is unavailable.
+- Make native optimizations and link-time optimization configurable, and use available compiler caches and faster linkers automatically.
+- Add support for Clang and Apple Clang.
+- Add support for building Debug mode with Clang
+- Installed PQ now resolves reference data, external-QM scripts, and Slakos files relative to its installation prefix.
+
+### Documentation
+
+- Rework the quick start, examples, troubleshooting, setup-file guidance, and reference manual.
+
 ## [v0.6.4](https://github.com/MolarVerse/PQ/releases/tag/v0.6.4) - 2026-03-31
 
 ### Bug Fixes

--- a/DEV-CHANGELOG.md
+++ b/DEV-CHANGELOG.md
@@ -8,3 +8,110 @@ in `CHANGELOG.md`.
 ## Next Release
 
 <!-- insertion marker -->
+## [v0.7.0](https://github.com/MolarVerse/PQ/releases/tag/v0.7.0) - 2026-08-06
+
+### Enhancements
+
+- Add FeNNol references and its QM runner.
+- Add `mace_mode` for selecting accurate or accelerated MACE execution.
+- Add the MM Hessian workflow.
+- Add `mshake-iter` and `mshake-tolerance`.
+- Add net-force removal for imported QM forces.
+- Implement Reaction Field long-range correction.
+
+### Bug Fixes
+
+- Count non-adjacent atom types correctly.
+- Guard the Berendsen thermostat against zero-temperature invalid values.
+- Reject aliased cell-list layouts.
+- Guard angle-force division for collinear configurations.
+- Reject non-finite external QM energies and forces.
+- Refresh the Langevin noise amplitude after friction changes.
+- Correct M-SHAKE loop bounds, convergence, iteration limits, time units, and previous-position handling.
+- Correct the no-PBC squared-distance calculation.
+- Define `ParameterFileReader` destruction where `ParameterFileSection` is complete so AppleClang builds succeed.
+- Export the potential force kernels.
+- Guard SLAKOS tests in builds without ASE.
+- Preserve molecular geometry during manostat scaling.
+
+### Performance
+
+- Skip zero-coefficient terms in `GuffPair::calculate`.
+
+### Build
+
+- Add the `.tpp` extension to `addLicense.sh`.
+
+### CI
+
+- Warm build caches from `dev` and `main`.
+- Build portable binaries for reusable compiler caches.
+- Require regular pull requests to add audience-qualified changelog entries.
+- Split user and developer changelogs and require curated user notes in release pull requests.
+- Replace per-PR changelog edits with release-time generation.
+- Add a workflow that dismisses stale PR approvals on real code changes but keeps them when a push only merges dev's tip into the PR branch.
+- Cache the integration-test environment.
+- Fix integration-test environment setup.
+- Cache base-branch performance instruction counts.
+- Run the performance gate only for relevant changes.
+- Post performance results as a persistent pull-request comment.
+- Add the callgrind instruction-count regression gate.
+- After a release is triggered, open a pull request from `main` to `dev` for approval instead of merging directly under the branch-protection rules.
+- Finalize release changelogs in the release pull request before tagging protected branches.
+- Keep automated release tags consistent with the existing v-prefixed version format.
+- Limit changed-file formatting checks to pull requests targeting dev.
+- Pass release PR metadata safely into shell validation.
+
+### Tests
+
+- Cover the renamed ASE MACE runner.
+- Expand coverage for reset kinetics, output writers, optimizers, evaluators, settings, force fields, thermostats, manostats, cell lists, and setup paths.
+- Add explicit coverage for enum sentinels.
+- Add FeNNol parser and runner tests.
+- Add brute-force and cell-list force-equivalence tests.
+- Add Hessian-builder tests.
+- Add an integration test for the atomic virial correction.
+- Add the math and algorithm regression suite.
+- Add M-SHAKE keyword, convergence, unit, loop-bound, and state tests.
+- Add fixed-work performance benchmarks for force kernels, pair potentials, linear algebra, box transforms, integration, kinetics, and constraints.
+- Add Reaction Field unit and long-range-correction tests.
+
+### Internal
+
+- Rename the ASE-based MACE runner classes consistently.
+- Prefix performance benchmark filenames.
+- Avoid a temporary vector during cell-list rebuilds.
+- Move changelog fragments into `changes/user/` and `changes/developer/` directories with `<category>.<title>.md` naming, and allow a fragment to hold multiple bullets.
+- Document the changelog fragment workflow in the Sphinx developer guide.
+- Organize migrated release notes into scope-specific fragments and validate content-preserving fragment reorganizations.
+- Add first version of CI for static analysis via clangd and clang-tidy (all clangd-tidy checks for now disabled apart a test check)
+- fix all `bugprone-*` apart from `bugprone-easily-swappable-parameters` warnings of code base
+- remove `<chrono>` transient header from timer as it was included in every single TU at the moment
+- remove transient pybind headers from `AseRunners` to decrease compilation parsing time by about 5-6% (total speedup approx. 4%)
+- remove more `matrix.hpp` header inclusions -- until now `mShake.hpp` exposed the header in its public API and therefore it ended up via `constraints.hpp` in `engine.hpp` and therefore almost everywhere, included `Eigen`
+- remove `matrix.hpp` dependency from `ForceFieldNonCoulomb` class as it was again included transitively in many many TUs
+- remove some useless public API functions from `ForceFieldNonCoulomb` class for easier maintainance as they were only used for testing
+- add pre-compiled-headers (pchs) to speedup compilation time ~20%
+- zero-initialize kinetic-energy accumulator tensors exposed by PCH-enabled builds
+- Return cell and neighbor collections by constant reference.
+- Inline Coulomb cutoff getters.
+- Remove default branches from enum switches and share sentinel fallbacks.
+- Make the input parser's `bind_front` approach clangd-compliant.
+- Move input validation into the engine configuration path.
+- Remove the unused Kokkos integrator implementation.
+- Add language-server configuration.
+- remove type alias for output namespace from pq namespace
+- add `DefaultFile` class for default file names and use it also in `EnergyOutput` to avoid manually repeating the default file names
+- remove `matrix.hpp` header from `typeAliases.hpp` as this way the `Eigen` library get included everywhere
+- remove `thermostat` namespace from `typeAliases.hpp`
+- remove `opt` namespace entries of `typeAliases.hpp`
+- remove `virial` namespace types for `typeAliases.hpp`
+- remove all `std` aliases from `typeaAliases.hpp`
+- remove `resetKinetics` from `typeAliases.hpp`
+
+### Documentation
+
+- Add shared contributor guidance.
+- Update the feature list and PQ reference.
+- Document Reaction Field, M-SHAKE, and FeNNol.
+- Refresh the reference manual, quick start, examples, and troubleshooting.

--- a/changes/developer/bugfix.atom-type-counting.md
+++ b/changes/developer/bugfix.atom-type-counting.md
@@ -1,1 +1,0 @@
-- Count non-adjacent atom types correctly.

--- a/changes/developer/bugfix.berendsen-zero-temperature.md
+++ b/changes/developer/bugfix.berendsen-zero-temperature.md
@@ -1,1 +1,0 @@
-- Guard the Berendsen thermostat against zero-temperature invalid values.

--- a/changes/developer/bugfix.cell-list-aliasing.md
+++ b/changes/developer/bugfix.cell-list-aliasing.md
@@ -1,1 +1,0 @@
-- Reject aliased cell-list layouts.

--- a/changes/developer/bugfix.collinear-angle-forces.md
+++ b/changes/developer/bugfix.collinear-angle-forces.md
@@ -1,1 +1,0 @@
-- Guard angle-force division for collinear configurations.

--- a/changes/developer/bugfix.external-qm-finite-values.md
+++ b/changes/developer/bugfix.external-qm-finite-values.md
@@ -1,1 +1,0 @@
-- Reject non-finite external QM energies and forces.

--- a/changes/developer/bugfix.langevin-friction.md
+++ b/changes/developer/bugfix.langevin-friction.md
@@ -1,1 +1,0 @@
-- Refresh the Langevin noise amplitude after friction changes.

--- a/changes/developer/bugfix.mshake.md
+++ b/changes/developer/bugfix.mshake.md
@@ -1,1 +1,0 @@
-- Correct M-SHAKE loop bounds, convergence, iteration limits, time units, and previous-position handling.

--- a/changes/developer/bugfix.no-pbc-distance.md
+++ b/changes/developer/bugfix.no-pbc-distance.md
@@ -1,1 +1,0 @@
-- Correct the no-PBC squared-distance calculation.

--- a/changes/developer/bugfix.potential-force-exports.md
+++ b/changes/developer/bugfix.potential-force-exports.md
@@ -1,1 +1,0 @@
-- Export the potential force kernels.

--- a/changes/developer/bugfix.slakos-without-ase.md
+++ b/changes/developer/bugfix.slakos-without-ase.md
@@ -1,1 +1,0 @@
-- Guard SLAKOS tests in builds without ASE.

--- a/changes/developer/bugfix.stochastic-manostat.md
+++ b/changes/developer/bugfix.stochastic-manostat.md
@@ -1,1 +1,0 @@
-- Preserve molecular geometry during manostat scaling.

--- a/changes/developer/build.scripts.md
+++ b/changes/developer/build.scripts.md
@@ -1,1 +1,0 @@
-- Add the `.tpp` extension to `addLicense.sh`.

--- a/changes/developer/ci.build-caches.md
+++ b/changes/developer/ci.build-caches.md
@@ -1,2 +1,0 @@
-- Warm build caches from `dev` and `main`.
-- Build portable binaries for reusable compiler caches.

--- a/changes/developer/ci.changelog-audience.md
+++ b/changes/developer/ci.changelog-audience.md
@@ -1,3 +1,0 @@
-- Require regular pull requests to add audience-qualified changelog entries.
-- Split user and developer changelogs and require curated user notes in release pull requests.
-- Replace per-PR changelog edits with release-time generation.

--- a/changes/developer/ci.dismiss-stale-approvals.md
+++ b/changes/developer/ci.dismiss-stale-approvals.md
@@ -1,1 +1,0 @@
-- Add a workflow that dismisses stale PR approvals on real code changes but keeps them when a push only merges dev's tip into the PR branch.

--- a/changes/developer/ci.integration-tests.md
+++ b/changes/developer/ci.integration-tests.md
@@ -1,2 +1,0 @@
-- Cache the integration-test environment.
-- Fix integration-test environment setup.

--- a/changes/developer/ci.performance-gate.md
+++ b/changes/developer/ci.performance-gate.md
@@ -1,4 +1,0 @@
-- Cache base-branch performance instruction counts.
-- Run the performance gate only for relevant changes.
-- Post performance results as a persistent pull-request comment.
-- Add the callgrind instruction-count regression gate.

--- a/changes/developer/ci.release-branch-protection.md
+++ b/changes/developer/ci.release-branch-protection.md
@@ -1,1 +1,0 @@
-- After a release is triggered, open a pull request from `main` to `dev` for approval instead of merging directly under the branch-protection rules.

--- a/changes/developer/ci.release-tag-prefix.md
+++ b/changes/developer/ci.release-tag-prefix.md
@@ -1,3 +1,0 @@
-- Keep automated release tags consistent with the existing v-prefixed version format.
-- Limit changed-file formatting checks to pull requests targeting dev.
-- Pass release PR metadata safely into shell validation.

--- a/changes/developer/documentation.ai.md
+++ b/changes/developer/documentation.ai.md
@@ -1,1 +1,0 @@
-- Add Claude Code and AI-agent instructions.

--- a/changes/developer/documentation.reference-refresh.md
+++ b/changes/developer/documentation.reference-refresh.md
@@ -1,3 +1,0 @@
-- Update the feature list and PQ reference.
-- Document Reaction Field, M-SHAKE, and FeNNol.
-- Refresh the reference manual, quick start, examples, and troubleshooting.

--- a/changes/developer/enhancement.fennol.md
+++ b/changes/developer/enhancement.fennol.md
@@ -1,1 +1,0 @@
-- Add FeNNol references and its QM runner.

--- a/changes/developer/enhancement.mace-execution.md
+++ b/changes/developer/enhancement.mace-execution.md
@@ -1,1 +1,0 @@
-- Add `mace_mode` for selecting accurate or accelerated MACE execution.

--- a/changes/developer/enhancement.mm-hessian.md
+++ b/changes/developer/enhancement.mm-hessian.md
@@ -1,1 +1,0 @@
-- Add the MM Hessian workflow.

--- a/changes/developer/enhancement.mshake-controls.md
+++ b/changes/developer/enhancement.mshake-controls.md
@@ -1,1 +1,0 @@
-- Add `mshake-iter` and `mshake-tolerance`.

--- a/changes/developer/enhancement.qm-net-force.md
+++ b/changes/developer/enhancement.qm-net-force.md
@@ -1,1 +1,0 @@
-- Add net-force removal for imported QM forces.

--- a/changes/developer/enhancement.reaction-field.md
+++ b/changes/developer/enhancement.reaction-field.md
@@ -1,1 +1,0 @@
-- Implement Reaction Field long-range correction.

--- a/changes/developer/internal.ase-mace-renaming.md
+++ b/changes/developer/internal.ase-mace-renaming.md
@@ -1,1 +1,0 @@
-- Rename the ASE-based MACE runner classes consistently.

--- a/changes/developer/internal.benchmark-prefixes.md
+++ b/changes/developer/internal.benchmark-prefixes.md
@@ -1,1 +1,0 @@
-- Prefix performance benchmark filenames.

--- a/changes/developer/internal.cell-list-rebuild.md
+++ b/changes/developer/internal.cell-list-rebuild.md
@@ -1,1 +1,0 @@
-- Avoid a temporary vector during cell-list rebuilds.

--- a/changes/developer/internal.changelog-fragment-layout.md
+++ b/changes/developer/internal.changelog-fragment-layout.md
@@ -1,3 +1,0 @@
-- Move changelog fragments into `changes/user/` and `changes/developer/` directories with `<category>.<title>.md` naming, and allow a fragment to hold multiple bullets.
-- Document the changelog fragment workflow in the Sphinx developer guide.
-- Organize migrated release notes into scope-specific fragments and validate content-preserving fragment reorganizations.

--- a/changes/developer/internal.clangd.md
+++ b/changes/developer/internal.clangd.md
@@ -1,2 +1,0 @@
-- Add first version of CI for static analysis via clangd and clang-tidy (all clangd-tidy checks for now disabled apart a test check)
-- fix all `bugprone-*` apart from `bugprone-easily-swappable-parameters` warnings of code base

--- a/changes/developer/internal.compilation.md
+++ b/changes/developer/internal.compilation.md
@@ -1,7 +1,0 @@
-- remove `<chrono>` transient header from timer as it was included in every single TU at the moment
-- remove transient pybind headers from `AseRunners` to decrease compilation parsing time by about 5-6% (total speedup approx. 4%)
-- remove more `matrix.hpp` header inclusions -- until now `mShake.hpp` exposed the header in its public API and therefore it ended up via `constraints.hpp` in `engine.hpp` and therefore almost everywhere, included `Eigen`
-- remove `matrix.hpp` dependency from `ForceFieldNonCoulomb` class as it was again included transitively in many many TUs
-- remove some useless public API functions from `ForceFieldNonCoulomb` class for easier maintainance as they were only used for testing
-- add pre-compiled-headers (pchs) to speedup compilation time ~20%
-- zero-initialize kinetic-energy accumulator tensors exposed by PCH-enabled builds

--- a/changes/developer/internal.const-collections.md
+++ b/changes/developer/internal.const-collections.md
@@ -1,1 +1,0 @@
-- Return cell and neighbor collections by constant reference.

--- a/changes/developer/internal.coulomb-cutoffs.md
+++ b/changes/developer/internal.coulomb-cutoffs.md
@@ -1,1 +1,0 @@
-- Inline Coulomb cutoff getters.

--- a/changes/developer/internal.enum-switches.md
+++ b/changes/developer/internal.enum-switches.md
@@ -1,1 +1,0 @@
-- Remove default branches from enum switches and share sentinel fallbacks.

--- a/changes/developer/internal.input-parser.md
+++ b/changes/developer/internal.input-parser.md
@@ -1,1 +1,0 @@
-- Make the input parser's `bind_front` approach clangd-compliant.

--- a/changes/developer/internal.input-validation.md
+++ b/changes/developer/internal.input-validation.md
@@ -1,1 +1,0 @@
-- Move input validation into the engine configuration path.

--- a/changes/developer/internal.kokkos.md
+++ b/changes/developer/internal.kokkos.md
@@ -1,1 +1,0 @@
-- Remove the unused Kokkos integrator implementation.

--- a/changes/developer/internal.language-server.md
+++ b/changes/developer/internal.language-server.md
@@ -1,1 +1,0 @@
-- Add language-server configuration.

--- a/changes/developer/internal.type-aliases.md
+++ b/changes/developer/internal.type-aliases.md
@@ -1,8 +1,0 @@
-- remove type alias for output namespace from pq namespace
-- add `DefaultFile` class for default file names and use it also in `EnergyOutput` to avoid manually repeating the default file names
-- remove `matrix.hpp` header from `typeAliases.hpp` as this way the `Eigen` library get included everywhere
-- remove `thermostat` namespace from `typeAliases.hpp`
-- remove `opt` namespace entries of `typeAliases.hpp`
-- remove `virial` namespace types for `typeAliases.hpp`
-- remove all `std` aliases from `typeaAliases.hpp`
-- remove `resetKinetics` from `typeAliases.hpp`

--- a/changes/developer/performance.guff-zero-coefficients.md
+++ b/changes/developer/performance.guff-zero-coefficients.md
@@ -1,1 +1,0 @@
-- Skip zero-coefficient terms in `GuffPair::calculate`.

--- a/changes/developer/test.ase-mace.md
+++ b/changes/developer/test.ase-mace.md
@@ -1,1 +1,0 @@
-- Cover the renamed ASE MACE runner.

--- a/changes/developer/test.coverage-expansion.md
+++ b/changes/developer/test.coverage-expansion.md
@@ -1,1 +1,0 @@
-- Expand coverage for reset kinetics, output writers, optimizers, evaluators, settings, force fields, thermostats, manostats, cell lists, and setup paths.

--- a/changes/developer/test.enum-sentinels.md
+++ b/changes/developer/test.enum-sentinels.md
@@ -1,1 +1,0 @@
-- Add explicit coverage for enum sentinels.

--- a/changes/developer/test.fennol.md
+++ b/changes/developer/test.fennol.md
@@ -1,1 +1,0 @@
-- Add FeNNol parser and runner tests.

--- a/changes/developer/test.force-equivalence.md
+++ b/changes/developer/test.force-equivalence.md
@@ -1,1 +1,0 @@
-- Add brute-force and cell-list force-equivalence tests.

--- a/changes/developer/test.hessian.md
+++ b/changes/developer/test.hessian.md
@@ -1,1 +1,0 @@
-- Add Hessian-builder tests.

--- a/changes/developer/test.integration-test-atomic-virial.md
+++ b/changes/developer/test.integration-test-atomic-virial.md
@@ -1,1 +1,0 @@
-- Add integration test for atomic virial correction in integration_tests/cgo/

--- a/changes/developer/test.math-algorithms.md
+++ b/changes/developer/test.math-algorithms.md
@@ -1,1 +1,0 @@
-- Add the math and algorithm regression suite.

--- a/changes/developer/test.mshake.md
+++ b/changes/developer/test.mshake.md
@@ -1,1 +1,0 @@
-- Add M-SHAKE keyword, convergence, unit, loop-bound, and state tests.

--- a/changes/developer/test.performance-benchmarks.md
+++ b/changes/developer/test.performance-benchmarks.md
@@ -1,1 +1,0 @@
-- Add fixed-work performance benchmarks for force kernels, pair potentials, linear algebra, box transforms, integration, kinetics, and constraints.

--- a/changes/developer/test.reaction-field.md
+++ b/changes/developer/test.reaction-field.md
@@ -1,1 +1,0 @@
-- Add Reaction Field unit and long-range-correction tests.

--- a/changes/parameter-reader-destructor.developer.bugfix.md
+++ b/changes/parameter-reader-destructor.developer.bugfix.md
@@ -1,1 +1,0 @@
-- Define `ParameterFileReader` destruction where `ParameterFileSection` is complete so AppleClang builds succeed.

--- a/changes/user/bugfix.atom-type-counting.md
+++ b/changes/user/bugfix.atom-type-counting.md
@@ -1,1 +1,0 @@
-- Count non-adjacent duplicate atom types correctly.

--- a/changes/user/bugfix.berendsen-zero-temperature.md
+++ b/changes/user/bugfix.berendsen-zero-temperature.md
@@ -1,1 +1,0 @@
-- Prevent the Berendsen thermostat from producing invalid velocities when the kinetic energy is zero.

--- a/changes/user/bugfix.cell-list-aliasing.md
+++ b/changes/user/bugfix.cell-list-aliasing.md
@@ -1,1 +1,0 @@
-- Reject periodic cell-list layouts in which neighbor offsets refer to the same cell more than once.

--- a/changes/user/bugfix.collinear-angle-forces.md
+++ b/changes/user/bugfix.collinear-angle-forces.md
@@ -1,1 +1,0 @@
-- Prevent undefined forces for collinear angle configurations, including linear equilibrium geometries such as CO2.

--- a/changes/user/bugfix.external-qm-finite-values.md
+++ b/changes/user/bugfix.external-qm-finite-values.md
@@ -1,1 +1,0 @@
-- Reject non-finite energies and forces from external QM calculations instead of propagating them into a trajectory.

--- a/changes/user/bugfix.jcoupling-topology-pointers.md
+++ b/changes/user/bugfix.jcoupling-topology-pointers.md
@@ -1,1 +1,0 @@
-- J-coupling topology references now remain valid throughout a simulation, preventing incorrect molecule data.

--- a/changes/user/bugfix.kinetic-virial.md
+++ b/changes/user/bugfix.kinetic-virial.md
@@ -1,2 +1,0 @@
-- Fix the virial mode used after copying physical data with atomic virial enabled.
-- Fix molecular virial broken with exception after previous bugfix

--- a/changes/user/bugfix.langevin-friction.md
+++ b/changes/user/bugfix.langevin-friction.md
@@ -1,1 +1,0 @@
-- Recompute Langevin noise when the friction setting changes.

--- a/changes/user/bugfix.mshake.md
+++ b/changes/user/bugfix.mshake.md
@@ -1,1 +1,0 @@
-- Fix M-SHAKE convergence, iteration limits, previous-position handling, and velocity corrections for constrained molecules.

--- a/changes/user/bugfix.reference-output.md
+++ b/changes/user/bugfix.reference-output.md
@@ -1,1 +1,0 @@
-- Reference output is validated before writing, preventing partial files when a referenced file cannot be read.

--- a/changes/user/bugfix.single-step-progressbar.md
+++ b/changes/user/bugfix.single-step-progressbar.md
@@ -1,1 +1,0 @@
-- Single-step simulations now complete their progress indicator without dividing by zero.

--- a/changes/user/bugfix.stochastic-manostat.md
+++ b/changes/user/bugfix.stochastic-manostat.md
@@ -1,1 +1,0 @@
-- Preserve molecular geometry and wrap positions correctly during stochastic cell rescaling.

--- a/changes/user/bugfix.timings-subsection-percent.md
+++ b/changes/user/bugfix.timings-subsection-percent.md
@@ -1,1 +1,0 @@
-- Display subsection percentages of total time correctly in the `.timings` output file.

--- a/changes/user/change.include-cleanup.md
+++ b/changes/user/change.include-cleanup.md
@@ -1,1 +1,0 @@
-- Clean include directives with IWYU.

--- a/changes/user/change.mace-model-keyword.md
+++ b/changes/user/change.mace-model-keyword.md
@@ -1,1 +1,0 @@
-- Rename `mace_model_size` to `mace_model`; the old keyword remains available with a deprecation warning.

--- a/changes/user/compatibility.ase-optional.md
+++ b/changes/user/compatibility.ase-optional.md
@@ -1,1 +1,0 @@
-- Allow builds without ASE even when built-in SLAKOS data is unavailable.

--- a/changes/user/compatibility.build-optimization.md
+++ b/changes/user/compatibility.build-optimization.md
@@ -1,1 +1,0 @@
-- Make native optimizations and link-time optimization configurable, and use available compiler caches and faster linkers automatically.

--- a/changes/user/compatibility.clang.md
+++ b/changes/user/compatibility.clang.md
@@ -1,2 +1,0 @@
-- Add support for Clang and Apple Clang.
-- Add support for building Debug mode with Clang

--- a/changes/user/compatibility.runtime-assets.md
+++ b/changes/user/compatibility.runtime-assets.md
@@ -1,1 +1,0 @@
-- Installed PQ now resolves reference data, external-QM scripts, and Slakos files relative to its installation prefix.

--- a/changes/user/documentation.reference-refresh.md
+++ b/changes/user/documentation.reference-refresh.md
@@ -1,1 +1,0 @@
-- Rework the quick start, examples, troubleshooting, setup-file guidance, and reference manual.

--- a/changes/user/enhancement.fennol.md
+++ b/changes/user/enhancement.fennol.md
@@ -1,1 +1,0 @@
-- Add FeNNol as an ASE-based QM runner.

--- a/changes/user/enhancement.mace-execution.md
+++ b/changes/user/enhancement.mace-execution.md
@@ -1,1 +1,0 @@
-- Add `mace_mode` to choose between accurate and accelerated MACE execution; accelerated mode requires matching cuequivariance packages.

--- a/changes/user/enhancement.mm-hessian.md
+++ b/changes/user/enhancement.mm-hessian.md
@@ -1,1 +1,0 @@
-- Add the `mm-hessian` job for molecular-mechanics Hessian calculations, with optional geometry optimization.

--- a/changes/user/enhancement.mshake-controls.md
+++ b/changes/user/enhancement.mshake-controls.md
@@ -1,1 +1,0 @@
-- Add `mshake-iter` and `mshake-tolerance` for controlling M-SHAKE convergence.

--- a/changes/user/enhancement.qm-net-force.md
+++ b/changes/user/enhancement.qm-net-force.md
@@ -1,1 +1,0 @@
-- Add `remove_net_force` for removing the total net force from imported QM forces.

--- a/changes/user/enhancement.reaction-field.md
+++ b/changes/user/enhancement.reaction-field.md
@@ -1,1 +1,0 @@
-- Add Reaction Field as a long-range electrostatics method.

--- a/changes/user/enhancement.setup-cli.md
+++ b/changes/user/enhancement.setup-cli.md
@@ -1,2 +1,0 @@
-- The `PQ` executable now exposes version, help, and compiled capabilities for setup tools.
-- PQ setup tools now expose bundled external-QM scripts and validate input ranges, setting constraints, resource paths, and disabled couplings.

--- a/changes/user/enhancement.trajectory-metadata.md
+++ b/changes/user/enhancement.trajectory-metadata.md
@@ -1,1 +1,0 @@
-- Trajectory comments can include the effective simulation step when `include_output_metadata` is enabled.

--- a/changes/user/performance.guff-zero-coefficients.md
+++ b/changes/user/performance.guff-zero-coefficients.md
@@ -1,1 +1,0 @@
-- Skip inactive terms in Guff pair-potential calculations.

--- a/scripts/tests/test_update_changelog.py
+++ b/scripts/tests/test_update_changelog.py
@@ -193,6 +193,49 @@ class ChangelogTests(unittest.TestCase):
             self.assertIn("- Enforce changelog audiences.", dev_text)
             self.assertFalse(developer_fragment.exists())
 
+    def test_prepared_release_requires_stamp_and_no_fragments(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            user_changelog = root / "CHANGELOG.md"
+            dev_changelog = root / "DEV-CHANGELOG.md"
+            changes_dir = root / "changes"
+            changes_dir.mkdir()
+
+            user_changelog.write_text(
+                "# Changelog\n\n## Next Release\n",
+                encoding="utf-8",
+            )
+            dev_changelog.write_text(
+                "# Developer Changelog\n\n"
+                "## Next Release\n\n"
+                "## [v1.1.0](release-url) - 2025-02-01\n",
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(
+                    CHANGELOG, "USER_CHANGELOG", user_changelog
+                ),
+                mock.patch.object(
+                    CHANGELOG, "DEV_CHANGELOG", dev_changelog
+                ),
+                mock.patch.object(CHANGELOG, "CHANGES_DIR", changes_dir),
+            ):
+                CHANGELOG.check_prepared_changelogs("v1.1.0")
+
+                legacy_fragment = changes_dir / "legacy.internal.md"
+                legacy_fragment.write_text(
+                    "- Legacy fragment.\n", encoding="utf-8"
+                )
+                with self.assertRaisesRegex(
+                    SystemExit, "unprocessed changelog fragments"
+                ):
+                    CHANGELOG.check_prepared_changelogs("v1.1.0")
+
+                legacy_fragment.unlink()
+                with self.assertRaisesRegex(SystemExit, "not prepared"):
+                    CHANGELOG.check_prepared_changelogs("v1.2.0")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -7,6 +7,7 @@ matching changelog and preserves existing unreleased and released entries.
 
 Usage:
     update_changelog.py --check
+    update_changelog.py --check-prepared <version>
     update_changelog.py <version>
 """
 
@@ -182,6 +183,34 @@ def check_release_changelogs():
     print("the release contains changelog entries")
 
 
+def check_prepared_changelogs(version):
+    """Check that a release is stamped and no fragments remain."""
+    header_prefix = f"## [{version}]("
+    user_lines = load_changelog(USER_CHANGELOG)
+    dev_lines = load_changelog(DEV_CHANGELOG)
+
+    if not any(line.startswith(header_prefix) for line in user_lines) and not any(
+        line.startswith(header_prefix) for line in dev_lines
+    ):
+        sys.exit(
+            f"release changelogs are not prepared for {version}; "
+            f"run scripts/update_changelog.py {version}"
+        )
+
+    remaining = sorted(
+        path
+        for path in CHANGES_DIR.rglob("*.md")
+        if path.name != "README.md"
+    )
+    if remaining:
+        names = ", ".join(
+            str(path.relative_to(CHANGES_DIR)) for path in remaining
+        )
+        sys.exit(f"release contains unprocessed changelog fragments: {names}")
+
+    print(f"release changelogs are prepared for {version}")
+
+
 def update_changelogs(version):
     repo = os.getenv("GITHUB_REPOSITORY", "MolarVerse/PQ")
 
@@ -241,8 +270,15 @@ def update_changelogs(version):
 
 
 def main():
+    if len(sys.argv) == 3 and sys.argv[1] == "--check-prepared":
+        check_prepared_changelogs(sys.argv[2])
+        return
+
     if len(sys.argv) != 2:
-        sys.exit(f"usage: {sys.argv[0]} --check | <version>")
+        sys.exit(
+            f"usage: {sys.argv[0]} --check | "
+            "--check-prepared <version> | <version>"
+        )
 
     argument = sys.argv[1]
     if argument == "--check":


### PR DESCRIPTION
The v0.7.0 release could not push generated changelogs directly to protected `main`.

This PR prepares v0.7.0 before tagging. After merge, the workflow creates the tag, release, and `main` to `dev` sync PR.