### PR TITLE
fix: explain valid changelog fragment filenames

### DIFF
--- a/changes/developer/bugfix.changelog-fragment-name-guidance.md
+++ b/changes/developer/bugfix.changelog-fragment-name-guidance.md
@@ -1,0 +1,1 @@
+- Explain the allowed characters when a changelog fragment filename is invalid.

--- a/scripts/changelog_fragments.py
+++ b/scripts/changelog_fragments.py
@@ -61,7 +61,10 @@ def parse_fragment_name(name, audience):
     match = FRAGMENT_RE.match(name)
     if not match:
         raise FragmentError(
-            f"invalid fragment name '{name}'; expected <category>.<slug>.md"
+            f"invalid fragment name '{name}'; expected <category>.<slug>.md, "
+            "where <category> uses only lowercase letters and <slug> starts "
+            "with a lowercase letter or digit and uses only lowercase letters, "
+            "digits, and hyphens"
         )
 
     category = match.group("category")

--- a/scripts/check_changelog_fragment.py
+++ b/scripts/check_changelog_fragment.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 from changelog_fragments import (
     AUDIENCE_SECTIONS,
-    FRAGMENT_RE,
     FragmentError,
     load_fragments,
     parse_fragment_name,
@@ -184,12 +183,6 @@ def validate_pr_changes(changes, root=ROOT, base_fragment_counts=None):
     for _, relative_path in editable_fragments:
         audience = fragment_audience(relative_path)
         name = Path(relative_path).name
-        if not FRAGMENT_RE.match(name):
-            errors.append(
-                f"invalid fragment name '{name}'; expected "
-                "<category>.<slug>.md"
-            )
-            continue
         try:
             parse_fragment_name(name, audience)
             read_fragment_entries(root / relative_path)

--- a/scripts/tests/test_changelog_fragments.py
+++ b/scripts/tests/test_changelog_fragments.py
@@ -31,6 +31,18 @@ class ChangelogFragmentTests(unittest.TestCase):
         with self.assertRaisesRegex(fragments.FragmentError, "invalid fragment name"):
             fragments.parse_fragment_name("trajectory.user.bugfix.md", "user")
 
+    def test_name_error_explains_allowed_characters(self):
+        with self.assertRaises(fragments.FragmentError) as context:
+            fragments.parse_fragment_name("bugfix.Slug-nAme.md", "user")
+
+        self.assertEqual(
+            "invalid fragment name 'bugfix.Slug-nAme.md'; expected "
+            "<category>.<slug>.md, where <category> uses only lowercase "
+            "letters and <slug> starts with a lowercase letter or digit and "
+            "uses only lowercase letters, digits, and hyphens",
+            str(context.exception),
+        )
+
     def test_entry_must_be_one_or_more_bullets(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             path = Path(temporary_directory) / "change.entry.md"

--- a/scripts/tests/test_check_changelog_fragment.py
+++ b/scripts/tests/test_check_changelog_fragment.py
@@ -92,6 +92,23 @@ class ChangelogFragmentCheckTests(unittest.TestCase):
                 any("invalid user category 'ci'" in error for error in errors)
             )
 
+    def test_invalid_name_error_explains_allowed_characters(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            path = root / "changes" / "user" / "bugfix.Slug-nAme.md"
+            path.parent.mkdir(parents=True)
+            path.write_text("- Fix the output.\n", encoding="utf-8")
+
+            errors = CHECK.validate_pr_changes(
+                [("A", "changes/user/bugfix.Slug-nAme.md")], root
+            )
+
+            self.assertEqual(1, len(errors))
+            self.assertIn("uses only lowercase letters", errors[0])
+            self.assertIn(
+                "uses only lowercase letters, digits, and hyphens", errors[0]
+            )
+
     def test_rejects_direct_changelog_edits(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)


### PR DESCRIPTION
## Summary
Explain the allowed characters in invalid changelog fragment errors and reuse the shared parser in the PR check.

## Tests
`python3 -m unittest discover -s scripts/tests -p 'test_*.py'`\n\nCloses #481.