### PR TITLE
fix: handle release recovery conflicts

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -111,8 +111,7 @@ jobs:
               fi
             fi
 
-            git restore --source=origin/dev --staged --worktree -- .
-            git add --all
+            git read-tree --reset -u origin/dev
             git commit -m "revert: restore $VERSION release from dev"
 
             if [[ "$(git rev-parse HEAD^{tree})" != \

--- a/changes/developer/bugfix.release-recovery-conflicts.md
+++ b/changes/developer/bugfix.release-recovery-conflicts.md
@@ -1,0 +1,1 @@
+- Fix release recovery when main and dev contain deleted or conflicted files.


### PR DESCRIPTION
Uses the `dev` tree to resolve rollback conflicts while preserving merge ancestry. Keeps the fix in the released tree.