### PR TITLE
Strong types

### DIFF
--- a/benchmarks/perf/perfBondedForces.cpp
+++ b/benchmarks/perf/perfBondedForces.cpp
@@ -59,7 +59,8 @@ int main()
     settings::PotentialSettings::setScale14Coulomb(0.75);
     settings::PotentialSettings::setScale14VanDerWaals(0.5);
 
-    auto bond = forceField::BondForceField(&molecule, &molecule, 0, 1, 0);
+    auto bond =
+        forceField::BondForceField(&molecule, &molecule, 0, 1, BondId{0});
     bond.setEquilibriumBondLength(1.2);
     bond.setForceConstant(3.0);
 

--- a/benchmarks/perf/perfBondedForces.cpp
+++ b/benchmarks/perf/perfBondedForces.cpp
@@ -75,7 +75,7 @@ int main()
     auto dihedral = forceField::DihedralForceField(
         {&molecule, &molecule, &molecule, &molecule},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
     dihedral.setPhaseShift(M_PI);
     dihedral.setPeriodicity(3);

--- a/benchmarks/perf/perfBondedForces.cpp
+++ b/benchmarks/perf/perfBondedForces.cpp
@@ -67,7 +67,7 @@ int main()
     auto angle = forceField::AngleForceField(
         {&molecule, &molecule, &molecule},
         {0, 1, 2},
-        0
+        AngleId{0}
     );
     angle.setEquilibriumAngle(M_PI / 2.0);
     angle.setForceConstant(3.0);

--- a/benchmarks/perf/perfInterWater.cpp
+++ b/benchmarks/perf/perfInterWater.cpp
@@ -55,8 +55,8 @@ using linearAlgebra::Vec3D;
 static constexpr long   ITERATIONS             = 50;
 static constexpr size_t WATER_TYPE             = 1;
 static constexpr double CUTOFF                 = 9.0;
-static constexpr int    HYDROGEN_ATOMIC_NUMBER = 1;
-static constexpr int    OXYGEN_ATOMIC_NUMBER   = 8;
+static constexpr auto   HYDROGEN_ATOMIC_NUMBER = AtomNumber{1};
+static constexpr auto   OXYGEN_ATOMIC_NUMBER   = AtomNumber{8};
 
 int main()
 {
@@ -82,7 +82,7 @@ int main()
     const auto makeAtom = [](const std::string_view name,
                              const Vec3D           &pos,
                              const double           charge,
-                             const int              atomicNumber)
+                             const AtomNumber       atomicNumber)
     {
         auto atom = std::make_shared<Atom>();
         atom->setName(name);

--- a/changes/developer/enhancement.strong-types.md
+++ b/changes/developer/enhancement.strong-types.md
@@ -1,0 +1,4 @@
+- add strong type for `AtomNumber`
+- add strong type for `BondId`
+- add strong type for `AngleId`
+- add strong type for `DihedralId`

--- a/include/config/atomNumberMap.hpp
+++ b/include/config/atomNumberMap.hpp
@@ -27,6 +27,8 @@
 #include <map>
 #include <string>
 
+#include "strongTypes.hpp"
+
 namespace constants
 {
     /**
@@ -43,29 +45,62 @@ namespace constants
      * sup with atomic number 1000000
      * dum with atomic number 1
      */
-    const std::map<std::string, int> atomNumberMap = {
-        {"h", 1},   {"d", 1},    {"t", 1},      {"he", 2},        {"li", 3},
-        {"be", 4},  {"b", 5},    {"c", 6},      {"n", 7},         {"o", 8},
-        {"f", 9},   {"ne", 10},  {"na", 11},    {"mg", 12},       {"al", 13},
-        {"si", 14}, {"p", 15},   {"s", 16},     {"cl", 17},       {"ar", 18},
-        {"k", 19},  {"ca", 20},  {"sc", 21},    {"ti", 22},       {"v", 23},
-        {"cr", 24}, {"mn", 25},  {"fe", 26},    {"co", 27},       {"ni", 28},
-        {"cu", 29}, {"zn", 30},  {"ga", 31},    {"ge", 32},       {"as", 33},
-        {"se", 34}, {"br", 35},  {"kr", 36},    {"rb", 37},       {"sr", 38},
-        {"y", 39},  {"zr", 40},  {"nb", 41},    {"mo", 42},       {"tc", 43},
-        {"ru", 44}, {"rh", 45},  {"pd", 46},    {"ag", 47},       {"cd", 48},
-        {"in", 49}, {"sn", 50},  {"sb", 51},    {"te", 52},       {"i", 53},
-        {"xe", 54}, {"cs", 55},  {"ba", 56},    {"la", 57},       {"ce", 58},
-        {"pr", 59}, {"nd", 60},  {"pm", 61},    {"sm", 62},       {"eu", 63},
-        {"gd", 64}, {"tb", 65},  {"dy", 66},    {"ho", 67},       {"er", 68},
-        {"tm", 69}, {"yb", 70},  {"lu", 71},    {"hf", 72},       {"ta", 73},
-        {"w", 74},  {"re", 75},  {"os", 76},    {"ir", 77},       {"pt", 78},
-        {"au", 79}, {"hg", 80},  {"tl", 81},    {"pb", 82},       {"bi", 83},
-        {"po", 84}, {"at", 85},  {"rn", 86},    {"fr", 87},       {"ra", 88},
-        {"ac", 89}, {"th", 90},  {"pa", 91},    {"u", 92},        {"np", 93},
-        {"pu", 94}, {"am", 95},  {"cm", 96},    {"bk", 97},       {"cf", 98},
-        {"es", 99}, {"fm", 100}, {"md", 101},   {"no", 102},      {"lr", 103},
-        {"q", 999}, {"x", 999},  {"cav", 1000}, {"sup", 1000000}, {"dum", 1}
+    const std::map<std::string, AtomNumber> atomNumberMap = {
+        {"h", AtomNumber{1}},         {"d", AtomNumber{1}},
+        {"t", AtomNumber{1}},         {"he", AtomNumber{2}},
+        {"li", AtomNumber{3}},        {"be", AtomNumber{4}},
+        {"b", AtomNumber{5}},         {"c", AtomNumber{6}},
+        {"n", AtomNumber{7}},         {"o", AtomNumber{8}},
+        {"f", AtomNumber{9}},         {"ne", AtomNumber{10}},
+        {"na", AtomNumber{11}},       {"mg", AtomNumber{12}},
+        {"al", AtomNumber{13}},       {"si", AtomNumber{14}},
+        {"p", AtomNumber{15}},        {"s", AtomNumber{16}},
+        {"cl", AtomNumber{17}},       {"ar", AtomNumber{18}},
+        {"k", AtomNumber{19}},        {"ca", AtomNumber{20}},
+        {"sc", AtomNumber{21}},       {"ti", AtomNumber{22}},
+        {"v", AtomNumber{23}},        {"cr", AtomNumber{24}},
+        {"mn", AtomNumber{25}},       {"fe", AtomNumber{26}},
+        {"co", AtomNumber{27}},       {"ni", AtomNumber{28}},
+        {"cu", AtomNumber{29}},       {"zn", AtomNumber{30}},
+        {"ga", AtomNumber{31}},       {"ge", AtomNumber{32}},
+        {"as", AtomNumber{33}},       {"se", AtomNumber{34}},
+        {"br", AtomNumber{35}},       {"kr", AtomNumber{36}},
+        {"rb", AtomNumber{37}},       {"sr", AtomNumber{38}},
+        {"y", AtomNumber{39}},        {"zr", AtomNumber{40}},
+        {"nb", AtomNumber{41}},       {"mo", AtomNumber{42}},
+        {"tc", AtomNumber{43}},       {"ru", AtomNumber{44}},
+        {"rh", AtomNumber{45}},       {"pd", AtomNumber{46}},
+        {"ag", AtomNumber{47}},       {"cd", AtomNumber{48}},
+        {"in", AtomNumber{49}},       {"sn", AtomNumber{50}},
+        {"sb", AtomNumber{51}},       {"te", AtomNumber{52}},
+        {"i", AtomNumber{53}},        {"xe", AtomNumber{54}},
+        {"cs", AtomNumber{55}},       {"ba", AtomNumber{56}},
+        {"la", AtomNumber{57}},       {"ce", AtomNumber{58}},
+        {"pr", AtomNumber{59}},       {"nd", AtomNumber{60}},
+        {"pm", AtomNumber{61}},       {"sm", AtomNumber{62}},
+        {"eu", AtomNumber{63}},       {"gd", AtomNumber{64}},
+        {"tb", AtomNumber{65}},       {"dy", AtomNumber{66}},
+        {"ho", AtomNumber{67}},       {"er", AtomNumber{68}},
+        {"tm", AtomNumber{69}},       {"yb", AtomNumber{70}},
+        {"lu", AtomNumber{71}},       {"hf", AtomNumber{72}},
+        {"ta", AtomNumber{73}},       {"w", AtomNumber{74}},
+        {"re", AtomNumber{75}},       {"os", AtomNumber{76}},
+        {"ir", AtomNumber{77}},       {"pt", AtomNumber{78}},
+        {"au", AtomNumber{79}},       {"hg", AtomNumber{80}},
+        {"tl", AtomNumber{81}},       {"pb", AtomNumber{82}},
+        {"bi", AtomNumber{83}},       {"po", AtomNumber{84}},
+        {"at", AtomNumber{85}},       {"rn", AtomNumber{86}},
+        {"fr", AtomNumber{87}},       {"ra", AtomNumber{88}},
+        {"ac", AtomNumber{89}},       {"th", AtomNumber{90}},
+        {"pa", AtomNumber{91}},       {"u", AtomNumber{92}},
+        {"np", AtomNumber{93}},       {"pu", AtomNumber{94}},
+        {"am", AtomNumber{95}},       {"cm", AtomNumber{96}},
+        {"bk", AtomNumber{97}},       {"cf", AtomNumber{98}},
+        {"es", AtomNumber{99}},       {"fm", AtomNumber{100}},
+        {"md", AtomNumber{101}},      {"no", AtomNumber{102}},
+        {"lr", AtomNumber{103}},      {"q", AtomNumber{999}},
+        {"x", AtomNumber{999}},       {"cav", AtomNumber{1000}},
+        {"sup", AtomNumber{1000000}}, {"dum", AtomNumber{1}}
     };
 
 }   // namespace constants

--- a/include/forceField/angleForceField.hpp
+++ b/include/forceField/angleForceField.hpp
@@ -57,8 +57,8 @@ namespace forceField
     class AngleForceField : public connectivity::Angle
     {
        private:
-        size_t _type;
-        bool   _isLinker = false;
+        AngleId _type;
+        bool    _isLinker = false;
 
         double _equilibriumAngle = 0.0;
         double _forceConstant    = 0.0;
@@ -67,7 +67,7 @@ namespace forceField
         AngleForceField(
             const std::vector<simulationBox::Molecule *> &molecules,
             const std::vector<size_t>                    &atomIndices,
-            const size_t                                  type
+            const AngleId                                 type
         );
 
         void calculateEnergyAndForces(
@@ -89,10 +89,10 @@ namespace forceField
          * standard getter methods *
          ***************************/
 
-        [[nodiscard]] size_t getType() const;
-        [[nodiscard]] bool   isLinker() const;
-        [[nodiscard]] double getEquilibriumAngle() const;
-        [[nodiscard]] double getForceConstant() const;
+        [[nodiscard]] AngleId getType() const;
+        [[nodiscard]] bool    isLinker() const;
+        [[nodiscard]] double  getEquilibriumAngle() const;
+        [[nodiscard]] double  getForceConstant() const;
     };
 
 }   // namespace forceField

--- a/include/forceField/angleType.hpp
+++ b/include/forceField/angleType.hpp
@@ -24,7 +24,7 @@
 
 #define _ANGLE_TYPE_HPP_
 
-#include <cstddef>
+#include "strongTypes.hpp"
 
 namespace forceField
 {
@@ -43,13 +43,13 @@ namespace forceField
     class AngleType
     {
        private:
-        size_t _id;
+        AngleId _id;
 
         double _equilibriumAngle;
         double _forceConstant;
 
        public:
-        AngleType(const size_t, const double, const double);
+        AngleType(const AngleId, const double, const double);
 
         friend bool operator==(const AngleType &, const AngleType &);
 
@@ -57,9 +57,9 @@ namespace forceField
          * standard getter methods *
          ***************************/
 
-        [[nodiscard]] size_t getId() const;
-        [[nodiscard]] double getEquilibriumAngle() const;
-        [[nodiscard]] double getForceConstant() const;
+        [[nodiscard]] AngleId getId() const;
+        [[nodiscard]] double  getEquilibriumAngle() const;
+        [[nodiscard]] double  getForceConstant() const;
     };
 
 }   // namespace forceField

--- a/include/forceField/bondForceField.hpp
+++ b/include/forceField/bondForceField.hpp
@@ -56,7 +56,7 @@ namespace forceField
     class BondForceField : public connectivity::Bond
     {
        private:
-        size_t _type;
+        BondId _type;
         bool   _isLinker = false;
 
         double _equilBondLength;
@@ -68,7 +68,7 @@ namespace forceField
             simulationBox::Molecule *molecule2,
             const size_t             atomIndex1,
             const size_t             atomIndex2,
-            const size_t             type
+            const BondId             type
         );
 
         void calculateEnergyAndForces(
@@ -90,7 +90,7 @@ namespace forceField
          * standard getter methods *
          ***************************/
 
-        [[nodiscard]] size_t getType() const;
+        [[nodiscard]] BondId getType() const;
         [[nodiscard]] bool   isLinker() const;
         [[nodiscard]] double getEquilibriumBondLength() const;
         [[nodiscard]] double getForceConstant() const;

--- a/include/forceField/bondType.hpp
+++ b/include/forceField/bondType.hpp
@@ -26,6 +26,8 @@
 
 #include <cstddef>
 
+#include "strongTypes.hpp"
+
 namespace forceField
 {
     class BondType;   // forward declaration
@@ -44,13 +46,13 @@ namespace forceField
     class BondType
     {
        private:
-        size_t _id;
+        BondId _id;
 
         double _equilBondLength;
         double _forceConstant;
 
        public:
-        BondType(const size_t, const double, const double);
+        BondType(const BondId, const double, const double);
 
         friend bool operator==(const BondType &, const BondType &);
 
@@ -58,7 +60,7 @@ namespace forceField
          * standard getter methods *
          ***************************/
 
-        [[nodiscard]] size_t getId() const;
+        [[nodiscard]] BondId getId() const;
         [[nodiscard]] double getEquilibriumBondLength() const;
         [[nodiscard]] double getForceConstant() const;
     };

--- a/include/forceField/bondType.hpp
+++ b/include/forceField/bondType.hpp
@@ -24,8 +24,6 @@
 
 #define _BOND_TYPE_HPP_
 
-#include <cstddef>
-
 #include "strongTypes.hpp"
 
 namespace forceField

--- a/include/forceField/dihedralForceField.hpp
+++ b/include/forceField/dihedralForceField.hpp
@@ -57,8 +57,8 @@ namespace forceField
     class DihedralForceField : public connectivity::Dihedral
     {
        private:
-        size_t _type;
-        bool   _isLinker = false;
+        DihedralId _type;
+        bool       _isLinker = false;
 
         double _forceConstant = 0.0;
         double _periodicity   = 0.0;
@@ -68,7 +68,7 @@ namespace forceField
         DihedralForceField(
             const std::vector<simulationBox::Molecule *> &molecules,
             const std::vector<size_t>                    &atomIndices,
-            const size_t                                  type
+            const DihedralId                              type
         );
 
         void calculateEnergyAndForces(
@@ -94,10 +94,10 @@ namespace forceField
 
         [[nodiscard]] bool isLinker() const;
 
-        [[nodiscard]] size_t getType() const;
-        [[nodiscard]] double getForceConstant() const;
-        [[nodiscard]] double getPeriodicity() const;
-        [[nodiscard]] double getPhaseShift() const;
+        [[nodiscard]] DihedralId getType() const;
+        [[nodiscard]] double     getForceConstant() const;
+        [[nodiscard]] double     getPeriodicity() const;
+        [[nodiscard]] double     getPhaseShift() const;
     };
 
 }   // namespace forceField

--- a/include/forceField/dihedralType.hpp
+++ b/include/forceField/dihedralType.hpp
@@ -26,6 +26,8 @@
 
 #include <cstddef>
 
+#include "strongTypes.hpp"
+
 namespace forceField
 {
     class DihedralType;   // forward declaration
@@ -44,7 +46,7 @@ namespace forceField
     class DihedralType
     {
        private:
-        size_t _id;
+        DihedralId _id;
 
         double _forceConstant;
         double _periodicity;
@@ -52,10 +54,10 @@ namespace forceField
 
        public:
         DihedralType(
-            const size_t id,
-            const double forceConstant,
-            const double frequency,
-            const double phaseShift
+            const DihedralId id,
+            const double     forceConstant,
+            const double     frequency,
+            const double     phaseShift
         );
 
         friend bool operator==(const DihedralType &, const DihedralType &);
@@ -64,10 +66,10 @@ namespace forceField
          * standard getter methods *
          ***************************/
 
-        [[nodiscard]] size_t getId() const;
-        [[nodiscard]] double getForceConstant() const;
-        [[nodiscard]] double getPeriodicity() const;
-        [[nodiscard]] double getPhaseShift() const;
+        [[nodiscard]] DihedralId getId() const;
+        [[nodiscard]] double     getForceConstant() const;
+        [[nodiscard]] double     getPeriodicity() const;
+        [[nodiscard]] double     getPhaseShift() const;
     };
 
 }   // namespace forceField

--- a/include/forceField/dihedralType.hpp
+++ b/include/forceField/dihedralType.hpp
@@ -24,8 +24,6 @@
 
 #define _DIHEDRAL_TYPE_HPP_
 
-#include <cstddef>
-
 #include "strongTypes.hpp"
 
 namespace forceField

--- a/include/forceField/forceFieldClass.hpp
+++ b/include/forceField/forceFieldClass.hpp
@@ -102,7 +102,7 @@ namespace forceField
         );
 
         const BondType      &findBondTypeById(BondId id) const;
-        const AngleType     &findAngleTypeById(size_t id) const;
+        const AngleType     &findAngleTypeById(AngleId id) const;
         const DihedralType  &findDihedralTypeById(size_t id) const;
         const DihedralType  &findImproperTypeById(size_t id) const;
         const JCouplingType &findJCouplingTypeById(size_t id) const;

--- a/include/forceField/forceFieldClass.hpp
+++ b/include/forceField/forceFieldClass.hpp
@@ -103,8 +103,8 @@ namespace forceField
 
         const BondType      &findBondTypeById(BondId id) const;
         const AngleType     &findAngleTypeById(AngleId id) const;
-        const DihedralType  &findDihedralTypeById(size_t id) const;
-        const DihedralType  &findImproperTypeById(size_t id) const;
+        const DihedralType  &findDihedralTypeById(DihedralId id) const;
+        const DihedralType  &findImproperTypeById(DihedralId id) const;
         const JCouplingType &findJCouplingTypeById(size_t id) const;
 
         /*****************************

--- a/include/forceField/forceFieldClass.hpp
+++ b/include/forceField/forceFieldClass.hpp
@@ -101,7 +101,7 @@ namespace forceField
             physicalData::PhysicalData &
         );
 
-        const BondType      &findBondTypeById(size_t id) const;
+        const BondType      &findBondTypeById(BondId id) const;
         const AngleType     &findAngleTypeById(size_t id) const;
         const DihedralType  &findDihedralTypeById(size_t id) const;
         const DihedralType  &findImproperTypeById(size_t id) const;

--- a/include/simulationBox/atom.hpp
+++ b/include/simulationBox/atom.hpp
@@ -30,6 +30,7 @@
 #include <string_view>   // for string_view
 
 #include "staticMatrix.hpp"
+#include "strongTypes.hpp"
 #include "vector3d.hpp"
 
 namespace simulationBox
@@ -56,7 +57,7 @@ namespace simulationBox
 
         bool _isActive = true;
 
-        int                   _atomicNumber;
+        AtomNumber            _atomicNumber;
         double                _mass;
         double                _partialCharge;
         std::optional<double> _qmCharge;
@@ -127,7 +128,12 @@ namespace simulationBox
         [[nodiscard]] size_t getExternalGlobalVDWType() const;
         [[nodiscard]] size_t getInternalGlobalVDWType() const;
 
-        [[nodiscard]] int    getAtomicNumber() const { return _atomicNumber; }
+        [[nodiscard]]
+        AtomNumber getAtomicNumber() const
+        {
+            return _atomicNumber;
+        }
+
         [[nodiscard]] double getMass() const;
         [[nodiscard]] double getPartialCharge() const { return _partialCharge; }
         [[nodiscard]] std::optional<double> getQMCharge() const;
@@ -152,7 +158,7 @@ namespace simulationBox
 
         void setName(const std::string_view &name);
         void setAtomTypeName(const std::string_view &atomTypeName);
-        void setAtomicNumber(const int atomicNumber);
+        void setAtomicNumber(const AtomNumber atomicNumber);
 
         void setMass(const double mass);
         void setPartialCharge(const double partialCharge);

--- a/include/simulationBox/molecule.hpp
+++ b/include/simulationBox/molecule.hpp
@@ -184,10 +184,10 @@ namespace simulationBox
             const size_t index
         ) const;
 
-        [[nodiscard]] int    getAtomicNumber(const size_t index) const;
-        [[nodiscard]] double getAtomMass(const size_t index) const;
-        [[nodiscard]] double getPartialCharge(const size_t index) const;
-        [[nodiscard]] size_t getAtomType(const size_t index) const;
+        [[nodiscard]] AtomNumber getAtomicNumber(const size_t index) const;
+        [[nodiscard]] double     getAtomMass(const size_t index) const;
+        [[nodiscard]] double     getPartialCharge(const size_t index) const;
+        [[nodiscard]] size_t     getAtomType(const size_t index) const;
         [[nodiscard]] size_t getInternalGlobalVDWType(const size_t index) const;
         [[nodiscard]] std::string getAtomName(const size_t index) const;
 

--- a/include/simulationBox/simulationBox.hpp
+++ b/include/simulationBox/simulationBox.hpp
@@ -223,10 +223,10 @@ namespace simulationBox
         [[nodiscard]] std::vector<linearAlgebra::Vec3D> getPositions() const;
         [[nodiscard]] std::vector<linearAlgebra::Vec3D> getVelocities() const;
         [[nodiscard]] std::vector<linearAlgebra::Vec3D> getForces() const;
-        [[nodiscard]] std::vector<int>      getAtomicNumbers() const;
-        [[nodiscard]] std::vector<double>   flattenPositions() const;
-        [[nodiscard]] std::set<std::string> getUniqueQMAtomNames() const;
-        [[nodiscard]] std::vector<double>   getFlattenedQMPositions() const;
+        [[nodiscard]] std::vector<AtomNumber> getAtomicNumbers() const;
+        [[nodiscard]] std::vector<double>     flattenPositions() const;
+        [[nodiscard]] std::set<std::string>   getUniqueQMAtomNames() const;
+        [[nodiscard]] std::vector<double>     getFlattenedQMPositions() const;
 
         /***************************
          * standard setter methods *

--- a/include/utilities/strongTypes.hpp
+++ b/include/utilities/strongTypes.hpp
@@ -24,4 +24,13 @@ struct BondIdTag
 };
 using BondId = StrongSizeT<struct BondIdTag>;
 
+struct AngleIdTag
+{
+    static std::string toString(const size_t &value)
+    {
+        return std::format("AngleId({})", value);
+    }
+};
+using AngleId = StrongSizeT<struct AngleIdTag>;
+
 #endif   // _STRONG_TYPES_HPP_

--- a/include/utilities/strongTypes.hpp
+++ b/include/utilities/strongTypes.hpp
@@ -1,0 +1,19 @@
+#ifndef _STRONG_TYPES_HPP_
+#define _STRONG_TYPES_HPP_
+
+#include <cstddef>
+#include <mstd/types.hpp>
+
+template <typename Tag>
+using StrongSizeT = mstd::StrongType<
+    size_t,
+    Tag,
+    mstd::StrongTypeTrait::ORDERED | mstd::StrongTypeTrait::HASHABLE>;
+
+struct AtomNumberTag
+{
+};
+
+using AtomNumber = StrongSizeT<struct AtomNumberTag>;
+
+#endif   // _STRONG_TYPES_HPP_

--- a/include/utilities/strongTypes.hpp
+++ b/include/utilities/strongTypes.hpp
@@ -1,3 +1,25 @@
+/*****************************************************************************
+<GPL_HEADER>
+
+    PQ
+    Copyright (C) 2023-now  Jakob Gamper
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<GPL_HEADER>
+******************************************************************************/
+
 #ifndef _STRONG_TYPES_HPP_
 #define _STRONG_TYPES_HPP_
 

--- a/include/utilities/strongTypes.hpp
+++ b/include/utilities/strongTypes.hpp
@@ -33,4 +33,13 @@ struct AngleIdTag
 };
 using AngleId = StrongSizeT<struct AngleIdTag>;
 
+struct DihedralIdTag
+{
+    static std::string toString(const size_t &value)
+    {
+        return std::format("DihedralId({})", value);
+    }
+};
+using DihedralId = StrongSizeT<struct DihedralIdTag>;
+
 #endif   // _STRONG_TYPES_HPP_

--- a/include/utilities/strongTypes.hpp
+++ b/include/utilities/strongTypes.hpp
@@ -24,6 +24,7 @@
 #define _STRONG_TYPES_HPP_
 
 #include <cstddef>
+#include <format>
 #include <mstd/types.hpp>
 
 template <typename Tag>

--- a/include/utilities/strongTypes.hpp
+++ b/include/utilities/strongTypes.hpp
@@ -10,10 +10,18 @@ using StrongSizeT = mstd::StrongType<
     Tag,
     mstd::StrongTypeTrait::ORDERED | mstd::StrongTypeTrait::HASHABLE>;
 
-struct AtomNumberTag
-{
-};
-
+// clang-format off
+struct AtomNumberTag{};
 using AtomNumber = StrongSizeT<struct AtomNumberTag>;
+// clang-format on
+
+struct BondIdTag
+{
+    static std::string toString(const size_t &value)
+    {
+        return std::format("BondId({})", value);
+    }
+};
+using BondId = StrongSizeT<struct BondIdTag>;
 
 #endif   // _STRONG_TYPES_HPP_

--- a/src/QM/ase/aseQMRunner.cpp
+++ b/src/QM/ase/aseQMRunner.cpp
@@ -44,7 +44,6 @@ using namespace constants;
 using namespace settings;
 
 using array_d = pybind11::array_t<double>;
-using array_i = pybind11::array_t<int>;
 
 namespace
 {
@@ -181,10 +180,16 @@ namespace
         const auto atomicNumbers = simBox.getAtomicNumbers();
         const auto nAtoms        = simBox.getNumberOfAtoms();
 
+        std::vector<int> atomicNumbersInt;
+        atomicNumbersInt.reserve(nAtoms);
+
+        for (const auto &atomicNumber : atomicNumbers)
+            atomicNumbersInt.push_back(static_cast<int>(atomicNumber.get()));
+
         try
         {
             const auto atomicNumbers_ =
-                array_i(ssize_t(nAtoms), &atomicNumbers[0]);
+                pybind11::array_t<int>(ssize_t(nAtoms), &atomicNumbersInt[0]);
 
             return atomicNumbers_;
         }

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,6 +1,14 @@
-add_library(config_headers INTERFACE)
+add_library(config_headers 
+    INTERFACE
+)
 
 target_link_libraries(config_headers
     INTERFACE
-    linearAlgebra
+    utilities
+)
+
+target_include_directories(config_headers
+    INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/include/config
 )

--- a/src/forceField/angleForceField.cpp
+++ b/src/forceField/angleForceField.cpp
@@ -52,7 +52,7 @@ using enum HybridZone;
 AngleForceField::AngleForceField(
     const std::vector<Molecule *> &molecules,
     const std::vector<size_t>     &atomIndices,
-    const size_t                   type
+    const AngleId                  type
 )
     : Angle(molecules, atomIndices), _type(type)
 {
@@ -223,9 +223,9 @@ bool AngleForceField::isLinker() const { return _isLinker; }
 /**
  * @brief get type of angle
  *
- * @return size_t
+ * @return AngleId
  */
-size_t AngleForceField::getType() const { return _type; }
+AngleId AngleForceField::getType() const { return _type; }
 
 /**
  * @brief get equilibrium angle

--- a/src/forceField/angleType.cpp
+++ b/src/forceField/angleType.cpp
@@ -35,13 +35,15 @@ using namespace utilities;
  * @param springConstant
  */
 AngleType::AngleType(
-    const size_t id,
-    const double equilibriumAngle,
-    const double springConstant
+    const AngleId id,
+    const double  equilibriumAngle,
+    const double  springConstant
 )
     : _id(id),
       _equilibriumAngle(equilibriumAngle),
-      _forceConstant(springConstant){};
+      _forceConstant(springConstant)
+{
+}
 
 /**
  * @brief operator overload for the comparison of two AngleType objects
@@ -68,9 +70,9 @@ bool forceField::operator==(const AngleType &self, const AngleType &other)
 /**
  * @brief get the id of the angle type
  *
- * @return size_t
+ * @return AngleId
  */
-size_t AngleType::getId() const { return _id; }
+AngleId AngleType::getId() const { return _id; }
 
 /**
  * @brief get the equilibrium angle of the angle type

--- a/src/forceField/bondForceField.cpp
+++ b/src/forceField/bondForceField.cpp
@@ -55,7 +55,7 @@ BondForceField::BondForceField(
     Molecule    *molecule2,
     const size_t atomIndex1,
     const size_t atomIndex2,
-    const size_t type
+    const BondId type
 )
     : Bond(molecule1, molecule2, atomIndex1, atomIndex2), _type(type)
 {
@@ -180,9 +180,9 @@ bool BondForceField::isLinker() const { return _isLinker; }
 /**
  * @brief get the type of the bond
  *
- * @return size_t
+ * @return BondId
  */
-size_t BondForceField::getType() const { return _type; }
+BondId BondForceField::getType() const { return _type; }
 
 /**
  * @brief get the equilibrium bond length

--- a/src/forceField/bondType.cpp
+++ b/src/forceField/bondType.cpp
@@ -35,7 +35,7 @@ using namespace utilities;
  * @param springConstant
  */
 BondType::BondType(
-    const size_t id,
+    const BondId id,
     const double equilibriumBondLength,
     const double springConstant
 )
@@ -70,9 +70,9 @@ bool forceField::operator==(const BondType &self, const BondType &other)
 /**
  * @brief get the id of the bond type
  *
- * @return size_t
+ * @return BondId
  */
-size_t BondType::getId() const { return _id; }
+BondId BondType::getId() const { return _id; }
 
 /**
  * @brief get the equilibrium bond length of the bond type

--- a/src/forceField/dihedralForceField.cpp
+++ b/src/forceField/dihedralForceField.cpp
@@ -51,7 +51,7 @@ using enum HybridZone;
 DihedralForceField::DihedralForceField(
     const std::vector<Molecule *> &molecules,
     const std::vector<size_t>     &atomIndices,
-    const size_t                   type
+    const DihedralId               type
 )
     : Dihedral(molecules, atomIndices), _type(type)
 {
@@ -250,9 +250,9 @@ bool DihedralForceField::isLinker() const { return _isLinker; }
 /**
  * @brief get type of dihedral
  *
- * @return size_t
+ * @return DihedralId
  */
-size_t DihedralForceField::getType() const { return _type; }
+DihedralId DihedralForceField::getType() const { return _type; }
 
 /**
  * @brief get force constant

--- a/src/forceField/dihedralType.cpp
+++ b/src/forceField/dihedralType.cpp
@@ -36,15 +36,17 @@ using namespace utilities;
  * @param phaseShift
  */
 DihedralType::DihedralType(
-    const size_t id,
-    const double forceConstant,
-    const double frequency,
-    const double phaseShift
+    const DihedralId id,
+    const double     forceConstant,
+    const double     frequency,
+    const double     phaseShift
 )
     : _id(id),
       _forceConstant(forceConstant),
       _periodicity(frequency),
-      _phaseShift(phaseShift){};
+      _phaseShift(phaseShift)
+{
+}
 
 /**
  * @brief operator overload for the comparison of two DihedralType objects
@@ -72,9 +74,9 @@ bool forceField::operator==(const DihedralType &self, const DihedralType &other)
 /**
  * @brief get the id of the dihedral type
  *
- * @return size_t
+ * @return DihedralId
  */
-size_t DihedralType::getId() const { return _id; }
+DihedralId DihedralType::getId() const { return _id; }
 
 /**
  * @brief get the force constant of the dihedral type

--- a/src/forceField/forceFieldClass.cpp
+++ b/src/forceField/forceFieldClass.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<ForceField> ForceField::clone() const
  *
  * @throws TopologyException if bond type with id not found
  */
-const BondType &ForceField::findBondTypeById(const size_t id) const
+const BondType &ForceField::findBondTypeById(const BondId id) const
 {
     auto isBondId = [id](const BondType &bondType)
     { return bondType.getId() == id; };
@@ -62,7 +62,7 @@ const BondType &ForceField::findBondTypeById(const size_t id) const
         return *bondType;
     else
         throw TopologyException(
-            std::format("Bond type with id {} not found.", id)
+            std::format("Bond type with id {} not found.", id.toString())
         );
 }
 

--- a/src/forceField/forceFieldClass.cpp
+++ b/src/forceField/forceFieldClass.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <format>   // for format
 
+#include "dihedralType.hpp"
 #include "exceptions.hpp"
 
 using namespace forceField;
@@ -97,7 +98,7 @@ const AngleType &ForceField::findAngleTypeById(const AngleId id) const
  *
  * @throws TopologyException if dihedral type with id not found
  */
-const DihedralType &ForceField::findDihedralTypeById(const size_t id) const
+const DihedralType &ForceField::findDihedralTypeById(const DihedralId id) const
 {
     auto isDihedralId = [id](const DihedralType &dihedralType)
     { return dihedralType.getId() == id; };
@@ -109,7 +110,7 @@ const DihedralType &ForceField::findDihedralTypeById(const size_t id) const
         return *dihedralType;
     else
         throw TopologyException(
-            std::format("Dihedral type with id {} not found.", id)
+            std::format("Dihedral type with id {} not found.", id.toString())
         );
 }
 
@@ -122,7 +123,7 @@ const DihedralType &ForceField::findDihedralTypeById(const size_t id) const
  * @throws TopologyException if improper dihedral type with id
  * not found
  */
-const DihedralType &ForceField::findImproperTypeById(const size_t id) const
+const DihedralType &ForceField::findImproperTypeById(const DihedralId id) const
 {
     auto isImproperId = [id](const DihedralType &dihedralType)
     { return dihedralType.getId() == id; };
@@ -134,7 +135,10 @@ const DihedralType &ForceField::findImproperTypeById(const size_t id) const
         return *dihedralType;
     else
         throw TopologyException(
-            std::format("Improper dihedral type with id {} not found.", id)
+            std::format(
+                "Improper dihedral type with id {} not found.",
+                id.toString()
+            )
         );
 }
 

--- a/src/forceField/forceFieldClass.cpp
+++ b/src/forceField/forceFieldClass.cpp
@@ -74,7 +74,7 @@ const BondType &ForceField::findBondTypeById(const BondId id) const
  *
  * @throws TopologyException if angle type with id not found
  */
-const AngleType &ForceField::findAngleTypeById(const size_t id) const
+const AngleType &ForceField::findAngleTypeById(const AngleId id) const
 {
     auto isAngleId = [id](const AngleType &angleType)
     { return angleType.getId() == id; };
@@ -85,7 +85,7 @@ const AngleType &ForceField::findAngleTypeById(const size_t id) const
         return *angleType;
     else
         throw TopologyException(
-            std::format("Angle type with id {} not found.", id)
+            std::format("Angle type with id {} not found.", id.toString())
         );
 }
 

--- a/src/input/parameterFileReader/angleSection.cpp
+++ b/src/input/parameterFileReader/angleSection.cpp
@@ -72,7 +72,7 @@ void AngleSection::processSection(
             )
         );
 
-    auto id               = stoul(lineElements[0]);
+    auto id               = AngleId{stoul(lineElements[0])};
     auto equilibriumAngle = stod(lineElements[1]) * DEG_TO_RAD;
     auto forceConstant    = stod(lineElements[2]);
 

--- a/src/input/parameterFileReader/bondSection.cpp
+++ b/src/input/parameterFileReader/bondSection.cpp
@@ -71,7 +71,7 @@ void BondSection::processSection(
             )
         );
 
-    auto id                  = stoul(lineElements[0]);
+    auto id                  = BondId{stoul(lineElements[0])};
     auto equilibriumDistance = stod(lineElements[1]);
     auto forceConstant       = stod(lineElements[2]);
 

--- a/src/input/parameterFileReader/dihedralSection.cpp
+++ b/src/input/parameterFileReader/dihedralSection.cpp
@@ -74,7 +74,7 @@ void DihedralSection::processSection(
             )
         );
 
-    auto id            = stoul(lineElements[0]);
+    auto id            = DihedralId{stoul(lineElements[0])};
     auto forceConstant = stod(lineElements[1]);
     auto periodicity   = stod(lineElements[2]);
     auto phase         = stod(lineElements[3]) * DEG_TO_RAD;

--- a/src/input/parameterFileReader/improperDihedralSection.cpp
+++ b/src/input/parameterFileReader/improperDihedralSection.cpp
@@ -76,7 +76,7 @@ void ImproperDihedralSection::processSection(
             )
         );
 
-    auto id            = stoul(lineElements[0]);
+    auto id            = DihedralId{stoul(lineElements[0])};
     auto forceConstant = stod(lineElements[1]);
     auto periodicity   = stod(lineElements[2]);
     auto phase         = stod(lineElements[3]) * DEG_TO_RAD;

--- a/src/input/topologyFileReader/angleSection.cpp
+++ b/src/input/topologyFileReader/angleSection.cpp
@@ -76,7 +76,7 @@ void AngleSection::processSection(
     auto atom1     = stoul(lineElements[0]);
     auto atom2     = stoul(lineElements[1]);
     auto atom3     = stoul(lineElements[2]);
-    auto angleType = stoul(lineElements[3]);
+    auto angleType = AngleId{stoul(lineElements[3])};
     auto isLinker  = false;
 
     if (5 == lineElements.size())

--- a/src/input/topologyFileReader/bondSection.cpp
+++ b/src/input/topologyFileReader/bondSection.cpp
@@ -71,7 +71,7 @@ void BondSection::processSection(
 
     const auto atom1    = stoul(lineElements[0]);
     const auto atom2    = stoul(lineElements[1]);
-    const auto bondType = stoul(lineElements[2]);
+    const auto bondType = BondId{stoul(lineElements[2])};
     auto       isLinker = false;
 
     if (4 == lineElements.size())

--- a/src/input/topologyFileReader/dihedralSection.cpp
+++ b/src/input/topologyFileReader/dihedralSection.cpp
@@ -30,6 +30,7 @@
 #include "dihedralForceField.hpp"   // for BondForceField
 #include "engine.hpp"               // for Engine
 #include "exceptions.hpp"           // for TopologyException
+#include "strongTypes.hpp"
 
 using namespace input::topology;
 using namespace simulationBox;
@@ -77,7 +78,7 @@ void DihedralSection::processSection(
     auto atom2        = stoul(lineElements[1]);
     auto atom3        = stoul(lineElements[2]);
     auto atom4        = stoul(lineElements[3]);
-    auto dihedralType = stoul(lineElements[4]);
+    auto dihedralType = DihedralId{stoul(lineElements[4])};
     auto isLinker     = false;
 
     if (6 == lineElements.size())

--- a/src/input/topologyFileReader/improperDihedralSection.cpp
+++ b/src/input/topologyFileReader/improperDihedralSection.cpp
@@ -75,7 +75,7 @@ void ImproperDihedralSection::processSection(
     auto atom2                = stoul(lineElements[1]);
     auto atom3                = stoul(lineElements[2]);
     auto atom4                = stoul(lineElements[3]);
-    auto improperDihedralType = stoul(lineElements[4]);
+    auto improperDihedralType = DihedralId{stoul(lineElements[4])};
 
     auto atoms = std::vector{atom1, atom2, atom3, atom4};
     std::ranges::sort(atoms);

--- a/src/simulationBox/atom.cpp
+++ b/src/simulationBox/atom.cpp
@@ -374,7 +374,7 @@ void Atom::setAtomTypeName(const std::string_view &atomTypeName)
  *
  * @param atomicNumber
  */
-void Atom::setAtomicNumber(const int atomicNumber)
+void Atom::setAtomicNumber(const AtomNumber atomicNumber)
 {
     _atomicNumber = atomicNumber;
 }

--- a/src/simulationBox/molecule.cpp
+++ b/src/simulationBox/molecule.cpp
@@ -477,9 +477,9 @@ Vec3D Molecule::getAtomShiftForce(const size_t index) const
  * @brief returns the atomic number of the atom by index
  *
  * @param index
- * @return int
+ * @return AtomNumber
  */
-int Molecule::getAtomicNumber(const size_t index) const
+AtomNumber Molecule::getAtomicNumber(const size_t index) const
 {
     return _atoms[index]->getAtomicNumber();
 }

--- a/src/simulationBox/simulationBox_standardMethods.cpp
+++ b/src/simulationBox/simulationBox_standardMethods.cpp
@@ -366,11 +366,11 @@ std::vector<linearAlgebra::Vec3D> SimulationBox::getForces() const
 /**
  * @brief get all atomic numbers of all atoms
  *
- * @return std::vector<int>
+ * @return std::vector<AtomNumber>
  */
-std::vector<int> SimulationBox::getAtomicNumbers() const
+std::vector<AtomNumber> SimulationBox::getAtomicNumbers() const
 {
-    std::vector<int> atomicNumbers;
+    std::vector<AtomNumber> atomicNumbers;
 
     for (const auto &atom : _atoms)
         atomicNumbers.push_back(atom->getAtomicNumber());

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(utilities
     PUBLIC
     linearAlgebra
     exceptions
+    mstd
 )
 
 install(TARGETS utilities

--- a/src/waterModels/inter/CMakeLists.txt
+++ b/src/waterModels/inter/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(interWater
     physicalData
     settings
     simulationBox
+    config_headers
 )
 
 install(TARGETS interWater

--- a/tests/src/forceField/testAngleForceField.cpp
+++ b/tests/src/forceField/testAngleForceField.cpp
@@ -38,6 +38,7 @@
 #include "molecule.hpp"                  // for Molecule
 #include "physicalData.hpp"              // for PhysicalData
 #include "simulationBox.hpp"             // for SimulationBox
+#include "strongTypes.hpp"
 
 namespace potential
 {
@@ -99,7 +100,7 @@ TEST_F(TestAngleForceField, calculateEnergyAndForces)
     auto bondForceField = forceField::AngleForceField(
         {&molecule, &molecule, &molecule},
         {0, 1, 2},
-        0
+        AngleId{0}
     );
     bondForceField.setEquilibriumAngle(90 * M_PI / 180.0);
     bondForceField.setForceConstant(3.0);
@@ -208,7 +209,7 @@ TEST_F(TestAngleForceField, collinearAngleProducesFiniteForces)
     auto angleForceField = forceField::AngleForceField(
         {&molecule, &molecule, &molecule},
         {0, 1, 2},
-        0
+        AngleId{0}
     );
     angleForceField.setEquilibriumAngle(M_PI);   // linear equilibrium
     angleForceField.setForceConstant(3.0);

--- a/tests/src/forceField/testAngleType.cpp
+++ b/tests/src/forceField/testAngleType.cpp
@@ -31,11 +31,11 @@
  */
 TEST(TestAngleType, operatorEqual)
 {
-    forceField::AngleType angleType1(0, 1.0, 2.0);
-    forceField::AngleType angleType2(0, 1.0, 2.0);
-    forceField::AngleType angleType3(1, 1.0, 2.0);
-    forceField::AngleType angleType4(0, 2.0, 2.0);
-    forceField::AngleType angleType5(0, 1.0, 3.0);
+    forceField::AngleType angleType1(AngleId{0}, 1.0, 2.0);
+    forceField::AngleType angleType2(AngleId{0}, 1.0, 2.0);
+    forceField::AngleType angleType3(AngleId{1}, 1.0, 2.0);
+    forceField::AngleType angleType4(AngleId{0}, 2.0, 2.0);
+    forceField::AngleType angleType5(AngleId{0}, 1.0, 3.0);
 
     EXPECT_TRUE(angleType1 == angleType2);
     EXPECT_FALSE(angleType1 == angleType3);

--- a/tests/src/forceField/testBondForceField.cpp
+++ b/tests/src/forceField/testBondForceField.cpp
@@ -86,7 +86,7 @@ TEST_F(TestBondForceField, calculateEnergyAndForces)
     molecule.addAtom(atom2);
 
     auto bondForceField =
-        forceField::BondForceField(&molecule, &molecule, 0, 1, 0);
+        forceField::BondForceField(&molecule, &molecule, 0, 1, BondId{0});
     bondForceField.setEquilibriumBondLength(1.2);
     bondForceField.setForceConstant(3.0);
     bondForceField.setIsLinker(false);

--- a/tests/src/forceField/testBondType.cpp
+++ b/tests/src/forceField/testBondType.cpp
@@ -31,11 +31,11 @@
  */
 TEST(TestBondType, operatorEqual)
 {
-    forceField::BondType bondType1(0, 1.0, 2.0);
-    forceField::BondType bondType2(0, 1.0, 2.0);
-    forceField::BondType bondType3(1, 1.0, 2.0);
-    forceField::BondType bondType4(0, 2.0, 2.0);
-    forceField::BondType bondType5(0, 1.0, 3.0);
+    forceField::BondType bondType1(BondId{0}, 1.0, 2.0);
+    forceField::BondType bondType2(BondId{0}, 1.0, 2.0);
+    forceField::BondType bondType3(BondId{1}, 1.0, 2.0);
+    forceField::BondType bondType4(BondId{0}, 2.0, 2.0);
+    forceField::BondType bondType5(BondId{0}, 1.0, 3.0);
 
     EXPECT_TRUE(bondType1 == bondType2);
     EXPECT_FALSE(bondType1 == bondType3);

--- a/tests/src/forceField/testDihedralForceField.cpp
+++ b/tests/src/forceField/testDihedralForceField.cpp
@@ -39,6 +39,7 @@
 #include "physicalData.hpp"              // for PhysicalData
 #include "potentialSettings.hpp"         // for PotentialSettings
 #include "simulationBox.hpp"             // for SimulationBox
+#include "strongTypes.hpp"
 
 namespace potential
 {
@@ -107,7 +108,7 @@ TEST_F(TestDihedralForceField, calculateEnergyAndForces)
     auto bondForceField = forceField::DihedralForceField(
         {&molecule, &molecule, &molecule, &molecule},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
     bondForceField.setPhaseShift(180.0 * M_PI / 180.0);
     bondForceField.setPeriodicity(3);

--- a/tests/src/forceField/testDihedralType.cpp
+++ b/tests/src/forceField/testDihedralType.cpp
@@ -31,12 +31,12 @@
  */
 TEST(TestDihedralType, operatorEqual)
 {
-    forceField::DihedralType dihedralType1(0, 1.0, 2.0, 3.0);
-    forceField::DihedralType dihedralType2(0, 1.0, 2.0, 3.0);
-    forceField::DihedralType dihedralType3(1, 1.0, 2.0, 3.0);
-    forceField::DihedralType dihedralType4(0, 2.0, 2.0, 3.0);
-    forceField::DihedralType dihedralType5(0, 1.0, 3.0, 3.0);
-    forceField::DihedralType dihedralType6(0, 1.0, 2.0, 4.0);
+    forceField::DihedralType dihedralType1(DihedralId{0}, 1.0, 2.0, 3.0);
+    forceField::DihedralType dihedralType2(DihedralId{0}, 1.0, 2.0, 3.0);
+    forceField::DihedralType dihedralType3(DihedralId{1}, 1.0, 2.0, 3.0);
+    forceField::DihedralType dihedralType4(DihedralId{0}, 2.0, 2.0, 3.0);
+    forceField::DihedralType dihedralType5(DihedralId{0}, 1.0, 3.0, 3.0);
+    forceField::DihedralType dihedralType6(DihedralId{0}, 1.0, 2.0, 4.0);
 
     EXPECT_TRUE(dihedralType1 == dihedralType2);
     EXPECT_FALSE(dihedralType1 == dihedralType3);

--- a/tests/src/forceField/testForceField.cpp
+++ b/tests/src/forceField/testForceField.cpp
@@ -46,7 +46,8 @@
 #include "physicalData.hpp"           // for PhysicalData
 #include "potentialSettings.hpp"      // for PotentialSettings
 #include "simulationBox.hpp"          // for SimulationBox
-#include "throwWithMessage.hpp"       // for EXPECT_THROW_MSG
+#include "strongTypes.hpp"
+#include "throwWithMessage.hpp"   // for EXPECT_THROW_MSG
 
 namespace potential
 {
@@ -82,7 +83,7 @@ TEST_F(TestForceField, findBondTypeById_notFoundError)
     EXPECT_THROW_MSG(
         forceField.findBondTypeById(BondId{0}),
         customException::TopologyException,
-        "Bond type with id " + std::to_string(0) + " not found."
+        "Bond type with id " + BondId(0).toString() + " not found."
     );
 }
 
@@ -111,7 +112,7 @@ TEST_F(TestForceField, findAngleTypeById_notFoundError)
     EXPECT_THROW_MSG(
         forceField.findAngleTypeById(AngleId{0}),
         customException::TopologyException,
-        "Angle type with id " + std::to_string(0) + " not found."
+        "Angle type with id " + AngleId(0).toString() + " not found."
     );
 }
 
@@ -122,11 +123,11 @@ TEST_F(TestForceField, findAngleTypeById_notFoundError)
 TEST_F(TestForceField, findDihedralTypeById)
 {
     auto forceField   = forceField::ForceField();
-    auto dihedralType = forceField::DihedralType(0, 1.0, 1.0, 1.0);
+    auto dihedralType = forceField::DihedralType(DihedralId{0}, 1.0, 1.0, 1.0);
 
     forceField.addDihedralType(dihedralType);
 
-    EXPECT_EQ(forceField.findDihedralTypeById(0), dihedralType);
+    EXPECT_EQ(forceField.findDihedralTypeById(DihedralId{0}), dihedralType);
 }
 
 /**
@@ -138,9 +139,9 @@ TEST_F(TestForceField, findDihedralTypeById_notFoundError)
     auto forceField = forceField::ForceField();
 
     EXPECT_THROW_MSG(
-        forceField.findDihedralTypeById(0),
+        forceField.findDihedralTypeById(DihedralId{0}),
         customException::TopologyException,
-        "Dihedral type with id " + std::to_string(0) + " not found."
+        "Dihedral type with id " + DihedralId(0).toString() + " not found."
     );
 }
 
@@ -150,12 +151,16 @@ TEST_F(TestForceField, findDihedralTypeById_notFoundError)
  */
 TEST_F(TestForceField, findImproperTypeById)
 {
-    auto forceField           = forceField::ForceField();
-    auto improperDihedralType = forceField::DihedralType(0, 1.0, 1.0, 1.0);
+    auto forceField = forceField::ForceField();
+    auto improperDihedralType =
+        forceField::DihedralType(DihedralId{0}, 1.0, 1.0, 1.0);
 
     forceField.addImproperDihedralType(improperDihedralType);
 
-    EXPECT_EQ(forceField.findImproperTypeById(0), improperDihedralType);
+    EXPECT_EQ(
+        forceField.findImproperTypeById(DihedralId{0}),
+        improperDihedralType
+    );
 }
 
 /**
@@ -167,9 +172,10 @@ TEST_F(TestForceField, findImproperDihedralTypeById_notFoundError)
     auto forceField = forceField::ForceField();
 
     EXPECT_THROW_MSG(
-        forceField.findImproperTypeById(0),
+        forceField.findImproperTypeById(DihedralId{0}),
         customException::TopologyException,
-        "Improper dihedral type with id " + std::to_string(0) + " not found."
+        "Improper dihedral type with id " + DihedralId(0).toString() +
+            " not found."
     );
 }
 
@@ -245,12 +251,12 @@ TEST_F(TestForceField, calculateBondedInteractions)
     auto dihedralForceField = forceField::DihedralForceField(
         {&molecule, &molecule, &molecule, &molecule},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
     auto improperDihedralForceField = forceField::DihedralForceField(
         {&molecule, &molecule, &molecule, &molecule},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
 
     bondForceField.setEquilibriumBondLength(1.2);

--- a/tests/src/forceField/testForceField.cpp
+++ b/tests/src/forceField/testForceField.cpp
@@ -93,11 +93,11 @@ TEST_F(TestForceField, findBondTypeById_notFoundError)
 TEST_F(TestForceField, findAngleTypeById)
 {
     auto forceField = forceField::ForceField();
-    auto angleType  = forceField::AngleType(0, 1.0, 1.0);
+    auto angleType  = forceField::AngleType(AngleId{0}, 1.0, 1.0);
 
     forceField.addAngleType(angleType);
 
-    EXPECT_EQ(forceField.findAngleTypeById(0), angleType);
+    EXPECT_EQ(forceField.findAngleTypeById(AngleId{0}), angleType);
 }
 
 /**
@@ -109,7 +109,7 @@ TEST_F(TestForceField, findAngleTypeById_notFoundError)
     auto forceField = forceField::ForceField();
 
     EXPECT_THROW_MSG(
-        forceField.findAngleTypeById(0),
+        forceField.findAngleTypeById(AngleId{0}),
         customException::TopologyException,
         "Angle type with id " + std::to_string(0) + " not found."
     );
@@ -240,7 +240,7 @@ TEST_F(TestForceField, calculateBondedInteractions)
     auto angleForceField = forceField::AngleForceField(
         {&molecule, &molecule, &molecule},
         {0, 1, 2},
-        0
+        AngleId{0}
     );
     auto dihedralForceField = forceField::DihedralForceField(
         {&molecule, &molecule, &molecule, &molecule},

--- a/tests/src/forceField/testForceField.cpp
+++ b/tests/src/forceField/testForceField.cpp
@@ -64,11 +64,11 @@ class TestForceField : public TestNonCoulombPotentialFF
 TEST_F(TestForceField, findBondTypeById)
 {
     auto       forceField = forceField::ForceField();
-    const auto bondType   = forceField::BondType(0, 1.0, 1.0);
+    const auto bondType   = forceField::BondType(BondId{0}, 1.0, 1.0);
 
     forceField.addBondType(bondType);
 
-    EXPECT_EQ(forceField.findBondTypeById(0), bondType);
+    EXPECT_EQ(forceField.findBondTypeById(BondId{0}), bondType);
 }
 
 /**
@@ -80,7 +80,7 @@ TEST_F(TestForceField, findBondTypeById_notFoundError)
     auto forceField = forceField::ForceField();
 
     EXPECT_THROW_MSG(
-        forceField.findBondTypeById(0),
+        forceField.findBondTypeById(BondId{0}),
         customException::TopologyException,
         "Bond type with id " + std::to_string(0) + " not found."
     );
@@ -236,7 +236,7 @@ TEST_F(TestForceField, calculateBondedInteractions)
     molecule.addAtom(atom4);
 
     auto bondForceField =
-        forceField::BondForceField(&molecule, &molecule, 0, 1, 0);
+        forceField::BondForceField(&molecule, &molecule, 0, 1, BondId{0});
     auto angleForceField = forceField::AngleForceField(
         {&molecule, &molecule, &molecule},
         {0, 1, 2},

--- a/tests/src/forceField/testJCoupling.cpp
+++ b/tests/src/forceField/testJCoupling.cpp
@@ -79,9 +79,14 @@ TEST(TestJCouplingType, symmetryFlagSetters)
 
 TEST(TestJCouplingForceField, settersAndGetters)
 {
-    simulationBox::Molecule molecule;
+    simulationBox::Molecule         molecule;
     forceField::JCouplingForceField ff(
-        std::vector<simulationBox::Molecule *>{&molecule, &molecule, &molecule, &molecule},
+        std::vector<simulationBox::Molecule *>{
+            &molecule,
+            &molecule,
+            &molecule,
+            &molecule
+        },
         std::vector<size_t>{0, 1, 2, 3},
         42
     );
@@ -105,9 +110,14 @@ TEST(TestJCouplingForceField, settersAndGetters)
 
 TEST(TestJCouplingForceField, symmetryFlagsDefaultTrue)
 {
-    simulationBox::Molecule molecule;
+    simulationBox::Molecule         molecule;
     forceField::JCouplingForceField ff(
-        std::vector<simulationBox::Molecule *>{&molecule, &molecule, &molecule, &molecule},
+        std::vector<simulationBox::Molecule *>{
+            &molecule,
+            &molecule,
+            &molecule,
+            &molecule
+        },
         std::vector<size_t>{0, 1, 2, 3},
         0
     );

--- a/tests/src/input/parameterFileReader/testAngleTypesSection.cpp
+++ b/tests/src/input/parameterFileReader/testAngleTypesSection.cpp
@@ -44,16 +44,16 @@ TEST_F(TestParameterFileSection, processSectionAngle)
     std::vector<std::string>           lineElements = {"0", "1.22", "234.3"};
     input::parameterFile::AngleSection angleSection;
     angleSection.processSection(lineElements, *_engine);
-    EXPECT_EQ(_engine->getForceField()->getAngleTypes().size(), 1);
-    EXPECT_EQ(_engine->getForceField()->getAngleTypes()[0].getId(), 0);
+
+    const auto &angleTypes = _engine->getForceField()->getAngleTypes();
+
+    EXPECT_EQ(angleTypes.size(), 1);
+    EXPECT_EQ(angleTypes[0].getId(), AngleId{0});
     EXPECT_EQ(
-        _engine->getForceField()->getAngleTypes()[0].getEquilibriumAngle(),
+        angleTypes[0].getEquilibriumAngle(),
         1.22 * constants::DEG_TO_RAD
     );
-    EXPECT_EQ(
-        _engine->getForceField()->getAngleTypes()[0].getForceConstant(),
-        234.3
-    );
+    EXPECT_EQ(angleTypes[0].getForceConstant(), 234.3);
 
     lineElements = {"1", "2", "1.0", "0"};
     EXPECT_THROW(

--- a/tests/src/input/parameterFileReader/testBondTypesSection.cpp
+++ b/tests/src/input/parameterFileReader/testBondTypesSection.cpp
@@ -43,16 +43,11 @@ TEST_F(TestParameterFileSection, processSectionBonds)
     std::vector<std::string>          lineElements = {"0", "1.22", "234.3"};
     input::parameterFile::BondSection bondSection;
     bondSection.processSection(lineElements, *_engine);
-    EXPECT_EQ(_engine->getForceField()->getBondTypes().size(), 1);
-    EXPECT_EQ(_engine->getForceField()->getBondTypes()[0].getId(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getBondTypes()[0].getEquilibriumBondLength(),
-        1.22
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getBondTypes()[0].getForceConstant(),
-        234.3
-    );
+    const auto &bondTypes = _engine->getForceField()->getBondTypes();
+    EXPECT_EQ(bondTypes.size(), 1);
+    EXPECT_EQ(bondTypes[0].getId(), BondId{0});
+    EXPECT_EQ(bondTypes[0].getEquilibriumBondLength(), 1.22);
+    EXPECT_EQ(bondTypes[0].getForceConstant(), 234.3);
 
     lineElements = {"1", "2", "1.0", "0"};
     EXPECT_THROW(

--- a/tests/src/input/parameterFileReader/testDihedralTypesSection.cpp
+++ b/tests/src/input/parameterFileReader/testDihedralTypesSection.cpp
@@ -44,20 +44,14 @@ TEST_F(TestParameterFileSection, processSectionDihedral)
     std::vector<std::string> lineElements = {"0", "1.22", "234.3", "324.3"};
     DihedralSection          dihedralSection;
     dihedralSection.processSection(lineElements, *_engine);
-    EXPECT_EQ(_engine->getForceField()->getDihedralTypes().size(), 1);
-    EXPECT_EQ(_engine->getForceField()->getDihedralTypes()[0].getId(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedralTypes()[0].getForceConstant(),
-        1.22
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedralTypes()[0].getPeriodicity(),
-        234.3
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedralTypes()[0].getPhaseShift(),
-        324.3 * constants::DEG_TO_RAD
-    );
+
+    const auto &dihedralTypes = _engine->getForceField()->getDihedralTypes();
+
+    EXPECT_EQ(dihedralTypes.size(), 1);
+    EXPECT_EQ(dihedralTypes[0].getId(), DihedralId{0});
+    EXPECT_EQ(dihedralTypes[0].getForceConstant(), 1.22);
+    EXPECT_EQ(dihedralTypes[0].getPeriodicity(), 234.3);
+    EXPECT_EQ(dihedralTypes[0].getPhaseShift(), 324.3 * constants::DEG_TO_RAD);
 
     lineElements = {"1", "2", "1.0", "0", "2"};
     EXPECT_THROW(

--- a/tests/src/input/parameterFileReader/testImproperDihedralTypesSection.cpp
+++ b/tests/src/input/parameterFileReader/testImproperDihedralTypesSection.cpp
@@ -44,18 +44,16 @@ TEST_F(TestParameterFileSection, processSectionImproperDihedral)
     std::vector<std::string> lineElements = {"0", "1.22", "234.3", "324.3"};
     ImproperDihedralSection  improperDihedralSection;
     improperDihedralSection.processSection(lineElements, *_engine);
-    EXPECT_EQ(_engine->getForceField()->getImproperTypes().size(), 1);
-    EXPECT_EQ(_engine->getForceField()->getImproperTypes()[0].getId(), 0);
+
+    const auto &improperDihedralTypes =
+        _engine->getForceField()->getImproperTypes();
+
+    EXPECT_EQ(improperDihedralTypes.size(), 1);
+    EXPECT_EQ(improperDihedralTypes[0].getId(), DihedralId{0});
+    EXPECT_EQ(improperDihedralTypes[0].getForceConstant(), 1.22);
+    EXPECT_EQ(improperDihedralTypes[0].getPeriodicity(), 234.3);
     EXPECT_EQ(
-        _engine->getForceField()->getImproperTypes()[0].getForceConstant(),
-        1.22
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperTypes()[0].getPeriodicity(),
-        234.3
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperTypes()[0].getPhaseShift(),
+        improperDihedralTypes[0].getPhaseShift(),
         324.3 * constants::DEG_TO_RAD
     );
 

--- a/tests/src/input/topologyReader/testAngleSection.cpp
+++ b/tests/src/input/topologyReader/testAngleSection.cpp
@@ -25,10 +25,11 @@
 #include <string>   // for string, allocator, basic_string
 #include <vector>   // for vector
 
-#include "angleSection.hpp"          // for AngleSection
-#include "engine.hpp"                // for Engine
-#include "exceptions.hpp"            // for TopologyException
-#include "gtest/gtest.h"             // for Message, TestPartResult
+#include "angleSection.hpp"   // for AngleSection
+#include "engine.hpp"         // for Engine
+#include "exceptions.hpp"     // for TopologyException
+#include "gtest/gtest.h"      // for Message, TestPartResult
+#include "strongTypes.hpp"
 #include "testTopologySection.hpp"   // for TestTopologySection
 
 /**
@@ -40,24 +41,19 @@ TEST_F(TestTopologySection, processSectionAngle)
     std::vector<std::string>      lineElements = {"2", "1", "3", "7"};
     input::topology::AngleSection angleSection;
     angleSection.processSection(lineElements, *_engine);
-    EXPECT_EQ(_engine->getForceField()->getAngles().size(), 1);
-    EXPECT_EQ(
-        _engine->getForceField()->getAngles()[0].getMolecules()[0],
-        &(_engine->getSimulationBox().getMolecules()[0])
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getAngles()[0].getMolecules()[1],
-        &(_engine->getSimulationBox().getMolecules()[1])
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getAngles()[0].getMolecules()[2],
-        &(_engine->getSimulationBox().getMolecules()[1])
-    );
-    EXPECT_EQ(_engine->getForceField()->getAngles()[0].getAtomIndices()[0], 0);
-    EXPECT_EQ(_engine->getForceField()->getAngles()[0].getAtomIndices()[1], 0);
-    EXPECT_EQ(_engine->getForceField()->getAngles()[0].getAtomIndices()[2], 1);
-    EXPECT_EQ(_engine->getForceField()->getAngles()[0].getType(), 7);
-    EXPECT_EQ(_engine->getForceField()->getAngles()[0].isLinker(), false);
+
+    const auto &angles    = _engine->getForceField()->getAngles();
+    const auto &molecules = _engine->getSimulationBox().getMolecules();
+
+    EXPECT_EQ(angles.size(), 1);
+    EXPECT_EQ(angles[0].getMolecules()[0], &(molecules[0]));
+    EXPECT_EQ(angles[0].getMolecules()[1], &(molecules[1]));
+    EXPECT_EQ(angles[0].getMolecules()[2], &(molecules[1]));
+    EXPECT_EQ(angles[0].getAtomIndices()[0], 0);
+    EXPECT_EQ(angles[0].getAtomIndices()[1], 0);
+    EXPECT_EQ(angles[0].getAtomIndices()[2], 1);
+    EXPECT_EQ(angles[0].getType(), AngleId{7});
+    EXPECT_EQ(angles[0].isLinker(), false);
 
     lineElements = {"2", "1", "3", "7", "*"};
     angleSection.processSection(lineElements, *_engine);

--- a/tests/src/input/topologyReader/testBondSection.cpp
+++ b/tests/src/input/topologyReader/testBondSection.cpp
@@ -40,23 +40,24 @@ TEST_F(TestTopologySection, processSectionBond)
     std::vector<std::string>     lineElements = {"1", "2", "7"};
     input::topology::BondSection bondSection;
     bondSection.processSection(lineElements, *_engine);
-    EXPECT_EQ(_engine->getForceField()->getBonds().size(), 1);
+    const auto &bonds = _engine->getForceField()->getBonds();
+    EXPECT_EQ(bonds.size(), 1);
     EXPECT_EQ(
-        _engine->getForceField()->getBonds()[0].getMolecule1(),
+        bonds[0].getMolecule1(),
         &(_engine->getSimulationBox().getMolecules()[0])
     );
     EXPECT_EQ(
-        _engine->getForceField()->getBonds()[0].getMolecule2(),
+        bonds[0].getMolecule2(),
         &(_engine->getSimulationBox().getMolecules()[1])
     );
-    EXPECT_EQ(_engine->getForceField()->getBonds()[0].getAtomIndex1(), 0);
-    EXPECT_EQ(_engine->getForceField()->getBonds()[0].getAtomIndex2(), 0);
-    EXPECT_EQ(_engine->getForceField()->getBonds()[0].getType(), 7);
-    EXPECT_EQ(_engine->getForceField()->getBonds()[0].isLinker(), false);
+    EXPECT_EQ(bonds[0].getAtomIndex1(), 0);
+    EXPECT_EQ(bonds[0].getAtomIndex2(), 0);
+    EXPECT_EQ(bonds[0].getType(), BondId{7});
+    EXPECT_EQ(bonds[0].isLinker(), false);
 
     lineElements = {"1", "2", "7", "*"};
     bondSection.processSection(lineElements, *_engine);
-    EXPECT_EQ(_engine->getForceField()->getBonds()[1].isLinker(), true);
+    EXPECT_EQ(bonds[1].isLinker(), true);
 
     lineElements = {"1", "1", "7"};
     EXPECT_THROW(

--- a/tests/src/input/topologyReader/testDihedralSection.cpp
+++ b/tests/src/input/topologyReader/testDihedralSection.cpp
@@ -25,10 +25,11 @@
 #include <string>   // for string, allocator, basic_string
 #include <vector>   // for vector
 
-#include "dihedralSection.hpp"       // for DihedralSection
-#include "engine.hpp"                // for Engine
-#include "exceptions.hpp"            // for TopologyException
-#include "gtest/gtest.h"             // for Message, TestPartResult
+#include "dihedralSection.hpp"   // for DihedralSection
+#include "engine.hpp"            // for Engine
+#include "exceptions.hpp"        // for TopologyException
+#include "gtest/gtest.h"         // for Message, TestPartResult
+#include "strongTypes.hpp"
 #include "testTopologySection.hpp"   // for TestTopologySection
 
 /**
@@ -40,45 +41,25 @@ TEST_F(TestTopologySection, processSectionDihedral)
     std::vector<std::string>         lineElements = {"1", "2", "3", "4", "7"};
     input::topology::DihedralSection dihedralSection;
     dihedralSection.processSection(lineElements, *_engine);
-    EXPECT_EQ(_engine->getForceField()->getDihedrals().size(), 1);
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getMolecules()[0],
-        &(_engine->getSimulationBox().getMolecules()[0])
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getMolecules()[1],
-        &(_engine->getSimulationBox().getMolecules()[1])
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getMolecules()[2],
-        &(_engine->getSimulationBox().getMolecules()[1])
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getMolecules()[3],
-        &(_engine->getSimulationBox().getMolecules()[1])
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getAtomIndices()[0],
-        0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getAtomIndices()[1],
-        0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getAtomIndices()[2],
-        1
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getAtomIndices()[3],
-        2
-    );
-    EXPECT_EQ(_engine->getForceField()->getDihedrals()[0].getType(), 7);
-    EXPECT_EQ(_engine->getForceField()->getDihedrals()[0].isLinker(), false);
+
+    const auto &dihedrals = _engine->getForceField()->getDihedrals();
+    const auto &molecules = _engine->getSimulationBox().getMolecules();
+
+    EXPECT_EQ(dihedrals.size(), 1);
+    EXPECT_EQ(dihedrals[0].getMolecules()[0], &(molecules[0]));
+    EXPECT_EQ(dihedrals[0].getMolecules()[1], &(molecules[1]));
+    EXPECT_EQ(dihedrals[0].getMolecules()[2], &(molecules[1]));
+    EXPECT_EQ(dihedrals[0].getMolecules()[3], &(molecules[1]));
+    EXPECT_EQ(dihedrals[0].getAtomIndices()[0], 0);
+    EXPECT_EQ(dihedrals[0].getAtomIndices()[1], 0);
+    EXPECT_EQ(dihedrals[0].getAtomIndices()[2], 1);
+    EXPECT_EQ(dihedrals[0].getAtomIndices()[3], 2);
+    EXPECT_EQ(dihedrals[0].getType(), DihedralId{7});
+    EXPECT_EQ(dihedrals[0].isLinker(), false);
 
     lineElements = {"1", "2", "3", "4", "7", "*"};
     dihedralSection.processSection(lineElements, *_engine);
-    EXPECT_EQ(_engine->getForceField()->getDihedrals()[1].isLinker(), true);
+    EXPECT_EQ(dihedrals[1].isLinker(), true);
 
     lineElements = {"1", "1", "2", "3", "4"};
     EXPECT_THROW(

--- a/tests/src/input/topologyReader/testImproperDihedralSection.cpp
+++ b/tests/src/input/topologyReader/testImproperDihedralSection.cpp
@@ -40,40 +40,21 @@ TEST_F(TestTopologySection, processSectionImproperDihedral)
     std::vector<std::string> lineElements = {"1", "2", "3", "4", "7"};
     input::topology::ImproperDihedralSection improperDihedralSection;
     improperDihedralSection.processSection(lineElements, *_engine);
-    EXPECT_EQ(_engine->getForceField()->getImproperDihedrals().size(), 1);
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getMolecules()[0],
-        &(_engine->getSimulationBox().getMolecules()[0])
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getMolecules()[1],
-        &(_engine->getSimulationBox().getMolecules()[1])
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getMolecules()[2],
-        &(_engine->getSimulationBox().getMolecules()[1])
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getMolecules()[3],
-        &(_engine->getSimulationBox().getMolecules()[1])
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getAtomIndices()[0],
-        0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getAtomIndices()[1],
-        0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getAtomIndices()[2],
-        1
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getAtomIndices()[3],
-        2
-    );
-    EXPECT_EQ(_engine->getForceField()->getImproperDihedrals()[0].getType(), 7);
+
+    const auto &improperDihedrals =
+        _engine->getForceField()->getImproperDihedrals();
+    const auto &molecules = _engine->getSimulationBox().getMolecules();
+
+    EXPECT_EQ(improperDihedrals.size(), 1);
+    EXPECT_EQ(improperDihedrals[0].getMolecules()[0], &(molecules[0]));
+    EXPECT_EQ(improperDihedrals[0].getMolecules()[1], &(molecules[1]));
+    EXPECT_EQ(improperDihedrals[0].getMolecules()[2], &(molecules[1]));
+    EXPECT_EQ(improperDihedrals[0].getMolecules()[3], &(molecules[1]));
+    EXPECT_EQ(improperDihedrals[0].getAtomIndices()[0], 0);
+    EXPECT_EQ(improperDihedrals[0].getAtomIndices()[1], 0);
+    EXPECT_EQ(improperDihedrals[0].getAtomIndices()[2], 1);
+    EXPECT_EQ(improperDihedrals[0].getAtomIndices()[3], 2);
+    EXPECT_EQ(improperDihedrals[0].getType(), DihedralId{7});
 
     lineElements = {"1", "1", "2", "3", "4"};
     EXPECT_THROW(

--- a/tests/src/setup/testForceFieldSetup.cpp
+++ b/tests/src/setup/testForceFieldSetup.cpp
@@ -53,18 +53,18 @@ TEST_F(TestSetup, forceFieldSetup_setupBonds)
     auto *molecule2Ptr = &_engine->getSimulationBox().getMolecule(1);
 
     auto bond1 =
-        forceField::BondForceField(molecule1Ptr, molecule2Ptr, 0, 1, 0);
+        forceField::BondForceField(molecule1Ptr, molecule2Ptr, 0, 1, BondId{0});
     auto bond2 =
-        forceField::BondForceField(molecule1Ptr, molecule1Ptr, 0, 1, 1);
+        forceField::BondForceField(molecule1Ptr, molecule1Ptr, 0, 1, BondId{1});
     auto bond3 =
-        forceField::BondForceField(molecule1Ptr, molecule2Ptr, 0, 1, 0);
+        forceField::BondForceField(molecule1Ptr, molecule2Ptr, 0, 1, BondId{0});
 
     _engine->getForceField()->addBond(bond1);
     _engine->getForceField()->addBond(bond2);
     _engine->getForceField()->addBond(bond3);
 
-    auto bondType1 = forceField::BondType(0, 1.0, 1.0);
-    auto bondType2 = forceField::BondType(1, 2.0, 2.0);
+    auto bondType1 = forceField::BondType(BondId{0}, 1.0, 1.0);
+    auto bondType2 = forceField::BondType(BondId{1}, 2.0, 2.0);
 
     _engine->getForceField()->addBondType(bondType1);
     _engine->getForceField()->addBondType(bondType2);
@@ -72,26 +72,19 @@ TEST_F(TestSetup, forceFieldSetup_setupBonds)
     auto setup = setup::ForceFieldSetup(*_engine);
     setup.setupBonds();
 
-    EXPECT_EQ(_engine->getForceField()->getBonds()[0].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getBonds()[0].getEquilibriumBondLength(),
-        1.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getBonds()[0].getForceConstant(), 1.0);
+    const auto &bonds = _engine->getForceField()->getBonds();
 
-    EXPECT_EQ(_engine->getForceField()->getBonds()[1].getType(), 1);
-    EXPECT_EQ(
-        _engine->getForceField()->getBonds()[1].getEquilibriumBondLength(),
-        2.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getBonds()[1].getForceConstant(), 2.0);
+    EXPECT_EQ(bonds[0].getType(), BondId{0});
+    EXPECT_EQ(bonds[0].getEquilibriumBondLength(), 1.0);
+    EXPECT_EQ(bonds[0].getForceConstant(), 1.0);
 
-    EXPECT_EQ(_engine->getForceField()->getBonds()[2].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getBonds()[2].getEquilibriumBondLength(),
-        1.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getBonds()[2].getForceConstant(), 1.0);
+    EXPECT_EQ(bonds[1].getType(), BondId{1});
+    EXPECT_EQ(bonds[1].getEquilibriumBondLength(), 2.0);
+    EXPECT_EQ(bonds[1].getForceConstant(), 2.0);
+
+    EXPECT_EQ(bonds[2].getType(), BondId{0});
+    EXPECT_EQ(bonds[2].getEquilibriumBondLength(), 1.0);
+    EXPECT_EQ(bonds[2].getForceConstant(), 1.0);
 
     EXPECT_EQ(_engine->getForceField()->getBondTypes().size(), 0);
 }
@@ -345,7 +338,8 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField)
     _engine->getSimulationBox().addMolecule(molecule1);
     auto *molecule1Ptr = &_engine->getSimulationBox().getMolecule(0);
 
-    auto bond = forceField::BondForceField(molecule1Ptr, molecule1Ptr, 0, 1, 0);
+    auto bond =
+        forceField::BondForceField(molecule1Ptr, molecule1Ptr, 0, 1, BondId{0});
     auto angle = forceField::AngleForceField(
         {molecule1Ptr, molecule1Ptr, molecule1Ptr},
         {0, 1, 2},
@@ -367,7 +361,7 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField)
     _engine->getForceField()->addDihedral(dihedral);
     _engine->getForceField()->addImproperDihedral(improperDihedral);
 
-    auto bondType             = forceField::BondType(0, 1.0, 2.0);
+    auto bondType             = forceField::BondType(BondId{0}, 1.0, 2.0);
     auto angleType            = forceField::AngleType(0, 2.0, 3.0);
     auto dihedralType         = forceField::DihedralType(0, 3.0, 4.0, 5.0);
     auto improperDihedralType = forceField::DihedralType(0, 4.0, 5.0, 6.0);
@@ -379,12 +373,11 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField)
 
     setup::setupForceField(*_engine);
 
-    EXPECT_EQ(_engine->getForceField()->getBonds()[0].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getBonds()[0].getEquilibriumBondLength(),
-        1.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getBonds()[0].getForceConstant(), 2.0);
+    const auto &bonds = _engine->getForceField()->getBonds();
+
+    EXPECT_EQ(bonds[0].getType(), BondId{0});
+    EXPECT_EQ(bonds[0].getEquilibriumBondLength(), 1.0);
+    EXPECT_EQ(bonds[0].getForceConstant(), 2.0);
 
     EXPECT_EQ(_engine->getForceField()->getAngles()[0].getType(), 0);
     EXPECT_EQ(
@@ -431,7 +424,8 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField_doNothing)
     _engine->getSimulationBox().addMolecule(molecule1);
     auto *molecule1Ptr = &_engine->getSimulationBox().getMolecule(0);
 
-    auto bond = forceField::BondForceField(molecule1Ptr, molecule1Ptr, 0, 1, 0);
+    auto bond =
+        forceField::BondForceField(molecule1Ptr, molecule1Ptr, 0, 1, BondId{0});
     auto angle = forceField::AngleForceField(
         {molecule1Ptr, molecule1Ptr, molecule1Ptr},
         {0, 1, 2},
@@ -453,7 +447,7 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField_doNothing)
     _engine->getForceField()->addDihedral(dihedral);
     _engine->getForceField()->addImproperDihedral(improperDihedral);
 
-    auto bondType             = forceField::BondType(0, 1.0, 2.0);
+    auto bondType             = forceField::BondType(BondId{0}, 1.0, 2.0);
     auto angleType            = forceField::AngleType(0, 2.0, 3.0);
     auto dihedralType         = forceField::DihedralType(0, 3.0, 4.0, 5.0);
     auto improperDihedralType = forceField::DihedralType(0, 4.0, 5.0, 6.0);

--- a/tests/src/setup/testForceFieldSetup.cpp
+++ b/tests/src/setup/testForceFieldSetup.cpp
@@ -107,25 +107,25 @@ TEST_F(TestSetup, forceFieldSetup_setupAngles)
     auto angle1 = forceField::AngleForceField(
         {molecule1Ptr, molecule2Ptr, molecule2Ptr},
         {0, 1, 2},
-        0
+        AngleId{0}
     );
     auto angle2 = forceField::AngleForceField(
         {molecule1Ptr, molecule1Ptr, molecule2Ptr},
         {0, 1, 2},
-        1
+        AngleId{1}
     );
     auto angle3 = forceField::AngleForceField(
         {molecule1Ptr, molecule2Ptr, molecule2Ptr},
         {0, 1, 2},
-        0
+        AngleId{0}
     );
 
     _engine->getForceField()->addAngle(angle1);
     _engine->getForceField()->addAngle(angle2);
     _engine->getForceField()->addAngle(angle3);
 
-    auto angleType1 = forceField::AngleType(0, 1.0, 1.0);
-    auto angleType2 = forceField::AngleType(1, 2.0, 2.0);
+    auto angleType1 = forceField::AngleType(AngleId{0}, 1.0, 1.0);
+    auto angleType2 = forceField::AngleType(AngleId{1}, 2.0, 2.0);
 
     _engine->getForceField()->addAngleType(angleType1);
     _engine->getForceField()->addAngleType(angleType2);
@@ -133,26 +133,19 @@ TEST_F(TestSetup, forceFieldSetup_setupAngles)
     auto setup = setup::ForceFieldSetup(*_engine);
     setup.setupAngles();
 
-    EXPECT_EQ(_engine->getForceField()->getAngles()[0].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getAngles()[0].getEquilibriumAngle(),
-        1.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getAngles()[0].getForceConstant(), 1.0);
+    const auto &angles = _engine->getForceField()->getAngles();
 
-    EXPECT_EQ(_engine->getForceField()->getAngles()[1].getType(), 1);
-    EXPECT_EQ(
-        _engine->getForceField()->getAngles()[1].getEquilibriumAngle(),
-        2.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getAngles()[1].getForceConstant(), 2.0);
+    EXPECT_EQ(angles[0].getType(), AngleId{0});
+    EXPECT_EQ(angles[0].getEquilibriumAngle(), 1.0);
+    EXPECT_EQ(angles[0].getForceConstant(), 1.0);
 
-    EXPECT_EQ(_engine->getForceField()->getAngles()[2].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getAngles()[2].getEquilibriumAngle(),
-        1.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getAngles()[2].getForceConstant(), 1.0);
+    EXPECT_EQ(angles[1].getType(), AngleId{1});
+    EXPECT_EQ(angles[1].getEquilibriumAngle(), 2.0);
+    EXPECT_EQ(angles[1].getForceConstant(), 2.0);
+
+    EXPECT_EQ(angles[2].getType(), AngleId{0});
+    EXPECT_EQ(angles[2].getEquilibriumAngle(), 1.0);
+    EXPECT_EQ(angles[2].getForceConstant(), 1.0);
 
     EXPECT_EQ(_engine->getForceField()->getAngleTypes().size(), 0);
 }
@@ -343,7 +336,7 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField)
     auto angle = forceField::AngleForceField(
         {molecule1Ptr, molecule1Ptr, molecule1Ptr},
         {0, 1, 2},
-        0
+        AngleId{0}
     );
     auto dihedral = forceField::DihedralForceField(
         {molecule1Ptr, molecule1Ptr, molecule1Ptr, molecule1Ptr},
@@ -362,7 +355,7 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField)
     _engine->getForceField()->addImproperDihedral(improperDihedral);
 
     auto bondType             = forceField::BondType(BondId{0}, 1.0, 2.0);
-    auto angleType            = forceField::AngleType(0, 2.0, 3.0);
+    auto angleType            = forceField::AngleType(AngleId{0}, 2.0, 3.0);
     auto dihedralType         = forceField::DihedralType(0, 3.0, 4.0, 5.0);
     auto improperDihedralType = forceField::DihedralType(0, 4.0, 5.0, 6.0);
 
@@ -379,12 +372,11 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField)
     EXPECT_EQ(bonds[0].getEquilibriumBondLength(), 1.0);
     EXPECT_EQ(bonds[0].getForceConstant(), 2.0);
 
-    EXPECT_EQ(_engine->getForceField()->getAngles()[0].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getAngles()[0].getEquilibriumAngle(),
-        2.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getAngles()[0].getForceConstant(), 3.0);
+    const auto &angles = _engine->getForceField()->getAngles();
+
+    EXPECT_EQ(angles[0].getType(), AngleId{0});
+    EXPECT_EQ(angles[0].getEquilibriumAngle(), 2.0);
+    EXPECT_EQ(angles[0].getForceConstant(), 3.0);
 
     EXPECT_EQ(_engine->getForceField()->getDihedrals()[0].getType(), 0);
     EXPECT_EQ(
@@ -429,7 +421,7 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField_doNothing)
     auto angle = forceField::AngleForceField(
         {molecule1Ptr, molecule1Ptr, molecule1Ptr},
         {0, 1, 2},
-        0
+        AngleId{0}
     );
     auto dihedral = forceField::DihedralForceField(
         {molecule1Ptr, molecule1Ptr, molecule1Ptr, molecule1Ptr},
@@ -448,7 +440,7 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField_doNothing)
     _engine->getForceField()->addImproperDihedral(improperDihedral);
 
     auto bondType             = forceField::BondType(BondId{0}, 1.0, 2.0);
-    auto angleType            = forceField::AngleType(0, 2.0, 3.0);
+    auto angleType            = forceField::AngleType(AngleId{0}, 2.0, 3.0);
     auto dihedralType         = forceField::DihedralType(0, 3.0, 4.0, 5.0);
     auto improperDihedralType = forceField::DihedralType(0, 4.0, 5.0, 6.0);
 
@@ -460,38 +452,23 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField_doNothing)
     settings::ForceFieldSettings::deactivate();
     setup::setupForceField(*_engine);
 
-    EXPECT_NE(
-        _engine->getForceField()->getBonds()[0].getEquilibriumBondLength(),
-        1.0
-    );
-    EXPECT_NE(_engine->getForceField()->getBonds()[0].getForceConstant(), 2.0);
+    const auto &bonds     = _engine->getForceField()->getBonds();
+    const auto &angles    = _engine->getForceField()->getAngles();
+    const auto &dihedrals = _engine->getForceField()->getDihedrals();
+    const auto &improperDihedrals =
+        _engine->getForceField()->getImproperDihedrals();
 
-    EXPECT_NE(
-        _engine->getForceField()->getAngles()[0].getEquilibriumAngle(),
-        2.0
-    );
-    EXPECT_NE(_engine->getForceField()->getAngles()[0].getForceConstant(), 3.0);
+    EXPECT_NE(bonds[0].getEquilibriumBondLength(), 1.0);
+    EXPECT_NE(bonds[0].getForceConstant(), 2.0);
 
-    EXPECT_NE(
-        _engine->getForceField()->getDihedrals()[0].getForceConstant(),
-        3.0
-    );
-    EXPECT_NE(
-        _engine->getForceField()->getDihedrals()[0].getPeriodicity(),
-        4.0
-    );
-    EXPECT_NE(_engine->getForceField()->getDihedrals()[0].getPhaseShift(), 5.0);
+    EXPECT_NE(angles[0].getEquilibriumAngle(), 2.0);
+    EXPECT_NE(angles[0].getForceConstant(), 3.0);
 
-    EXPECT_NE(
-        _engine->getForceField()->getImproperDihedrals()[0].getForceConstant(),
-        4.0
-    );
-    EXPECT_NE(
-        _engine->getForceField()->getImproperDihedrals()[0].getPeriodicity(),
-        5.0
-    );
-    EXPECT_NE(
-        _engine->getForceField()->getImproperDihedrals()[0].getPhaseShift(),
-        6.0
-    );
+    EXPECT_NE(dihedrals[0].getForceConstant(), 3.0);
+    EXPECT_NE(dihedrals[0].getPeriodicity(), 4.0);
+    EXPECT_NE(dihedrals[0].getPhaseShift(), 5.0);
+
+    EXPECT_NE(improperDihedrals[0].getForceConstant(), 4.0);
+    EXPECT_NE(improperDihedrals[0].getPeriodicity(), 5.0);
+    EXPECT_NE(improperDihedrals[0].getPhaseShift(), 6.0);
 }

--- a/tests/src/setup/testForceFieldSetup.cpp
+++ b/tests/src/setup/testForceFieldSetup.cpp
@@ -168,25 +168,25 @@ TEST_F(TestSetup, forceFieldSetup_setupDihedrals)
     auto dihedral1 = forceField::DihedralForceField(
         {molecule1Ptr, molecule2Ptr, molecule2Ptr, molecule2Ptr},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
     auto dihedral2 = forceField::DihedralForceField(
         {molecule1Ptr, molecule1Ptr, molecule2Ptr, molecule2Ptr},
         {0, 1, 2, 3},
-        1
+        DihedralId{1}
     );
     auto dihedral3 = forceField::DihedralForceField(
         {molecule1Ptr, molecule2Ptr, molecule2Ptr, molecule2Ptr},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
 
     _engine->getForceField()->addDihedral(dihedral1);
     _engine->getForceField()->addDihedral(dihedral2);
     _engine->getForceField()->addDihedral(dihedral3);
 
-    auto dihedralType1 = forceField::DihedralType(0, 1.0, 1.0, 1.0);
-    auto dihedralType2 = forceField::DihedralType(1, 2.0, 2.0, 2.0);
+    auto dihedralType1 = forceField::DihedralType(DihedralId{0}, 1.0, 1.0, 1.0);
+    auto dihedralType2 = forceField::DihedralType(DihedralId{1}, 2.0, 2.0, 2.0);
 
     _engine->getForceField()->addDihedralType(dihedralType1);
     _engine->getForceField()->addDihedralType(dihedralType2);
@@ -194,38 +194,22 @@ TEST_F(TestSetup, forceFieldSetup_setupDihedrals)
     auto setup = setup::ForceFieldSetup(*_engine);
     setup.setupDihedrals();
 
-    EXPECT_EQ(_engine->getForceField()->getDihedrals()[0].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getForceConstant(),
-        1.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getDihedrals()[0].getPhaseShift(), 1.0);
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getPeriodicity(),
-        1.0
-    );
+    const auto &dihedrals = _engine->getForceField()->getDihedrals();
 
-    EXPECT_EQ(_engine->getForceField()->getDihedrals()[1].getType(), 1);
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[1].getForceConstant(),
-        2.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getDihedrals()[1].getPhaseShift(), 2.0);
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[1].getPeriodicity(),
-        2.0
-    );
+    EXPECT_EQ(dihedrals[0].getType(), DihedralId{0});
+    EXPECT_EQ(dihedrals[0].getForceConstant(), 1.0);
+    EXPECT_EQ(dihedrals[0].getPhaseShift(), 1.0);
+    EXPECT_EQ(dihedrals[0].getPeriodicity(), 1.0);
 
-    EXPECT_EQ(_engine->getForceField()->getDihedrals()[2].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[2].getForceConstant(),
-        1.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getDihedrals()[2].getPhaseShift(), 1.0);
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[2].getPeriodicity(),
-        1.0
-    );
+    EXPECT_EQ(dihedrals[1].getType(), DihedralId{1});
+    EXPECT_EQ(dihedrals[1].getForceConstant(), 2.0);
+    EXPECT_EQ(dihedrals[1].getPhaseShift(), 2.0);
+    EXPECT_EQ(dihedrals[1].getPeriodicity(), 2.0);
+
+    EXPECT_EQ(dihedrals[2].getType(), DihedralId{0});
+    EXPECT_EQ(dihedrals[2].getForceConstant(), 1.0);
+    EXPECT_EQ(dihedrals[2].getPhaseShift(), 1.0);
+    EXPECT_EQ(dihedrals[2].getPeriodicity(), 1.0);
 
     EXPECT_EQ(_engine->getForceField()->getDihedralTypes().size(), 0);
 }
@@ -248,25 +232,25 @@ TEST_F(TestSetup, forceFieldSetup_setupImproperDihedrals)
     auto dihedral1 = forceField::DihedralForceField(
         {molecule1Ptr, molecule2Ptr, molecule2Ptr, molecule2Ptr},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
     auto dihedral2 = forceField::DihedralForceField(
         {molecule1Ptr, molecule1Ptr, molecule2Ptr, molecule2Ptr},
         {0, 1, 2, 3},
-        1
+        DihedralId{1}
     );
     auto dihedral3 = forceField::DihedralForceField(
         {molecule1Ptr, molecule2Ptr, molecule2Ptr, molecule2Ptr},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
 
     _engine->getForceField()->addImproperDihedral(dihedral1);
     _engine->getForceField()->addImproperDihedral(dihedral2);
     _engine->getForceField()->addImproperDihedral(dihedral3);
 
-    auto dihedralType1 = forceField::DihedralType(0, 1.0, 1.0, 1.0);
-    auto dihedralType2 = forceField::DihedralType(1, 2.0, 2.0, 2.0);
+    auto dihedralType1 = forceField::DihedralType(DihedralId{0}, 1.0, 1.0, 1.0);
+    auto dihedralType2 = forceField::DihedralType(DihedralId{1}, 2.0, 2.0, 2.0);
 
     _engine->getForceField()->addImproperDihedralType(dihedralType1);
     _engine->getForceField()->addImproperDihedralType(dihedralType2);
@@ -274,47 +258,23 @@ TEST_F(TestSetup, forceFieldSetup_setupImproperDihedrals)
     auto setup = setup::ForceFieldSetup(*_engine);
     setup.setupImproperDihedrals();
 
-    EXPECT_EQ(_engine->getForceField()->getImproperDihedrals()[0].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getForceConstant(),
-        1.0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getPhaseShift(),
-        1.0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getPeriodicity(),
-        1.0
-    );
+    const auto &improperDihedrals =
+        _engine->getForceField()->getImproperDihedrals();
 
-    EXPECT_EQ(_engine->getForceField()->getImproperDihedrals()[1].getType(), 1);
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[1].getForceConstant(),
-        2.0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[1].getPhaseShift(),
-        2.0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[1].getPeriodicity(),
-        2.0
-    );
+    EXPECT_EQ(improperDihedrals[0].getType(), DihedralId{0});
+    EXPECT_EQ(improperDihedrals[0].getForceConstant(), 1.0);
+    EXPECT_EQ(improperDihedrals[0].getPhaseShift(), 1.0);
+    EXPECT_EQ(improperDihedrals[0].getPeriodicity(), 1.0);
 
-    EXPECT_EQ(_engine->getForceField()->getImproperDihedrals()[2].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[2].getForceConstant(),
-        1.0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[2].getPhaseShift(),
-        1.0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[2].getPeriodicity(),
-        1.0
-    );
+    EXPECT_EQ(improperDihedrals[1].getType(), DihedralId{1});
+    EXPECT_EQ(improperDihedrals[1].getForceConstant(), 2.0);
+    EXPECT_EQ(improperDihedrals[1].getPhaseShift(), 2.0);
+    EXPECT_EQ(improperDihedrals[1].getPeriodicity(), 2.0);
+
+    EXPECT_EQ(improperDihedrals[2].getType(), DihedralId{0});
+    EXPECT_EQ(improperDihedrals[2].getForceConstant(), 1.0);
+    EXPECT_EQ(improperDihedrals[2].getPhaseShift(), 1.0);
+    EXPECT_EQ(improperDihedrals[2].getPeriodicity(), 1.0);
 
     EXPECT_EQ(_engine->getForceField()->getImproperTypes().size(), 0);
 }
@@ -341,12 +301,12 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField)
     auto dihedral = forceField::DihedralForceField(
         {molecule1Ptr, molecule1Ptr, molecule1Ptr, molecule1Ptr},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
     auto improperDihedral = forceField::DihedralForceField(
         {molecule1Ptr, molecule1Ptr, molecule1Ptr, molecule1Ptr},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
 
     _engine->getForceField()->addBond(bond);
@@ -354,10 +314,11 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField)
     _engine->getForceField()->addDihedral(dihedral);
     _engine->getForceField()->addImproperDihedral(improperDihedral);
 
-    auto bondType             = forceField::BondType(BondId{0}, 1.0, 2.0);
-    auto angleType            = forceField::AngleType(AngleId{0}, 2.0, 3.0);
-    auto dihedralType         = forceField::DihedralType(0, 3.0, 4.0, 5.0);
-    auto improperDihedralType = forceField::DihedralType(0, 4.0, 5.0, 6.0);
+    auto bondType     = forceField::BondType(BondId{0}, 1.0, 2.0);
+    auto angleType    = forceField::AngleType(AngleId{0}, 2.0, 3.0);
+    auto dihedralType = forceField::DihedralType(DihedralId{0}, 3.0, 4.0, 5.0);
+    auto improperDihedralType =
+        forceField::DihedralType(DihedralId{0}, 4.0, 5.0, 6.0);
 
     _engine->getForceField()->addBondType(bondType);
     _engine->getForceField()->addAngleType(angleType);
@@ -366,42 +327,29 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField)
 
     setup::setupForceField(*_engine);
 
-    const auto &bonds = _engine->getForceField()->getBonds();
+    const auto &bonds     = _engine->getForceField()->getBonds();
+    const auto &angles    = _engine->getForceField()->getAngles();
+    const auto &dihedrals = _engine->getForceField()->getDihedrals();
+    const auto &improperDihedrals =
+        _engine->getForceField()->getImproperDihedrals();
 
     EXPECT_EQ(bonds[0].getType(), BondId{0});
     EXPECT_EQ(bonds[0].getEquilibriumBondLength(), 1.0);
     EXPECT_EQ(bonds[0].getForceConstant(), 2.0);
 
-    const auto &angles = _engine->getForceField()->getAngles();
-
     EXPECT_EQ(angles[0].getType(), AngleId{0});
     EXPECT_EQ(angles[0].getEquilibriumAngle(), 2.0);
     EXPECT_EQ(angles[0].getForceConstant(), 3.0);
 
-    EXPECT_EQ(_engine->getForceField()->getDihedrals()[0].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getForceConstant(),
-        3.0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getDihedrals()[0].getPeriodicity(),
-        4.0
-    );
-    EXPECT_EQ(_engine->getForceField()->getDihedrals()[0].getPhaseShift(), 5.0);
+    EXPECT_EQ(dihedrals[0].getType(), DihedralId{0});
+    EXPECT_EQ(dihedrals[0].getForceConstant(), 3.0);
+    EXPECT_EQ(dihedrals[0].getPeriodicity(), 4.0);
+    EXPECT_EQ(dihedrals[0].getPhaseShift(), 5.0);
 
-    EXPECT_EQ(_engine->getForceField()->getImproperDihedrals()[0].getType(), 0);
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getForceConstant(),
-        4.0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getPeriodicity(),
-        5.0
-    );
-    EXPECT_EQ(
-        _engine->getForceField()->getImproperDihedrals()[0].getPhaseShift(),
-        6.0
-    );
+    EXPECT_EQ(improperDihedrals[0].getType(), DihedralId{0});
+    EXPECT_EQ(improperDihedrals[0].getForceConstant(), 4.0);
+    EXPECT_EQ(improperDihedrals[0].getPeriodicity(), 5.0);
+    EXPECT_EQ(improperDihedrals[0].getPhaseShift(), 6.0);
 }
 
 /**
@@ -426,12 +374,12 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField_doNothing)
     auto dihedral = forceField::DihedralForceField(
         {molecule1Ptr, molecule1Ptr, molecule1Ptr, molecule1Ptr},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
     auto improperDihedral = forceField::DihedralForceField(
         {molecule1Ptr, molecule1Ptr, molecule1Ptr, molecule1Ptr},
         {0, 1, 2, 3},
-        0
+        DihedralId{0}
     );
 
     _engine->getForceField()->addBond(bond);
@@ -439,10 +387,11 @@ TEST_F(TestSetup, forceFieldSetup_setupForceField_doNothing)
     _engine->getForceField()->addDihedral(dihedral);
     _engine->getForceField()->addImproperDihedral(improperDihedral);
 
-    auto bondType             = forceField::BondType(BondId{0}, 1.0, 2.0);
-    auto angleType            = forceField::AngleType(AngleId{0}, 2.0, 3.0);
-    auto dihedralType         = forceField::DihedralType(0, 3.0, 4.0, 5.0);
-    auto improperDihedralType = forceField::DihedralType(0, 4.0, 5.0, 6.0);
+    auto bondType     = forceField::BondType(BondId{0}, 1.0, 2.0);
+    auto angleType    = forceField::AngleType(AngleId{0}, 2.0, 3.0);
+    auto dihedralType = forceField::DihedralType(DihedralId{0}, 3.0, 4.0, 5.0);
+    auto improperDihedralType =
+        forceField::DihedralType(DihedralId{0}, 4.0, 5.0, 6.0);
 
     _engine->getForceField()->addBondType(bondType);
     _engine->getForceField()->addAngleType(angleType);

--- a/tests/src/setup/testSimulationBoxSetup.cpp
+++ b/tests/src/setup/testSimulationBoxSetup.cpp
@@ -310,17 +310,17 @@ TEST_F(TestSetup, testSetAtomicNumbers)
     SimulationBoxSetup simulationBoxSetup(*_engine);
     simulationBoxSetup.setAtomicNumbers();
 
-    EXPECT_DOUBLE_EQ(
+    EXPECT_EQ(
         _engine->getSimulationBox().getMolecules()[0].getAtomicNumber(0),
-        6
+        AtomNumber{6}
     );
-    EXPECT_DOUBLE_EQ(
+    EXPECT_EQ(
         _engine->getSimulationBox().getMolecules()[0].getAtomicNumber(1),
-        1
+        AtomNumber{1}
     );
-    EXPECT_DOUBLE_EQ(
+    EXPECT_EQ(
         _engine->getSimulationBox().getMolecules()[0].getAtomicNumber(2),
-        8
+        AtomNumber{8}
     );
 }
 

--- a/tests/src/setup/testWaterModelSetup.cpp
+++ b/tests/src/setup/testWaterModelSetup.cpp
@@ -231,7 +231,7 @@ TEST_F(TestSetup, waterModelSetupRejectsWaterBondsInTopology)
     addWaterSystem(*_mdEngine);
     auto *water = &_mdEngine->getSimulationBox().getMolecule(0);
     _mdEngine->getForceField()->addBond(
-        forceField::BondForceField(water, water, 0, 1, 0)
+        forceField::BondForceField(water, water, 0, 1, BondId{0})
     );
 
     EXPECT_THROW(WaterModelSetup(*_mdEngine).setup(), UserInputException);

--- a/tests/src/setup/testWaterModelSetup.cpp
+++ b/tests/src/setup/testWaterModelSetup.cpp
@@ -35,6 +35,7 @@
 #include "molecule.hpp"
 #include "moleculeType.hpp"
 #include "settings.hpp"
+#include "strongTypes.hpp"
 #include "testSetup.hpp"
 #include "waterModelSettings.hpp"
 #include "waterModelSetup.hpp"
@@ -244,7 +245,11 @@ TEST_F(TestSetup, waterModelSetupRejectsWaterAnglesInTopology)
     addWaterSystem(*_mdEngine);
     auto *water = &_mdEngine->getSimulationBox().getMolecule(0);
     _mdEngine->getForceField()->addAngle(
-        forceField::AngleForceField({water, water, water}, {0, 1, 2}, 0)
+        forceField::AngleForceField(
+            {water, water, water},
+            {0, 1, 2},
+            AngleId{0}
+        )
     );
 
     EXPECT_THROW(WaterModelSetup(*_mdEngine).setup(), UserInputException);

--- a/tests/src/waterModels/testWaterModels.cpp
+++ b/tests/src/waterModels/testWaterModels.cpp
@@ -46,6 +46,7 @@
 #include "potentialSettings.hpp"
 #include "settings.hpp"
 #include "simulationBox.hpp"
+#include "strongTypes.hpp"
 #include "waterModelSettings.hpp"
 
 using linearAlgebra::Vec3D;
@@ -98,7 +99,7 @@ namespace
         const auto h1     = std::make_shared<Atom>();
         const auto h2     = std::make_shared<Atom>();
 
-        oxygen->setAtomicNumber(8);
+        oxygen->setAtomicNumber(AtomNumber{8});
         oxygen->setPartialCharge(-0.82);
         oxygen->setQMCharge(-0.9);
         oxygen->setPosition(origin);
@@ -106,7 +107,7 @@ namespace
         oxygen->setInternalGlobalVDWType(0);
         oxygen->setForceToZero();
 
-        h1->setAtomicNumber(1);
+        h1->setAtomicNumber(AtomNumber{1});
         h1->setPartialCharge(0.41);
         h1->setQMCharge(0.45);
         h1->setPosition(origin + Vec3D{geometry.oh1, 0.0, 0.0});
@@ -114,7 +115,7 @@ namespace
         h1->setInternalGlobalVDWType(0);
         h1->setForceToZero();
 
-        h2->setAtomicNumber(1);
+        h2->setAtomicNumber(AtomNumber{1});
         h2->setPartialCharge(0.41);
         h2->setQMCharge(0.45);
         h2->setPosition(
@@ -787,5 +788,8 @@ TEST(SimulationBoxViews, ConstAndMutableWaterViewsFilterCorrectly)
     size_t     water     = 0;
     for ([[maybe_unused]] const auto &molecule : waterView) ++water;
     EXPECT_EQ(water, 1);
-    EXPECT_EQ(simBox.getMolecule(0).getAtom(0).getAtomicNumber(), 8);
+    EXPECT_EQ(
+        simBox.getMolecule(0).getAtom(0).getAtomicNumber(),
+        AtomNumber{8}
+    );
 }


### PR DESCRIPTION
This PR introduces strong type for:
`AtomNumber`
`BondId`
`AngleId`
`DihedralId`

By using these strong types, mismatches in the ids, indices etc. are much much much easier visible