### PR TITLE
ci: support hotfix release pull requests

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -2,9 +2,18 @@
 name: Docs
 
 on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/jekyll-gh-pages.yml"
+      - "docs/sphinx/**"
+
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+    paths:
+      - ".github/workflows/jekyll-gh-pages.yml"
+      - "docs/sphinx/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -46,6 +55,7 @@ jobs:
 
       # Deployment job
       - name: deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
           branch: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,11 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       (github.event.action == 'opened' ||
-      github.event.action == 'reopened') &&
+      github.event.action == 'reopened' ||
+      github.event.action == 'synchronize') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+      startsWith(github.event.pull_request.head.ref, 'hotfix/'))
     concurrency:
       group: prepare-release-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -38,11 +40,24 @@ jobs:
         id: release
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           if [[ "$HEAD_REF" =~ ^release/(v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
             echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          elif [[ "$HEAD_REF" =~ ^hotfix/ ]]; then
+            latest="$(git ls-remote --tags --refs \
+              "https://github.com/$REPOSITORY.git" 'v[0-9]*.[0-9]*.[0-9]*' |
+              awk '{ sub("refs/tags/", "", $2); if ($2 ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/) print $2 }' |
+              sort -V |
+              tail -n 1)"
+            if [[ ! "$latest" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              echo "Could not infer latest release tag from $REPOSITORY."
+              exit 1
+            fi
+            version="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
           else
-            echo "Release branches must be named release/vX.Y.Z."
+            echo "Release branches must be named release/vX.Y.Z or hotfix/*."
             exit 1
           fi
 
@@ -113,7 +128,8 @@ jobs:
   check-release:
     if: >-
       github.event_name == 'pull_request' &&
-      startsWith(github.event.pull_request.head.ref, 'release/') &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+      startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&
       (github.event.action == 'edited' ||
       github.event.action == 'synchronize')
     runs-on: ubuntu-latest
@@ -124,16 +140,27 @@ jobs:
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           if [[ "$HEAD_REF" =~ ^release/(v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
             version="${BASH_REMATCH[1]}"
+            if [[ "$PR_TITLE" != "Release-${version#v}" ]]; then
+              echo "Release PR title must be Release-${version#v}."
+              exit 1
+            fi
+          elif [[ "$HEAD_REF" =~ ^hotfix/ ]]; then
+            latest="$(git ls-remote --tags --refs \
+              "https://github.com/$REPOSITORY.git" 'v[0-9]*.[0-9]*.[0-9]*' |
+              awk '{ sub("refs/tags/", "", $2); if ($2 ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/) print $2 }' |
+              sort -V |
+              tail -n 1)"
+            if [[ ! "$latest" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              echo "Could not infer latest release tag from $REPOSITORY."
+              exit 1
+            fi
+            version="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))"
           else
-            echo "Release branches must be named release/vX.Y.Z."
-            exit 1
-          fi
-
-          if [[ "$PR_TITLE" != "Release-${version#v}" ]]; then
-            echo "Release PR title must be Release-${version#v}."
+            echo "Release branches must be named release/vX.Y.Z or hotfix/*."
             exit 1
           fi
 
@@ -169,7 +196,8 @@ jobs:
       (github.event_name == 'pull_request' &&
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/'))
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+      startsWith(github.event.pull_request.head.ref, 'hotfix/')))
     runs-on: ubuntu-latest
 
     steps:
@@ -182,6 +210,7 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           MERGE_COMMIT: ${{ github.event.pull_request.merge_commit_sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             version="$DISPATCH_VERSION"
@@ -191,8 +220,21 @@ jobs:
             version="${BASH_REMATCH[1]}"
             commit="$MERGE_COMMIT"
             source="PR #$PR_NUMBER"
+          elif [[ "$HEAD_REF" =~ ^hotfix/ ]]; then
+            latest="$(git ls-remote --tags --refs \
+              "https://github.com/$REPOSITORY.git" 'v[0-9]*.[0-9]*.[0-9]*' |
+              awk '{ sub("refs/tags/", "", $2); if ($2 ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/) print $2 }' |
+              sort -V |
+              tail -n 1)"
+            if [[ ! "$latest" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              echo "Could not infer latest release tag from $REPOSITORY."
+              exit 1
+            fi
+            version="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))"
+            commit="$MERGE_COMMIT"
+            source="hotfix PR #$PR_NUMBER"
           else
-            echo "Release branches must be named release/vX.Y.Z."
+            echo "Release branches must be named release/vX.Y.Z or hotfix/*."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,8 @@ jobs:
             version="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))"
             echo "version=$version" >> "$GITHUB_OUTPUT"
           else
-            echo "Release branches must be named release/vX.Y.Z or hotfix/*."
+            echo "Regular releases use release/vX.Y.Z."
+            echo "Hotfixes must use hotfix/*; their patch version is auto-bumped."
             exit 1
           fi
 
@@ -160,7 +161,8 @@ jobs:
             fi
             version="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))"
           else
-            echo "Release branches must be named release/vX.Y.Z or hotfix/*."
+            echo "Regular releases use release/vX.Y.Z."
+            echo "Hotfixes must use hotfix/*; their patch version is auto-bumped."
             exit 1
           fi
 
@@ -234,7 +236,8 @@ jobs:
             commit="$MERGE_COMMIT"
             source="hotfix PR #$PR_NUMBER"
           else
-            echo "Release branches must be named release/vX.Y.Z or hotfix/*."
+            echo "Regular releases use release/vX.Y.Z."
+            echo "Hotfixes must use hotfix/*; their patch version is auto-bumped."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- run Docs CI for pull requests that touch `docs/sphinx/**` or the docs workflow
- keep Docs deployment restricted to pushes on `main`
- allow `hotfix/*` pull requests into `main` to use the release lifecycle
- infer the hotfix release version by bumping the latest `vX.Y.Z` tag, e.g. `v0.7.0 -> v0.7.1`
- prepare changelogs on the hotfix branch before merge and publish the inferred tag/release after merge

## Why

Docs-only hotfixes into `main` currently have no useful Docs CI signal, and the release workflow only understands `release/vX.Y.Z` branches. This restores a clean hotfix path without backporting unrelated CI changes from `dev`.

## Validation

- Ruby YAML parse for `.github/workflows/jekyll-gh-pages.yml` and `.github/workflows/release.yml`
- local bash resolver test: latest `v0.7.0`, next `v0.7.1`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`
- `git diff --check`
- `make html` in `docs/sphinx` using the temporary Sphinx environment

`actionlint` is not installed locally, so workflow linting was limited to YAML parsing and shell/version-resolution checks.
