### PR TITLE
docs: annotate topology field units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ implementation changes are documented in
 ## Next Release
 
 <!-- insertion marker -->
+## [v0.7.1](https://github.com/MolarVerse/PQ/releases/tag/v0.7.1) - 2026-08-18
+
+### Documentation
+
+- Document the units used by topology setup-file indices, constraints, and force constants.
+
 ## [v0.7.0](https://github.com/MolarVerse/PQ/releases/tag/v0.7.0) - 2026-08-07
 
 ### New Features

--- a/changes/user/documentation.topology-setup-units.md
+++ b/changes/user/documentation.topology-setup-units.md
@@ -1,0 +1,1 @@
+- Document the units used by topology setup-file indices, constraints, and force constants.

--- a/changes/user/documentation.topology-setup-units.md
+++ b/changes/user/documentation.topology-setup-units.md
@@ -1,1 +1,0 @@
-- Document the units used by topology setup-file indices, constraints, and force constants.

--- a/docs/sphinx/src/userGuide/setupFiles.rst
+++ b/docs/sphinx/src/userGuide/setupFiles.rst
@@ -118,6 +118,13 @@ The topology line formats are:
     | ``DIST_CONSTRAINTS``: atom_1 atom_2 lower_distance upper_distance force_constant dforce_constant_dt
     | ``J_COUPLINGS``: atom_1 atom_2 atom_3 atom_4 j_coupling_type
 
+Fields named ``atom_*`` are unitless global atom indices. Fields named
+``*_type`` are unitless indices into the corresponding parameter-file section.
+Distances in ``SHAKE`` and ``DIST_CONSTRAINTS`` are given in Å. The
+``DIST_CONSTRAINTS`` force constant is given in
+:math:`\frac{\text{kcal}}{\text{mol Å}^2}` and ``dforce_constant_dt`` in
+:math:`\frac{\text{kcal}}{\text{mol Å}^2\text{ fs}}`.
+
 The optional fourth field in ``SHAKE`` entries is accepted for legacy input
 files but is not used by the reader. The optional ``*`` marker in the bonded
 sections marks a linker interaction. Topology atom indices are global atom


### PR DESCRIPTION
## Summary

- document topology atom/type fields as unitless indices
- document SHAKE and distance-constraint distances as Angstrom
- document distance-constraint force constants and time derivatives
- add a user changelog fragment for the release workflow

## Release Flow

Draft until #521 is merged into `main`.

After #521 lands, this `hotfix/*` PR should let the release workflow infer `v0.7.1`, prepare the changelog on this branch, and publish the tag/release after merge.

Closes #518.

## Validation

- `python3 scripts/update_changelog.py --check`
- `git diff --check`
- `make html` in `docs/sphinx` using the temporary Sphinx environment
