### PR TITLE
ci: fix release and sync PR automation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   check-changelog-fragment:
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository ||
+      github.event.pull_request.head.ref != 'main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -130,11 +130,28 @@ jobs:
           NUMBER: ${{ steps.release.outputs.number }}
           VERSION: ${{ steps.release.outputs.version }}
         run: |
-          gh pr create \
+          release_notes="$(gh api --method POST \
+            "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            -f tag_name="$VERSION" \
+            -f target_commitish="$BRANCH" \
+            --jq .body)"
+
+          pr_url="$(gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "Release-$NUMBER" \
             --body "Release $VERSION." \
-            --label release \
-            --reviewer 97gamjak \
-            --reviewer ape33
+            --label release)"
+          echo "Created release pull request: $pr_url"
+
+          pr_number="$(gh pr view "$pr_url" --json number --jq .number)"
+          while IFS= read -r reviewer; do
+            if ! gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/pulls/$pr_number/requested_reviewers" \
+              -f "reviewers[]=$reviewer" >/dev/null; then
+              echo "::warning::Could not request review from @$reviewer."
+            fi
+          done < <(
+            printf '%s\n' "$release_notes" |
+              python3 scripts/release_reviewers.py "$GITHUB_REPOSITORY"
+          )

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -135,4 +135,6 @@ jobs:
             --head "$BRANCH" \
             --title "Release-$NUMBER" \
             --body "Release $VERSION." \
-            --label release
+            --label release \
+            --reviewer 97gamjak \
+            --reviewer ape33

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,10 +281,25 @@ jobs:
             exit 0
           fi
 
-          gh pr create \
+          pr_url="$(gh pr create \
             --base dev \
             --head main \
             --title "Sync main into dev after $VERSION" \
-            --body "Sync release $VERSION back into dev." \
-            --reviewer 97gamjak \
-            --reviewer ape33
+            --body "Sync release $VERSION back into dev.")"
+          echo "Created sync pull request: $pr_url"
+
+          release_notes="$(gh api --method POST \
+            "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            -f tag_name="$VERSION" \
+            --jq .body)"
+          pr_number="$(gh pr view "$pr_url" --json number --jq .number)"
+          while IFS= read -r reviewer; do
+            if ! gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/pulls/$pr_number/requested_reviewers" \
+              -f "reviewers[]=$reviewer" >/dev/null; then
+              echo "::warning::Could not request review from @$reviewer."
+            fi
+          done < <(
+            printf '%s\n' "$release_notes" |
+              python3 scripts/release_reviewers.py "$GITHUB_REPOSITORY"
+          )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,16 +181,13 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           MERGE_COMMIT: ${{ github.event.pull_request.merge_commit_sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             version="$DISPATCH_VERSION"
             commit="$DISPATCH_COMMIT"
-            source="manual retry"
           elif [[ "$HEAD_REF" =~ ^release/(v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
             version="${BASH_REMATCH[1]}"
             commit="$MERGE_COMMIT"
-            source="PR #$PR_NUMBER"
           else
             echo "Release branches must be named release/vX.Y.Z."
             exit 1
@@ -202,7 +199,6 @@ jobs:
           fi
 
           echo "commit=$commit" >> "$GITHUB_OUTPUT"
-          echo "source=$source" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Mint release bot token
@@ -261,7 +257,6 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_SOURCE: ${{ steps.release.outputs.source }}
           VERSION: ${{ steps.release.outputs.version }}
         run: |
           if gh release view "$VERSION" >/dev/null 2>&1; then
@@ -271,8 +266,8 @@ jobs:
 
           gh release create "$VERSION" \
             --verify-tag \
-            --title "Release $VERSION" \
-            --notes "Released from $RELEASE_SOURCE. See CHANGELOG.md and DEV-CHANGELOG.md for details."
+            --title "$VERSION" \
+            --generate-notes
 
       - name: Open main to dev sync pull request
         env:
@@ -290,4 +285,6 @@ jobs:
             --base dev \
             --head main \
             --title "Sync main into dev after $VERSION" \
-            --body "Sync release $VERSION back into dev."
+            --body "Sync release $VERSION back into dev." \
+            --reviewer 97gamjak \
+            --reviewer ape33

--- a/changes/developer/ci.release-workflow-followups.md
+++ b/changes/developer/ci.release-workflow-followups.md
@@ -1,0 +1,1 @@
+- Generate standard GitHub release notes and streamline release and post-release pull requests.

--- a/changes/developer/ci.release-workflow-followups.md
+++ b/changes/developer/ci.release-workflow-followups.md
@@ -1,1 +1,1 @@
-- Generate standard GitHub release notes and streamline release and post-release pull requests.
+- Generate standard release notes and request release contributors on generated release and sync pull requests.

--- a/scripts/release_reviewers.py
+++ b/scripts/release_reviewers.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Extract human PR authors from generated GitHub release notes."""
+
+import re
+import sys
+
+
+ENTRY_RE = re.compile(
+    r"^[*-] .* by @(?P<login>[A-Za-z0-9-]+(?:\[bot\])?) in "
+    r"https://github\.com/(?P<repository>[^/]+/[^/]+)/pull/[0-9]+$"
+)
+
+
+def extract_reviewers(notes, repository):
+    """Return unique, non-bot PR authors in release-note order."""
+    reviewers = []
+    seen = set()
+
+    for line in notes.splitlines():
+        match = ENTRY_RE.match(line)
+        if not match or match.group("repository") != repository:
+            continue
+
+        login = match.group("login")
+        if login.endswith("[bot]") or login in seen:
+            continue
+
+        seen.add(login)
+        reviewers.append(login)
+
+    return reviewers
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} <owner/repository>")
+
+    notes = sys.stdin.read()
+    for reviewer in extract_reviewers(notes, sys.argv[1]):
+        print(reviewer)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_release_reviewers.py
+++ b/scripts/tests/test_release_reviewers.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Tests for release reviewer extraction."""
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+from release_reviewers import extract_reviewers
+
+
+class ReleaseReviewersTest(unittest.TestCase):
+    def test_extracts_unique_human_authors(self):
+        notes = """## What's Changed
+* First change by @ape33 in https://github.com/MolarVerse/PQ/pull/1
+* Second change by @97gamjak in https://github.com/MolarVerse/PQ/pull/2
+* Follow-up by @ape33 in https://github.com/MolarVerse/PQ/pull/3
+* Release by @pq-release-bot[bot] in https://github.com/MolarVerse/PQ/pull/4
+"""
+
+        self.assertEqual(
+            ["ape33", "97gamjak"],
+            extract_reviewers(notes, "MolarVerse/PQ"),
+        )
+
+    def test_ignores_other_repositories_and_unstructured_mentions(self):
+        notes = """## What's Changed
+* Other repository by @outside in https://github.com/Other/PQ/pull/5
+Mention @maintainer outside a generated entry.
+"""
+
+        self.assertEqual([], extract_reviewers(notes, "MolarVerse/PQ"))
+
+    def test_uses_the_generated_entry_author(self):
+        notes = (
+            "* Title by @incorrect in https://github.com/MolarVerse/PQ/pull/6 "
+            "by @actual in https://github.com/MolarVerse/PQ/pull/7\n"
+        )
+
+        self.assertEqual(
+            ["actual"],
+            extract_reviewers(notes, "MolarVerse/PQ"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Generate standard GitHub release notes.
- Skip changelog checks for post-release sync PRs.
- Request human release contributors on generated release and sync PRs.

Fixes #472
Fixes #473
Fixes #474